### PR TITLE
* highlight linked file when a resource is selected

### DIFF
--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -8,7 +8,7 @@ import Colors, {FontColors, BackgroundColors} from '@styles/Colors';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectFile} from '@redux/reducers/main';
 import {ROOT_FILE_ENTRY} from '@src/constants';
-import {FolderAddOutlined} from '@ant-design/icons';
+import {FolderAddOutlined, EyeInvisibleOutlined} from '@ant-design/icons';
 import {PROCESS_ENV} from '@actions/common/apply';
 import {FileEntry} from '@models/fileentry';
 import {FileMapType, ResourceMapType} from '@models/appstate';
@@ -26,6 +26,7 @@ interface TreeNode {
   key: string;
   title: React.ReactNode;
   children: TreeNode[];
+  highlight: boolean;
   isLeaf?: boolean;
 }
 
@@ -42,6 +43,21 @@ const StyledNumberOfResources = styled(Typography.Text)`
   margin-left: 12px;
 `;
 
+const NodeContainer = styled.div`
+  position: relative;
+`;
+const NodeTitleContainer = styled.div`
+  padding-right: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+const NodeActionsContainer = styled.div`
+  position: absolute;
+  right: 0;
+  top: 0;
+`;
+
 const createNode = (
   fileEntry: FileEntry,
   fileMap: FileMapType,
@@ -51,11 +67,17 @@ const createNode = (
 
   const node: TreeNode = {
     key: fileEntry.filePath,
-    title: <>
-      {fileEntry.name}
-      {resources.length > 0 ? <StyledNumberOfResources type="secondary">{resources.length}</StyledNumberOfResources> : ''}
-    </>,
-    children: []
+    title: <NodeContainer>
+      <NodeTitleContainer>
+        {fileEntry.name}
+        {resources.length > 0 ? <StyledNumberOfResources type="secondary">{resources.length}</StyledNumberOfResources> : ''}
+      </NodeTitleContainer>
+      <NodeActionsContainer>
+        {fileEntry.excluded && <EyeInvisibleOutlined />}
+      </NodeActionsContainer>
+    </NodeContainer>,
+    children: [],
+    highlight: fileEntry.highlight
   };
 
   if (fileEntry.children) {
@@ -128,9 +150,30 @@ const FileTreeContainer = styled.div`
   & .ant-tree-treenode::selection {
     background: ${Colors.selectionGradient}  !important;
   }
+  & .filter-node {
+    font-style: italic;
+    font-weight: bold;
+    background: ${Colors.highlightGradient};
+    color: ${FontColors.resourceRowHighlight};
+  }
   .ant-tree.ant-tree-directory .ant-tree-treenode .ant-tree-node-content-wrapper.ant-tree-node-selected {
     color: black !important;
     font-weight: bold;
+  }
+  & .ant-tree-iconEle {
+    flex-shrink: 0;
+  }
+  & .ant-tree-iconEle .anticon {
+    vertical-align: -2px;
+  }
+  & .ant-tree-node-content-wrapper {
+    display: flex;
+    overflow: hidden;
+  }
+
+  & .ant-tree-node-content-wrapper .ant-tree-title {
+    overflow: hidden;
+    flex-grow: 1;
   }
 `;
 
@@ -148,6 +191,7 @@ const FileTreePane = () => {
   const previewResource = useAppSelector(state => state.main.previewResource);
   const previewMode = useSelector(inPreviewMode);
   const fileMap = useAppSelector(state => state.main.fileMap);
+  const selectedPath = useAppSelector(state => state.main.selectedPath);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const [tree, setTree] = React.useState<TreeNode | null>(null);
 
@@ -236,6 +280,11 @@ const FileTreePane = () => {
         onSelect={onSelect}
         defaultExpandAll
         treeData={[tree]}
+        selectedKeys={[selectedPath || '-']}
+        filterTreeNode={(node) => {
+          // @ts-ignore
+          return node.highlight;
+        }}
       /> : <NoFilesContainer>No folder selected.</NoFilesContainer>}
     </FileTreeContainer>
   );

--- a/src/redux/utils/selection.ts
+++ b/src/redux/utils/selection.ts
@@ -66,21 +66,30 @@ export function selectResourceFileEntry(resource: K8sResource, fileMap: FileMapT
 }
 
 /**
+ * Updates highlighted file, based on the selected resource
+ */
+const updateFileHighlight = (fileMap: FileMapType, selectedResource: K8sResource) => {
+  Object.entries(fileMap).forEach(([filePath, file]) => {
+    file.highlight = filePath === selectedResource.filePath;
+  });
+};
+
+/**
  * Ensures the correct resources are selected/highlighted when selecting the
  * specified resource
  */
-
 export function updateSelectionAndHighlights(state: AppState, resource: K8sResource) {
   clearResourceSelections(state.resourceMap, resource.id);
   if (!state.previewResource) {
     clearFileSelections(state.fileMap);
   }
   state.selectedResource = undefined;
-
   if (resource.selected) {
     resource.selected = false;
   } else {
     resource.selected = true;
+    updateFileHighlight(state.fileMap, resource);
+
     state.selectedResource = resource.id;
     if (isFileResource(resource)) {
       state.selectedPath = selectResourceFileEntry(resource, state.fileMap);


### PR DESCRIPTION
https://trello.com/c/ZnUvxHSB/85-show-different-file-states-in-file-tree

* unselect resource when file is selected & vice-versa
* excluded files now have crossed-eye icon
* add ellipsis to file tree & block filenames from wrapping