### PR TITLE
feat: scroll selected resource into view if not visible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import featureJson from '@src/feature-flags.json';
 import ClustersPane from '@organisms/ClustersPane';
 import {ClusterExplorerTooltip, FileExplorerTooltip} from '@constants/tooltips';
 import {TOOLTIP_DELAY} from '@constants/constants';
+import AppContext from './AppContext';
 
 const StyledRow = styled(Row)`
   background-color: ${BackgroundColors.darkThemeBackground};
@@ -144,7 +145,7 @@ const App = () => {
   if (appWidth !== size.width) setAppWidth(size.width);
 
   return (
-    <div>
+    <AppContext.Provider value={{windowSize: size}}>
       <MessageBox />
       <Layout style={{height: mainHeight}}>
         <PageHeader />
@@ -191,7 +192,7 @@ const App = () => {
                 left={
                   <>
                     <div style={{display: leftMenuSelection === 'file-explorer' ? 'inline' : 'none'}}>
-                      <FileTreePane windowHeight={size.height} />
+                      <FileTreePane />
                     </div>
                     <div
                       style={{
@@ -204,7 +205,7 @@ const App = () => {
                   </>
                 }
                 hideLeft={!leftActive}
-                nav={<NavigatorPane windowHeight={size.height} />}
+                nav={<NavigatorPane />}
                 editor={<ActionsPane contentHeight={contentHeight} />}
                 right={
                   <>
@@ -253,7 +254,7 @@ const App = () => {
       <DiffModal />
       <StartupModal />
       <HotKeysHandler onToggleLeftMenu={() => toggleLeftMenu()} onToggleRightMenu={() => toggleRightMenu()} />
-    </div>
+    </AppContext.Provider>
   );
 };
 

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const AppContext = React.createContext({
+  windowSize: {
+    height: 0,
+    width: 0,
+  },
+});
+
+export default AppContext;

--- a/src/components/molecules/ScrollIntoView/ScrollIntoView.tsx
+++ b/src/components/molecules/ScrollIntoView/ScrollIntoView.tsx
@@ -5,7 +5,7 @@ interface ScrollIntoViewProps {
 }
 
 const ScrollIntoView = React.forwardRef(({children}: ScrollIntoViewProps, ref) => {
-  const containerRef = React.useRef<any>(null);
+  const containerRef = React.useRef<HTMLSpanElement>(null);
   React.useImperativeHandle(ref, () => {
     return {
       scrollIntoView: () => {

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useContext} from 'react';
 import styled from 'styled-components';
 import path from 'path';
 import {Row, Button, Tree, Typography, Skeleton, Tooltip} from 'antd';
@@ -7,8 +7,9 @@ import {Row, Button, Tree, Typography, Skeleton, Tooltip} from 'antd';
 import Colors, {FontColors, BackgroundColors} from '@styles/Colors';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectFile, setSelectingFile} from '@redux/reducers/main';
-import {ROOT_FILE_ENTRY, TOOLTIP_DELAY} from '@constants/constants';
+import {ROOT_FILE_ENTRY, TOOLTIP_DELAY, FILE_TREE_HEIGHT_OFFSET} from '@constants/constants';
 
+import AppContext from '@src/AppContext';
 import {FolderAddOutlined, ReloadOutlined} from '@ant-design/icons';
 
 import {FileEntry} from '@models/fileentry';
@@ -233,10 +234,9 @@ const BrowseButton = styled(Button)`
   margin-top: 1px;
 `;
 
-const FILE_TREE_HEIGHT_OFFSET = 122;
-
-const FileTreePane = (props: {windowHeight: number | undefined}) => {
-  const {windowHeight} = props;
+const FileTreePane = () => {
+  const {windowSize} = useContext(AppContext);
+  const windowHeight = windowSize.height;
   const dispatch = useAppDispatch();
   const previewMode = useSelector(inPreviewMode);
   const previewLoader = useAppSelector(state => state.main.previewLoader);

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useContext} from 'react';
 import {Row, Skeleton} from 'antd';
 import styled from 'styled-components';
 import {useSelector} from 'react-redux';
@@ -9,6 +9,10 @@ import Colors, {BackgroundColors} from '@styles/Colors';
 import {useAppSelector} from '@redux/hooks';
 import {MonoPaneTitle, MonoPaneTitleCol, PaneContainer, MonoSectionTitle} from '@atoms';
 import {MinusSquareOutlined, PlusSquareOutlined} from '@ant-design/icons';
+
+import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
+
+import AppContext from '@src/AppContext';
 
 import HelmChartsSection from './components/HelmChartsSection';
 import KustomizationsSection from './components/KustomizationsSection';
@@ -115,10 +119,10 @@ const SectionHeader = (props: {
   );
 };
 
-const NAVIGATOR_HEIGHT_OFFSET = 112;
-
-const NavigatorPane = (props: {windowHeight: number}) => {
-  const {windowHeight} = props;
+const NavigatorPane = () => {
+  const {windowSize} = useContext(AppContext);
+  const windowHeight = windowSize.height;
+  const navigatorHeight = windowHeight - NAVIGATOR_HEIGHT_OFFSET;
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const uiState = useAppSelector(state => state.ui);
   const helmCharts = useSelector(selectHelmCharts);
@@ -155,8 +159,7 @@ const NavigatorPane = (props: {windowHeight: number}) => {
       </TitleRow>
       <NavigatorPaneContainer
         style={{
-          height:
-            windowHeight && windowHeight > NAVIGATOR_HEIGHT_OFFSET ? windowHeight - NAVIGATOR_HEIGHT_OFFSET : '100%',
+          height: windowHeight && windowHeight > NAVIGATOR_HEIGHT_OFFSET ? navigatorHeight : '100%',
         }}
       >
         {uiState.isFolderLoading ? (

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -4,3 +4,5 @@ export const ROOT_FILE_ENTRY = '<root>';
 export const APP_MIN_WIDTH = 800;
 export const APP_MIN_HEIGHT = 600;
 export const TOOLTIP_DELAY = 1.0;
+export const NAVIGATOR_HEIGHT_OFFSET = 112;
+export const FILE_TREE_HEIGHT_OFFSET = 122;


### PR DESCRIPTION
introduced AppContext to avoid prop drilling of the windowSize

This PR...

## Changes

- scrolls selected resource into view if it's not visible, which allows us to click links in the navigator/editor and the newly selected resource will be scrolled into view

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
