### PR TITLE
fix pane heights

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -169,7 +169,7 @@ const ActionsPane = (props: {contentHeight: string}) => {
                 {uiState.isFolderLoading || previewLoader.isLoading ? (
                   <StyledSkeleton active />
                 ) : (
-                  <Monaco editorHeight={contentHeight} />
+                  <Monaco editorHeight={`${parseInt(contentHeight, 10) - 120}`} />
                 )}
               </TabPane>
               {selectedResource && selectedResource?.kind === 'ConfigMap' && (

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -404,8 +404,8 @@ const FileTreePane = (props: {windowHeight: number | undefined}) => {
         <StyledSkeleton active />
       ) : tree ? (
         <StyledTreeDirectoryTree
-          // height is needed to enable Tree's virtual scroll
-          height={windowHeight && windowHeight > 180 ? windowHeight - 180 : 0}
+          // height is needed to enable Tree's virtual scroll ToDo: Do constants based on the hights of app title and pane title, or get height of parent.
+          height={windowHeight && windowHeight > 122 ? windowHeight - 122 : 0}
           onSelect={onSelect}
           treeData={[tree]}
           ref={treeRef}


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- pane heights for filetree (too short) and monaco (too long)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
