### PR TITLE
Refactor: rename variable names for clarity

### DIFF
--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -78,7 +78,7 @@ const GraphView = (props: {editorHeight: string}) => {
   const fileMap = useAppSelector(state => state.main.fileMap);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const activeResources = useSelector(selectActiveResources);
-  const previewResource = useAppSelector(state => state.main.previewResource);
+  const previewResource = useAppSelector(state => state.main.previewResourceId);
 
   const dispatch = useAppDispatch();
   const [reactFlow, setReactFlow] = useState();

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -29,7 +29,7 @@ function mapRefToElement(source: K8sResource, ref: ResourceRef): Edge {
   return {
     id: `${source.id}-${ref.targetResource}-${ref.type}`,
     source: source.id,
-    target: ref.targetResource || ref.refName,
+    target: ref.targetResource || ref.name,
     animated: false,
     type: 'smoothstep',
   };

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -21,7 +21,7 @@ function mapResourceToElement(resource: K8sResource): Node {
       wasSelectedInGraphView: false,
     },
     position: {x: 0, y: 0},
-    style: {background: resource.selected ? 'lighblue' : resource.highlight ? 'lightgreen' : 'white'},
+    style: {background: resource.selected ? 'lighblue' : resource.isHighlighted ? 'lightgreen' : 'white'},
   };
 }
 
@@ -119,7 +119,7 @@ const GraphView = (props: {editorHeight: string}) => {
       nds.map(nd => {
         const resource = resourceMap[nd.id];
         if (resource) {
-          nd.style = {background: resource.selected ? 'lightblue' : resource.highlight ? 'lightgreen' : 'white'};
+          nd.style = {background: resource.selected ? 'lightblue' : resource.isHighlighted ? 'lightgreen' : 'white'};
         }
         return nd;
       })

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -21,7 +21,7 @@ function mapResourceToElement(resource: K8sResource): Node {
       wasSelectedInGraphView: false,
     },
     position: {x: 0, y: 0},
-    style: {background: resource.selected ? 'lighblue' : resource.isHighlighted ? 'lightgreen' : 'white'},
+    style: {background: resource.isSelected ? 'lighblue' : resource.isHighlighted ? 'lightgreen' : 'white'},
   };
 }
 
@@ -119,7 +119,7 @@ const GraphView = (props: {editorHeight: string}) => {
       nds.map(nd => {
         const resource = resourceMap[nd.id];
         if (resource) {
-          nd.style = {background: resource.selected ? 'lightblue' : resource.isHighlighted ? 'lightgreen' : 'white'};
+          nd.style = {background: resource.isSelected ? 'lightblue' : resource.isHighlighted ? 'lightgreen' : 'white'};
         }
         return nd;
       })

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -27,7 +27,7 @@ function mapResourceToElement(resource: K8sResource): Node {
 
 function mapRefToElement(source: K8sResource, ref: ResourceRef): Edge {
   return {
-    id: `${source.id}-${ref.targetResource}-${ref.refType}`,
+    id: `${source.id}-${ref.targetResource}-${ref.type}`,
     source: source.id,
     target: ref.targetResource || ref.refName,
     animated: false,
@@ -95,7 +95,7 @@ const GraphView = (props: {editorHeight: string}) => {
     let data: any[] = [mapResourceToElement(resource)];
     if (resource.refs) {
       const refs = resource.refs
-        .filter(ref => !isUnsatisfiedRef(ref.refType))
+        .filter(ref => !isUnsatisfiedRef(ref.type))
         .map(ref => mapRefToElement(resource, ref));
       data = data.concat(refs);
     }

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -27,9 +27,9 @@ function mapResourceToElement(resource: K8sResource): Node {
 
 function mapRefToElement(source: K8sResource, ref: ResourceRef): Edge {
   return {
-    id: `${source.id}-${ref.targetResource}-${ref.type}`,
+    id: `${source.id}-${ref.targetResourceId}-${ref.type}`,
     source: source.id,
-    target: ref.targetResource || ref.name,
+    target: ref.targetResourceId || ref.name,
     animated: false,
     type: 'smoothstep',
   };

--- a/src/components/molecules/GraphView/Sidebar.tsx
+++ b/src/components/molecules/GraphView/Sidebar.tsx
@@ -16,7 +16,7 @@ const Sidebar = (reactFlow: any) => {
   const store = useStore();
   const dispatch = useAppDispatch();
   const zoomPanHelper = useZoomPanHelper();
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const settings = useAppSelector(state => state.config.settings);
 
   const performTransform = useCallback(
@@ -42,11 +42,11 @@ const Sidebar = (reactFlow: any) => {
   );
 
   const selectSelectedResource = useCallback(() => {
-    if (selectedResource) {
+    if (selectedResourceId) {
       const {nodes} = store.getState();
 
       if (nodes.length) {
-        const node = nodes.find(n => n.id === selectedResource);
+        const node = nodes.find(n => n.id === selectedResourceId);
         if (node) {
           if (node.data.wasSelectedInGraphView === true) {
             node.data.wasSelectedInGraphView = false;
@@ -59,13 +59,13 @@ const Sidebar = (reactFlow: any) => {
         }
       }
     }
-  }, [selectedResource, store, performTransform]);
+  }, [selectedResourceId, store, performTransform]);
 
   useEffect(() => {
     if (settings.autoZoomGraphOnSelection) {
       selectSelectedResource();
     }
-  }, [selectedResource, settings.autoZoomGraphOnSelection, selectSelectedResource]);
+  }, [selectedResourceId, settings.autoZoomGraphOnSelection, selectSelectedResource]);
 
   const onZoomChange = useCallback(
     (e: any) => {
@@ -105,7 +105,7 @@ const Sidebar = (reactFlow: any) => {
         <Button type="primary" onClick={handleZoom(1 / 1.4)}>
           Zoom out
         </Button>
-        <Button type="primary" onClick={selectSelectedResource} disabled={selectedResource === undefined}>
+        <Button type="primary" onClick={selectSelectedResource} disabled={selectedResourceId === undefined}>
           Zoom on selected resource
         </Button>
         <Checkbox onChange={onZoomChange} checked={settings.autoZoomGraphOnSelection === true}>

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -75,7 +75,7 @@ const Monaco = (props: {editorHeight: string}) => {
   const {editorHeight} = props;
   const fileMap = useAppSelector(state => state.main.fileMap);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [code, setCode] = useState('');
@@ -153,16 +153,16 @@ const Monaco = (props: {editorHeight: string}) => {
       return;
     }
     // is a file and no resource selected?
-    if (selectedPath && !selectedResource) {
+    if (selectedPath && !selectedResourceId) {
       try {
         dispatch(updateFileEntry({path: selectedPath, content: value}));
         setOrgCode(value);
       } catch (e) {
         logMessage(`Failed to update file ${e}`, dispatch);
       }
-    } else if (selectedResource && resourceMap[selectedResource]) {
+    } else if (selectedResourceId && resourceMap[selectedResourceId]) {
       try {
-        dispatch(updateResource({resourceId: selectedResource, content: value.toString()}));
+        dispatch(updateResource({resourceId: selectedResourceId, content: value.toString()}));
         setOrgCode(value);
       } catch (e) {
         logMessage(`Failed to update resource ${e}`, dispatch);
@@ -186,12 +186,12 @@ const Monaco = (props: {editorHeight: string}) => {
       });
       actionSaveDisposableRef.current = newActionSaveDisposable;
     }
-  }, [editor, selectedPath, selectedResource]);
+  }, [editor, selectedPath, selectedResourceId]);
 
   useEffect(() => {
     let newCode = '';
-    if (selectedResource) {
-      const resource = resourceMap[selectedResource];
+    if (selectedResourceId) {
+      const resource = resourceMap[selectedResourceId];
       if (resource) {
         newCode = resource.text;
       }
@@ -205,11 +205,11 @@ const Monaco = (props: {editorHeight: string}) => {
     setCode(newCode);
     setOrgCode(newCode);
     setDirty(false);
-  }, [fileMap, selectedPath, selectedResource, resourceMap]);
+  }, [fileMap, selectedPath, selectedResourceId, resourceMap]);
 
   const options = {
     selectOnLineNumbers: true,
-    readOnly: isInPreviewMode || (!selectedPath && !selectedResource),
+    readOnly: isInPreviewMode || (!selectedPath && !selectedResourceId),
     fontWeight: 'bold',
     glyphMargin: true,
     minimap: {
@@ -227,8 +227,8 @@ const Monaco = (props: {editorHeight: string}) => {
   };
 
   const applyCodeIntel = () => {
-    if (editor && selectedResource && resourceMap[selectedResource]) {
-      const resource = resourceMap[selectedResource];
+    if (editor && selectedResourceId && resourceMap[selectedResourceId]) {
+      const resource = resourceMap[selectedResourceId];
       const {newDecorations, newHoverDisposables, newCommandDisposables, newLinkDisposables} =
         codeIntel.applyForResource(resource, selectResource, resourceMap);
       const idsOfNewDecorations = setDecorations(editor, newDecorations, idsOfDecorationsRef.current);
@@ -245,13 +245,13 @@ const Monaco = (props: {editorHeight: string}) => {
     return () => {
       clearCodeIntel();
     };
-  }, [code, selectedResource, resourceMap]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [code, selectedResourceId, resourceMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     let resourceSchema;
 
-    if (selectedResource) {
-      const resource = resourceMap[selectedResource];
+    if (selectedResourceId) {
+      const resource = resourceMap[selectedResourceId];
       if (resource) {
         resourceSchema = getResourceSchema(resource);
       }
@@ -280,7 +280,7 @@ const Monaco = (props: {editorHeight: string}) => {
       const newCompletionDisposable = codeIntel.applyAutocomplete(resourceMap);
       completionDisposableRef.current = newCompletionDisposable;
     }
-  }, [selectedResource, resourceMap]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedResourceId, resourceMap]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (editor) {

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -159,7 +159,7 @@ export function applyForResource(
   const listOfOutgoingRefsByEqualPos: {position: RefPosition; outgoingRefs: ResourceRef[]}[] = [];
 
   refs.forEach(ref => {
-    const refPos = ref.refPos;
+    const refPos = ref.position;
     if (refPos && isOutgoingRef(ref.type)) {
       const refsByEqualPosIndex = listOfOutgoingRefsByEqualPos.findIndex(e => areRefPosEqual(e.position, refPos));
       if (refsByEqualPosIndex === -1) {
@@ -174,7 +174,7 @@ export function applyForResource(
   });
 
   unsatisfiedRefs.forEach(ref => {
-    const refPos = ref.refPos;
+    const refPos = ref.position;
     if (refPos) {
       const inlineRange = new monaco.Range(refPos.line, refPos.column, refPos.line, refPos.column + refPos.length);
       const glyphDecoration = createGlyphDecoration(refPos.line, GlyphDecorationTypes.UnsatisfiedRef);

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -201,18 +201,18 @@ export function applyForResource(
 
     const commandMarkdownLinkList: monaco.IMarkdownString[] = [];
     outgoingRefs.forEach(outgoingRef => {
-      if (!outgoingRef.targetResource) {
+      if (!outgoingRef.targetResourceId) {
         return;
       }
-      const outgoingRefResource = resourceMap[outgoingRef.targetResource];
+      const outgoingRefResource = resourceMap[outgoingRef.targetResourceId];
       if (!outgoingRefResource) {
         return;
       }
       const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
         `${outgoingRefResource.kind}: ${outgoingRefResource.name}`,
         () => {
-          if (outgoingRef.targetResource) {
-            selectResource(outgoingRef.targetResource);
+          if (outgoingRef.targetResourceId) {
+            selectResource(outgoingRef.targetResourceId);
           }
         }
       );
@@ -231,8 +231,8 @@ export function applyForResource(
     if (outgoingRefs.length === 1) {
       const outgoingRef = outgoingRefs[0];
       const linkDisposable = createLinkProvider(inlineRange, () => {
-        if (outgoingRef.targetResource) {
-          selectResource(outgoingRef.targetResource);
+        if (outgoingRef.targetResourceId) {
+          selectResource(outgoingRef.targetResourceId);
         }
       });
       newLinkDisposables.push(linkDisposable);

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -155,12 +155,12 @@ export function applyForResource(
     return {newDecorations, newHoverDisposables, newCommandDisposables, newLinkDisposables};
   }
 
-  const unsatisfiedRefs = refs?.filter(r => isUnsatisfiedRef(r.refType));
+  const unsatisfiedRefs = refs?.filter(r => isUnsatisfiedRef(r.type));
   const listOfOutgoingRefsByEqualPos: {position: RefPosition; outgoingRefs: ResourceRef[]}[] = [];
 
   refs.forEach(ref => {
     const refPos = ref.refPos;
-    if (refPos && isOutgoingRef(ref.refType)) {
+    if (refPos && isOutgoingRef(ref.type)) {
       const refsByEqualPosIndex = listOfOutgoingRefsByEqualPos.findIndex(e => areRefPosEqual(e.position, refPos));
       if (refsByEqualPosIndex === -1) {
         listOfOutgoingRefsByEqualPos.push({

--- a/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
+++ b/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
@@ -119,7 +119,6 @@ const TreeContainer = styled.div`
 const NavigatorHelmRow = (props: NavigatorHelmRowProps) => {
   const helmValues = useSelector(selectHelmValues);
   const previewValuesFile = useAppSelector(state => state.main.previewValuesFile);
-  const selectedValuesFile = useAppSelector(state => state.main.selectedValuesFile);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
   const dispatch = useAppDispatch();
   const scrollContainer = React.useRef(null);

--- a/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
+++ b/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
@@ -118,7 +118,7 @@ const TreeContainer = styled.div`
 
 const NavigatorHelmRow = (props: NavigatorHelmRowProps) => {
   const helmValues = useSelector(selectHelmValues);
-  const previewValuesFile = useAppSelector(state => state.main.previewValuesFile);
+  const previewValuesFile = useAppSelector(state => state.main.previewValuesFileId);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
   const dispatch = useAppDispatch();
   const scrollContainer = React.useRef(null);

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -177,7 +177,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
 
   const dispatch = useAppDispatch();
   const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
   const [resource, setResource] = useState<K8sResource>();
   const scrollContainer = React.useRef(null);
@@ -211,7 +211,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
   // on mount, if this resource is selected, scroll to it (the subsection expanded and rendered this)
   useEffect(() => {
     const isVisible = isScrolledIntoView();
-    if (isSelected && selectedResource && !isVisible) {
+    if (isSelected && selectedResourceId && !isVisible) {
       // @ts-ignore
       scrollContainer.current?.scrollIntoView();
     }
@@ -219,11 +219,11 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
 
   useEffect(() => {
     const isVisible = isScrolledIntoView();
-    if (isSelected && selectedResource && !isVisible) {
+    if (isSelected && selectedResourceId && !isVisible) {
       // @ts-ignore
       scrollContainer.current?.scrollIntoView();
     }
-  }, [isSelected, selectedResource]);
+  }, [isSelected, selectedResourceId]);
 
   const selectResource = (resId: string) => {
     dispatch(selectK8sResource(resId));

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -103,14 +103,14 @@ const RefLink = (props: {resourceRef: ResourceRef; resourceMap: ResourceMapType;
   const {resourceRef, resourceMap, onClick} = props;
 
   const targetName =
-    resourceRef.targetResource && resourceMap[resourceRef.targetResource]
-      ? resourceMap[resourceRef.targetResource].name
+    resourceRef.targetResourceId && resourceMap[resourceRef.targetResourceId]
+      ? resourceMap[resourceRef.targetResourceId].name
       : resourceRef.name;
 
   let linkText = targetName;
 
-  if (resourceRef.targetResource) {
-    const resourceKind = resourceMap[resourceRef.targetResource].kind;
+  if (resourceRef.targetResourceId) {
+    const resourceKind = resourceMap[resourceRef.targetResourceId].kind;
     linkText = `${resourceKind}: ${targetName}`;
   }
 
@@ -136,8 +136,8 @@ const PopoverContent = (props: {
   const {children, resourceRefs, resourceMap, selectResource} = props;
 
   const onLinkClick = (ref: ResourceRef) => {
-    if (ref.targetResource) {
-      selectResource(ref.targetResource);
+    if (ref.targetResourceId) {
+      selectResource(ref.targetResourceId);
     }
   };
 
@@ -147,15 +147,15 @@ const PopoverContent = (props: {
       <StyledDivider />
       {resourceRefs
         .sort((a, b) => {
-          if (a.targetResource && b.targetResource) {
-            const resourceA = resourceMap[a.targetResource];
-            const resourceB = resourceMap[b.targetResource];
+          if (a.targetResourceId && b.targetResourceId) {
+            const resourceA = resourceMap[a.targetResourceId];
+            const resourceB = resourceMap[b.targetResourceId];
             return resourceA.kind.localeCompare(resourceB.kind);
           }
           return 0;
         })
         .map(resourceRef => (
-          <StyledRefDiv key={resourceRef.targetResource || resourceRef.name}>
+          <StyledRefDiv key={resourceRef.targetResourceId || resourceRef.name}>
             <RefLink resourceRef={resourceRef} resourceMap={resourceMap} onClick={() => onLinkClick(resourceRef)} />
           </StyledRefDiv>
         ))}

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -105,7 +105,7 @@ const RefLink = (props: {resourceRef: ResourceRef; resourceMap: ResourceMapType;
   const targetName =
     resourceRef.targetResource && resourceMap[resourceRef.targetResource]
       ? resourceMap[resourceRef.targetResource].name
-      : resourceRef.refName;
+      : resourceRef.name;
 
   let linkText = targetName;
 
@@ -155,7 +155,7 @@ const PopoverContent = (props: {
           return 0;
         })
         .map(resourceRef => (
-          <StyledRefDiv key={resourceRef.targetResource || resourceRef.refName}>
+          <StyledRefDiv key={resourceRef.targetResource || resourceRef.name}>
             <RefLink resourceRef={resourceRef} resourceMap={resourceMap} onClick={() => onLinkClick(resourceRef)} />
           </StyledRefDiv>
         ))}

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -114,13 +114,13 @@ const RefLink = (props: {resourceRef: ResourceRef; resourceMap: ResourceMapType;
     linkText = `${resourceKind}: ${targetName}`;
   }
 
-  if (isOutgoingRef(resourceRef.refType)) {
+  if (isOutgoingRef(resourceRef.type)) {
     return <OutgoingRefLink onClick={onClick} text={linkText} />;
   }
-  if (isIncomingRef(resourceRef.refType)) {
+  if (isIncomingRef(resourceRef.type)) {
     return <IncomingRefLink onClick={onClick} text={linkText} />;
   }
-  if (isUnsatisfiedRef(resourceRef.refType)) {
+  if (isUnsatisfiedRef(resourceRef.type)) {
     return <UnsatisfiedRefLink text={targetName} />;
   }
 
@@ -237,7 +237,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
           placement="rightTop"
           content={
             <PopoverContent
-              resourceRefs={resource.refs.filter(r => isIncomingRef(r.refType))}
+              resourceRefs={resource.refs.filter(r => isIncomingRef(r.type))}
               resourceMap={resourceMap}
               selectResource={selectResource}
             >
@@ -266,7 +266,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
           mouseEnterDelay={0.5}
           content={
             <PopoverContent
-              resourceRefs={resource.refs.filter(r => isOutgoingRef(r.refType) || isUnsatisfiedRef(r.refType))}
+              resourceRefs={resource.refs.filter(r => isOutgoingRef(r.type) || isUnsatisfiedRef(r.type))}
               resourceMap={resourceMap}
               selectResource={selectResource}
             >

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -84,7 +84,7 @@ export function applyWithConfirm(
 const ActionsPane = (props: {contentHeight: string}) => {
   const {contentHeight} = props;
 
-  const selectedResourceId = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const applyingResource = useAppSelector(state => state.main.isApplyingResource);
   const [selectedResource, setSelectedResource] = useState<K8sResource>();
   const resourceMap = useAppSelector(state => state.main.resourceMap);

--- a/src/components/organisms/ClustersPane/ClustersPane.tsx
+++ b/src/components/organisms/ClustersPane/ClustersPane.tsx
@@ -38,7 +38,7 @@ const ClustersContainer = styled.div`
 
 const ClustersPane = () => {
   const dispatch = useAppDispatch();
-  const previewResource = useAppSelector(state => state.main.previewResource);
+  const previewResource = useAppSelector(state => state.main.previewResourceId);
   const previewMode = useSelector(inPreviewMode);
   const clusterMode = useSelector(inClusterMode);
   const previewLoader = useAppSelector(state => state.main.previewLoader);

--- a/src/components/organisms/DiffModal/DiffModal.tsx
+++ b/src/components/organisms/DiffModal/DiffModal.tsx
@@ -45,7 +45,7 @@ const DiffModal = () => {
 
   const diffContent = useAppSelector(state => state.main.diffContent);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const diffResourceId = useAppSelector(state => state.main.diffResource);
+  const diffResourceId = useAppSelector(state => state.main.diffResourceId);
   const [diffResource, setDiffResource] = useState<K8sResource>();
   const [resourceContent, setResourceContent] = useState<string>();
   const fileMap = useAppSelector(state => state.main.fileMap);

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -243,7 +243,7 @@ const FileTreePane = () => {
   const uiState = useAppSelector(state => state.ui);
   const fileMap = useAppSelector(state => state.main.fileMap);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
   const isSelectingFile = useAppSelector(state => state.main.isSelectingFile);
   const [tree, setTree] = React.useState<TreeNode | null>(null);
@@ -317,14 +317,14 @@ const FileTreePane = () => {
   }
 
   useEffect(() => {
-    if (selectedResource && tree) {
-      const resource = resourceMap[selectedResource];
+    if (selectedResourceId && tree) {
+      const resource = resourceMap[selectedResourceId];
       if (resource) {
         const filePath = resource.filePath;
         highlightFilePath(filePath);
       }
     }
-  }, [selectedResource]);
+  }, [selectedResourceId]);
 
   useEffect(() => {
     // removes any highlight when a file is selected

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -125,7 +125,7 @@ const NavigatorPane = () => {
   const navigatorHeight = windowHeight - NAVIGATOR_HEIGHT_OFFSET;
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const uiState = useAppSelector(state => state.ui);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const helmCharts = useSelector(selectHelmCharts);
   const helmValues = useSelector(selectHelmValues);
   const kustomizations = useSelector(selectKustomizations);
@@ -148,10 +148,10 @@ const NavigatorPane = () => {
   };
 
   useEffect(() => {
-    if (kustomizations.some(kustomization => kustomization.id === selectedResource)) {
+    if (kustomizations.some(kustomization => kustomization.id === selectedResourceId)) {
       expandSection('kustomizations');
     }
-  }, [selectedResource]);
+  }, [selectedResourceId]);
 
   return (
     <>

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -206,7 +206,7 @@ const NavigatorPane = () => {
                     onExpand={() => expandSection('kustomizations')}
                     onCollapse={() => collapseSection('kustomizations')}
                     isSelected={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.selected)}
-                    isHighlighted={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.highlight)}
+                    isHighlighted={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.isHighlighted)}
                   />
                 }
               >

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -205,7 +205,7 @@ const NavigatorPane = () => {
                     isExpanded={expandedSections.indexOf('kustomizations') !== -1}
                     onExpand={() => expandSection('kustomizations')}
                     onCollapse={() => collapseSection('kustomizations')}
-                    isSelected={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.selected)}
+                    isSelected={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.isSelected)}
                     isHighlighted={!isSectionExpanded('kustomizations') && kustomizations.some(k => k.isHighlighted)}
                   />
                 }

--- a/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
@@ -17,14 +17,14 @@ const KustomizationsSection = (props: KustomizationsSectionProps) => {
 
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const previewResource = useAppSelector(state => state.main.previewResource);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
 
   const selectResource = (resourceId: string) => {
     dispatch(selectK8sResource(resourceId));
   };
 
   const selectPreview = (id: string) => {
-    if (id !== selectedResource) {
+    if (id !== selectedResourceId) {
       dispatch(selectK8sResource(id));
     }
     if (id !== previewResource) {

--- a/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
@@ -16,7 +16,7 @@ const KustomizationsSection = (props: KustomizationsSectionProps) => {
   const dispatch = useAppDispatch();
 
   const previewLoader = useAppSelector(state => state.main.previewLoader);
-  const previewResource = useAppSelector(state => state.main.previewResource);
+  const previewResource = useAppSelector(state => state.main.previewResourceId);
   const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
 
   const selectResource = (resourceId: string) => {

--- a/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
@@ -39,7 +39,7 @@ const KustomizationsSection = (props: KustomizationsSectionProps) => {
       {kustomizations.map((k: K8sResource) => {
         const isSelected = k.selected || previewResource === k.id;
         const isDisabled = Boolean(previewResource && previewResource !== k.id);
-        const isHighlighted = k.highlight;
+        const isHighlighted = k.isHighlighted;
         const buttonActive = previewResource !== undefined && previewResource === k.id;
 
         return (

--- a/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
@@ -37,7 +37,7 @@ const KustomizationsSection = (props: KustomizationsSectionProps) => {
   return (
     <>
       {kustomizations.map((k: K8sResource) => {
-        const isSelected = k.selected || previewResource === k.id;
+        const isSelected = k.isSelected || previewResource === k.id;
         const isDisabled = Boolean(previewResource && previewResource !== k.id);
         const isHighlighted = k.isHighlighted;
         const buttonActive = previewResource !== undefined && previewResource === k.id;

--- a/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
@@ -24,7 +24,7 @@ const ResourcesSection = () => {
   const dispatch = useAppDispatch();
   const appConfig = useAppSelector(state => state.config);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const previewResource = useAppSelector(state => state.main.previewResource);
+  const previewResource = useAppSelector(state => state.main.previewResourceId);
   const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const resources = useSelector(selectActiveResources);
 

--- a/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
@@ -25,7 +25,7 @@ const ResourcesSection = () => {
   const appConfig = useAppSelector(state => state.config);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const previewResource = useAppSelector(state => state.main.previewResource);
-  const selectedResource = useAppSelector(state => state.main.selectedResource);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const resources = useSelector(selectActiveResources);
 
   const [namespace, setNamespace] = useState<string>(ALL_NAMESPACES);
@@ -124,7 +124,7 @@ const ResourcesSection = () => {
       })
     );
     setExpandedSubsectionsBySection(updatedExpandedSubsectionsBySection);
-  }, [resourceMap, selectedResource]);
+  }, [resourceMap, selectedResourceId]);
 
   function shouldSubsectionBeExpanded(subsection: NavigatorSubSection) {
     return (
@@ -132,7 +132,7 @@ const ResourcesSection = () => {
       (resources.length > 0 &&
         resources.some(
           resource =>
-            resource.kind === subsection.kindSelector && (resource.isHighlighted || selectedResource === resource.id)
+            resource.kind === subsection.kindSelector && (resource.isHighlighted || selectedResourceId === resource.id)
         ))
     );
   }

--- a/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
@@ -132,7 +132,7 @@ const ResourcesSection = () => {
       (resources.length > 0 &&
         resources.some(
           resource =>
-            resource.kind === subsection.kindSelector && (resource.highlight || selectedResource === resource.id)
+            resource.kind === subsection.kindSelector && (resource.isHighlighted || selectedResource === resource.id)
         ))
     );
   }

--- a/src/components/organisms/NavigatorPane/components/Section.tsx
+++ b/src/components/organisms/NavigatorPane/components/Section.tsx
@@ -73,7 +73,7 @@ const Section = (props: {
                   <SubsectionHeader
                     isExpanded={isSubsectionExpanded(subsection.name)}
                     isHighlighted={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.isHighlighted)}
-                    isSelected={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.selected)}
+                    isSelected={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.isSelected)}
                     onExpand={() => onSubsectionExpand(section.name, subsection.name)}
                     onCollapse={() => onSubsectionCollapse(section.name, subsection.name)}
                     resourcesCount={visibleResources.length}
@@ -87,7 +87,7 @@ const Section = (props: {
                       key={resource.id}
                       rowKey={resource.id}
                       label={resource.name}
-                      isSelected={Boolean(resource.selected)}
+                      isSelected={Boolean(resource.isSelected)}
                       highlighted={Boolean(resource.isHighlighted)}
                       hasIncomingRefs={Boolean(hasIncomingRefs(resource))}
                       hasOutgoingRefs={Boolean(hasOutgoingRefs(resource))}

--- a/src/components/organisms/NavigatorPane/components/Section.tsx
+++ b/src/components/organisms/NavigatorPane/components/Section.tsx
@@ -72,7 +72,7 @@ const Section = (props: {
                 header={
                   <SubsectionHeader
                     isExpanded={isSubsectionExpanded(subsection.name)}
-                    isHighlighted={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.highlight)}
+                    isHighlighted={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.isHighlighted)}
                     isSelected={!isSubsectionExpanded(subsection.name) && visibleResources.some(r => r.selected)}
                     onExpand={() => onSubsectionExpand(section.name, subsection.name)}
                     onCollapse={() => onSubsectionCollapse(section.name, subsection.name)}
@@ -88,7 +88,7 @@ const Section = (props: {
                       rowKey={resource.id}
                       label={resource.name}
                       isSelected={Boolean(resource.selected)}
-                      highlighted={Boolean(resource.highlight)}
+                      highlighted={Boolean(resource.isHighlighted)}
                       hasIncomingRefs={Boolean(hasIncomingRefs(resource))}
                       hasOutgoingRefs={Boolean(hasOutgoingRefs(resource))}
                       hasUnsatisfiedRefs={Boolean(hasUnsatisfiedRefs(resource))}

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -105,7 +105,7 @@ const ExitButton = (props: {onClick: () => void}) => {
 };
 
 const PageHeader = () => {
-  const previewResourceId = useAppSelector(state => state.main.previewResource);
+  const previewResourceId = useAppSelector(state => state.main.previewResourceId);
   const previewValuesFileId = useAppSelector(state => state.main.previewValuesFile);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const activeResources = useSelector(selectActiveResources);

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -106,7 +106,7 @@ const ExitButton = (props: {onClick: () => void}) => {
 
 const PageHeader = () => {
   const previewResourceId = useAppSelector(state => state.main.previewResourceId);
-  const previewValuesFileId = useAppSelector(state => state.main.previewValuesFile);
+  const previewValuesFileId = useAppSelector(state => state.main.previewValuesFileId);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const activeResources = useSelector(selectActiveResources);
   const helmValuesMap = useAppSelector(state => state.main.helmValuesMap);

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -38,7 +38,7 @@ type PreviewLoaderType = {
 interface AppState {
   fileMap: FileMapType; // maps filePath to FileEntry, filePath is relative to selected rootFolder
   resourceMap: ResourceMapType; // maps resource ids to resources
-  selectedResource?: string; // the id of the currently selected resource
+  selectedResourceId?: string; // the id of the currently selected resource
   selectedPath?: string; // the currently selected path
   previewType?: 'kustomization' | 'cluster' | 'helm';
   previewResource?: string; // the resource currently being previewed

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -47,7 +47,7 @@ interface AppState {
   diffContent?: string; // the diff content for the resource being diffed
   helmChartMap: HelmChartMapType; // maps chart ids to helm charts
   helmValuesMap: HelmValuesMapType; // maps values ids to helm values files
-  selectedValuesFile?: string; // the currently selected values file
+  selectedValuesFileId?: string; // the currently selected values file
   previewValuesFile?: string; // the values file currently being previewed
   isSelectingFile: boolean; // if we are currently in the process of selecting a file - used for one-time UI updates
   isApplyingResource: boolean; // if we are currently applying a resource - room for improvement...

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -43,7 +43,7 @@ interface AppState {
   previewType?: 'kustomization' | 'cluster' | 'helm';
   previewResourceId?: string; // the resource currently being previewed
   previewLoader: PreviewLoaderType;
-  diffResource?: string; // the resource currently being diffed
+  diffResourceId?: string; // the resource currently being diffed
   diffContent?: string; // the diff content for the resource being diffed
   helmChartMap: HelmChartMapType; // maps chart ids to helm charts
   helmValuesMap: HelmValuesMapType; // maps values ids to helm values files

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -48,7 +48,7 @@ interface AppState {
   helmChartMap: HelmChartMapType; // maps chart ids to helm charts
   helmValuesMap: HelmValuesMapType; // maps values ids to helm values files
   selectedValuesFileId?: string; // the currently selected values file
-  previewValuesFile?: string; // the values file currently being previewed
+  previewValuesFileId?: string; // the values file currently being previewed
   isSelectingFile: boolean; // if we are currently in the process of selecting a file - used for one-time UI updates
   isApplyingResource: boolean; // if we are currently applying a resource - room for improvement...
 }

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -41,7 +41,7 @@ interface AppState {
   selectedResourceId?: string; // the id of the currently selected resource
   selectedPath?: string; // the currently selected path
   previewType?: 'kustomization' | 'cluster' | 'helm';
-  previewResource?: string; // the resource currently being previewed
+  previewResourceId?: string; // the resource currently being previewed
   previewLoader: PreviewLoaderType;
   diffResource?: string; // the resource currently being diffed
   diffContent?: string; // the diff content for the resource being diffed

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -12,7 +12,7 @@ interface K8sResource {
   kind: string; // k8s resource kind
   version: string; // k8s resource version
   namespace?: string; // k8s namespace is specified (for filtering)
-  highlight: boolean; // if highlighted in UI (should probalby move to UI state object)
+  isHighlighted: boolean; // if highlighted in UI (should probalby move to UI state object)
   selected: boolean; // if selected in UI (should probably move to UI state object)
   text: string; // unparsed resource content (for editing)
   content: any; // contains parsed yaml resource - used for filtering/finding links/refs, etc

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -13,7 +13,7 @@ interface K8sResource {
   version: string; // k8s resource version
   namespace?: string; // k8s namespace is specified (for filtering)
   isHighlighted: boolean; // if highlighted in UI (should probalby move to UI state object)
-  selected: boolean; // if selected in UI (should probably move to UI state object)
+  isSelected: boolean; // if selected in UI (should probably move to UI state object)
   text: string; // unparsed resource content (for editing)
   content: any; // contains parsed yaml resource - used for filtering/finding links/refs, etc
   refs?: ResourceRef[]; // array of refs to other resources

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -66,7 +66,7 @@ export enum ResourceRefType {
 interface ResourceRef {
   type: ResourceRefType; // the type of ref (see enum)
   name: string; // the ref value - for example the name of a configmap
-  targetResource?: string; // the resource this is referring to (empty for unsatisfied refs)
+  targetResourceId?: string; // the resource this is referring to (empty for unsatisfied refs)
   position?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)
 }
 

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -67,7 +67,7 @@ interface ResourceRef {
   type: ResourceRefType; // the type of ref (see enum)
   name: string; // the ref value - for example the name of a configmap
   targetResource?: string; // the resource this is referring to (empty for unsatisfied refs)
-  refPos?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)
+  position?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)
 }
 
 interface RefPosition {

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -64,7 +64,7 @@ export enum ResourceRefType {
 }
 
 interface ResourceRef {
-  refType: ResourceRefType; // the type of ref (see enum)
+  type: ResourceRefType; // the type of ref (see enum)
   refName: string; // the ref value - for example the name of a configmap
   targetResource?: string; // the resource this is referring to (empty for unsatisfied refs)
   refPos?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -65,7 +65,7 @@ export enum ResourceRefType {
 
 interface ResourceRef {
   type: ResourceRefType; // the type of ref (see enum)
-  refName: string; // the ref value - for example the name of a configmap
+  name: string; // the ref value - for example the name of a configmap
   targetResource?: string; // the resource this is referring to (empty for unsatisfied refs)
   refPos?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)
 }

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -269,13 +269,13 @@ export const mainSlice = createSlice({
  */
 
 function setPreviewData<State>(payload: SetPreviewDataPayload, state: AppState) {
-  state.previewResource = undefined;
+  state.previewResourceId = undefined;
   state.previewValuesFile = undefined;
 
   if (payload.previewResourceId) {
     if (state.previewType === 'kustomization') {
       if (state.resourceMap[payload.previewResourceId]) {
-        state.previewResource = payload.previewResourceId;
+        state.previewResourceId = payload.previewResourceId;
       } else {
         log.error(`Unknown preview id: ${payload.previewResourceId}`);
       }
@@ -288,7 +288,7 @@ function setPreviewData<State>(payload: SetPreviewDataPayload, state: AppState) 
       }
     }
     if (state.previewType === 'cluster') {
-      state.previewResource = payload.previewResourceId;
+      state.previewResourceId = payload.previewResourceId;
     }
   }
 

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -125,7 +125,7 @@ export const mainSlice = createSlice({
             const resources = extractK8sResources(action.payload.content, filePath.substring(rootFolder.length));
             Object.values(resources).forEach(r => {
               state.resourceMap[r.id] = r;
-              r.highlight = true;
+              r.isHighlighted = true;
             });
 
             reprocessResources([], state.resourceMap, state.fileMap);
@@ -251,7 +251,7 @@ export const mainSlice = createSlice({
       state.helmValuesMap = action.payload.helmValuesMap;
       state.previewLoader.isLoading = false;
       state.previewLoader.targetResourceId = undefined;
-      state.selectedResource = undefined;
+      state.selectedResourceId = undefined;
       state.selectedPath = undefined;
       state.previewResource = undefined;
       state.previewType = undefined;
@@ -327,7 +327,7 @@ function selectFilePath(filePath: string, state: AppState) {
     });
   }
 
-  state.selectedResource = undefined;
+  state.selectedResourceId = undefined;
   state.selectedPath = filePath;
 }
 

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -270,7 +270,7 @@ export const mainSlice = createSlice({
 
 function setPreviewData<State>(payload: SetPreviewDataPayload, state: AppState) {
   state.previewResourceId = undefined;
-  state.previewValuesFile = undefined;
+  state.previewValuesFileId = undefined;
 
   if (payload.previewResourceId) {
     if (state.previewType === 'kustomization') {
@@ -282,7 +282,7 @@ function setPreviewData<State>(payload: SetPreviewDataPayload, state: AppState) 
     }
     if (state.previewType === 'helm') {
       if (state.helmValuesMap[payload.previewResourceId]) {
-        state.previewValuesFile = payload.previewResourceId;
+        state.previewValuesFileId = payload.previewResourceId;
       } else {
         log.error(`Unknown preview id: ${payload.previewResourceId}`);
       }

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -150,7 +150,7 @@ export const mainSlice = createSlice({
           resource.content = parseDocument(value).toJS();
           recalculateResourceRanges(resource, state);
           reprocessResources([resource.id], state.resourceMap, state.fileMap);
-          resource.selected = false;
+          resource.isSelected = false;
           updateSelectionAndHighlights(state, resource);
         }
       } catch (e) {

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -176,7 +176,7 @@ export const mainSlice = createSlice({
         values.selected = values.id === payload;
       });
 
-      state.selectedValuesFile = state.helmValuesMap[payload].selected ? payload : undefined;
+      state.selectedValuesFileId = state.helmValuesMap[payload].selected ? payload : undefined;
       selectFilePath(state.helmValuesMap[payload].filePath, state);
     },
     /**
@@ -253,12 +253,12 @@ export const mainSlice = createSlice({
       state.previewLoader.targetResourceId = undefined;
       state.selectedResourceId = undefined;
       state.selectedPath = undefined;
-      state.previewResource = undefined;
+      state.previewResourceId = undefined;
       state.previewType = undefined;
     });
 
     builder.addCase(performResourceDiff.fulfilled, (state, action) => {
-      state.diffResource = action.payload.diffResourceId;
+      state.diffResourceId = action.payload.diffResourceId;
       state.diffContent = action.payload.diffContent;
     });
   },

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -315,7 +315,7 @@ function selectFilePath(filePath: string, state: AppState) {
   if (entries.length > 0) {
     const parent = entries[entries.length - 1];
     getResourcesForPath(parent.filePath, state.resourceMap).forEach(r => {
-      r.highlight = true;
+      r.isHighlighted = true;
     });
 
     if (parent.children) {

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -26,7 +26,7 @@ export const selectActiveResources = createSelector(
 
 export const selectSelectedResource = createSelector(
   (state: RootState) => state.main.resourceMap,
-  (state: RootState) => state.main.selectedResource,
+  (state: RootState) => state.main.selectedResourceId,
   (resourceMap, selectedResourceId) => (selectedResourceId ? resourceMap[selectedResourceId] : undefined)
 );
 

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -16,7 +16,7 @@ export const selectAllResources = createSelector(
 
 export const selectActiveResources = createSelector(
   selectAllResources,
-  (state: RootState) => state.main.previewResource,
+  (state: RootState) => state.main.previewResourceId,
   (state: RootState) => state.main.previewValuesFile,
   (resources, previewResource, previewValuesFile) =>
     resources.filter(
@@ -46,12 +46,12 @@ export const selectHelmValues = createSelector(
 
 export const inPreviewMode = createSelector(
   (state: RootState) => state.main,
-  appState => Boolean(appState.previewResource) || Boolean(appState.previewValuesFile)
+  appState => Boolean(appState.previewResourceId) || Boolean(appState.previewValuesFile)
 );
 
 export const inClusterMode = createSelector(
   (state: RootState) => state,
-  appState => appState.main.previewResource && appState.main.previewResource.endsWith(appState.config.kubeconfig)
+  appState => appState.main.previewResourceId && appState.main.previewResourceId.endsWith(appState.config.kubeconfig)
 );
 
 export const selectLogs = createSelector(

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -17,7 +17,7 @@ export const selectAllResources = createSelector(
 export const selectActiveResources = createSelector(
   selectAllResources,
   (state: RootState) => state.main.previewResourceId,
-  (state: RootState) => state.main.previewValuesFile,
+  (state: RootState) => state.main.previewValuesFileId,
   (resources, previewResource, previewValuesFile) =>
     resources.filter(
       r => (previewResource === undefined && previewValuesFile === undefined) || r.filePath.startsWith(PREVIEW_PREFIX)
@@ -46,7 +46,7 @@ export const selectHelmValues = createSelector(
 
 export const inPreviewMode = createSelector(
   (state: RootState) => state.main,
-  appState => Boolean(appState.previewResourceId) || Boolean(appState.previewValuesFile)
+  appState => Boolean(appState.previewResourceId) || Boolean(appState.previewValuesFileId)
 );
 
 export const inClusterMode = createSelector(

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -212,7 +212,7 @@ export function reloadFile(absolutePath: string, fileEntry: FileEntry, state: Ap
     let wasSelected = false;
 
     resourcesInFile.forEach(resource => {
-      if (state.selectedResource === resource.id) {
+      if (state.selectedResourceId === resource.id) {
         updateSelectionAndHighlights(state, resource);
         wasSelected = true;
       }
@@ -311,7 +311,7 @@ export function addPath(absolutePath: string, state: AppState, appConfig: AppCon
 function removeFile(fileEntry: FileEntry, state: AppState) {
   log.info(`removing file ${fileEntry.filePath}`);
   getResourcesForPath(fileEntry.filePath, state.resourceMap).forEach(resource => {
-    if (state.selectedResource === resource.id) {
+    if (state.selectedResourceId === resource.id) {
       updateSelectionAndHighlights(state, resource);
     }
     delete state.resourceMap[resource.id];

--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -129,13 +129,13 @@ export function getKustomizationRefs(
           (selectParent && r.type === ResourceRefType.KustomizationParent)
       )
       .forEach(r => {
-        if (r.targetResource) {
-          const target = resourceMap[r.targetResource];
+        if (r.targetResourceId) {
+          const target = resourceMap[r.targetResourceId];
           if (target) {
-            linkedResourceIds.push(r.targetResource);
+            linkedResourceIds.push(r.targetResourceId);
 
             if (target.kind === 'Kustomization' && r.type === ResourceRefType.KustomizationResource) {
-              linkedResourceIds = linkedResourceIds.concat(getKustomizationRefs(resourceMap, r.targetResource));
+              linkedResourceIds = linkedResourceIds.concat(getKustomizationRefs(resourceMap, r.targetResourceId));
             }
           }
         }

--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -125,8 +125,8 @@ export function getKustomizationRefs(
     kustomization.refs
       .filter(
         r =>
-          r.refType === ResourceRefType.KustomizationResource ||
-          (selectParent && r.refType === ResourceRefType.KustomizationParent)
+          r.type === ResourceRefType.KustomizationResource ||
+          (selectParent && r.type === ResourceRefType.KustomizationParent)
       )
       .forEach(r => {
         if (r.targetResource) {
@@ -134,7 +134,7 @@ export function getKustomizationRefs(
           if (target) {
             linkedResourceIds.push(r.targetResource);
 
-            if (target.kind === 'Kustomization' && r.refType === ResourceRefType.KustomizationResource) {
+            if (target.kind === 'Kustomization' && r.type === ResourceRefType.KustomizationResource) {
               linkedResourceIds = linkedResourceIds.concat(getKustomizationRefs(resourceMap, r.targetResource));
             }
           }

--- a/src/redux/services/resource.test.ts
+++ b/src/redux/services/resource.test.ts
@@ -13,7 +13,7 @@ test('get-namespaces', () => {
     kind: 'ResourceType',
     version: '1.0',
     isHighlighted: false,
-    selected: false,
+    isSelected: false,
     content: {},
     text: '',
   };

--- a/src/redux/services/resource.test.ts
+++ b/src/redux/services/resource.test.ts
@@ -12,7 +12,7 @@ test('get-namespaces', () => {
     name: 'resource name',
     kind: 'ResourceType',
     version: '1.0',
-    highlight: false,
+    isHighlighted: false,
     selected: false,
     content: {},
     text: '',

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -148,7 +148,7 @@ function createResourceRef(
       resource.refs.push({
         type: refType,
         name: refName,
-        refPos: refNode?.getNodePosition(),
+        position: refNode?.getNodePosition(),
         targetResource,
       });
     }
@@ -597,8 +597,8 @@ function processRefs(resourceMap: ResourceMapType) {
       let shouldPush = true;
 
       if (isUnsatisfiedRef(ref.type)) {
-        if (ref.refPos) {
-          const foundSatisfiedRefOnSamePosition = findSatisfiedRefOnPosition(ref.refPos);
+        if (ref.position) {
+          const foundSatisfiedRefOnSamePosition = findSatisfiedRefOnPosition(ref.position);
           if (foundSatisfiedRefOnSamePosition) {
             shouldPush = false;
           }

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -142,14 +142,14 @@ function createResourceRef(
     // make sure we don't duplicate
     if (
       !resource.refs.some(
-        ref => ref.type === refType && ref.name === refName && ref.targetResource === targetResource
+        ref => ref.type === refType && ref.name === refName && ref.targetResourceId === targetResource
       )
     ) {
       resource.refs.push({
         type: refType,
         name: refName,
         position: refNode?.getNodePosition(),
-        targetResource,
+        targetResourceId: targetResource,
       });
     }
   } else {

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -142,11 +142,11 @@ function createResourceRef(
     // make sure we don't duplicate
     if (
       !resource.refs.some(
-        ref => ref.refType === refType && ref.refName === refName && ref.targetResource === targetResource
+        ref => ref.type === refType && ref.refName === refName && ref.targetResource === targetResource
       )
     ) {
       resource.refs.push({
-        refType,
+        type: refType,
         refName,
         refPos: refNode?.getNodePosition(),
         targetResource,
@@ -596,7 +596,7 @@ function processRefs(resourceMap: ResourceMapType) {
     resource.refs?.forEach(ref => {
       let shouldPush = true;
 
-      if (isUnsatisfiedRef(ref.refType)) {
+      if (isUnsatisfiedRef(ref.type)) {
         if (ref.refPos) {
           const foundSatisfiedRefOnSamePosition = findSatisfiedRefOnPosition(ref.refPos);
           if (foundSatisfiedRefOnSamePosition) {

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -387,7 +387,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             name: createResourceName(relativePath, content),
             filePath: relativePath,
             id: uuidv4(),
-            highlight: false,
+            isHighlighted: false,
             selected: false,
             kind: content.kind,
             version: content.apiVersion,

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -142,12 +142,12 @@ function createResourceRef(
     // make sure we don't duplicate
     if (
       !resource.refs.some(
-        ref => ref.type === refType && ref.refName === refName && ref.targetResource === targetResource
+        ref => ref.type === refType && ref.name === refName && ref.targetResource === targetResource
       )
     ) {
       resource.refs.push({
         type: refType,
-        refName,
+        name: refName,
         refPos: refNode?.getNodePosition(),
         targetResource,
       });

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -388,7 +388,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             filePath: relativePath,
             id: uuidv4(),
             isHighlighted: false,
-            selected: false,
+            isSelected: false,
             kind: content.kind,
             version: content.apiVersion,
             content,

--- a/src/redux/services/resourceRefs.ts
+++ b/src/redux/services/resourceRefs.ts
@@ -54,19 +54,19 @@ export function isUnsatisfiedRef(e: ResourceRefType) {
 }
 
 export function hasIncomingRefs(resource: K8sResource) {
-  return resource.refs?.some(e => isIncomingRef(e.refType));
+  return resource.refs?.some(e => isIncomingRef(e.type));
 }
 
 export function hasOutgoingRefs(resource: K8sResource) {
-  return resource.refs?.some(e => isOutgoingRef(e.refType));
+  return resource.refs?.some(e => isOutgoingRef(e.type));
 }
 
 export function hasRefs(resource: K8sResource) {
-  return resource.refs?.some(e => isOutgoingRef(e.refType));
+  return resource.refs?.some(e => isOutgoingRef(e.type));
 }
 
 export function hasUnsatisfiedRefs(resource: K8sResource) {
-  return resource.refs?.some(e => isUnsatisfiedRef(e.refType));
+  return resource.refs?.some(e => isUnsatisfiedRef(e.type));
 }
 
 export type RefMapper = {

--- a/src/redux/services/selection.ts
+++ b/src/redux/services/selection.ts
@@ -44,11 +44,11 @@ export function updateSelectionAndHighlights(state: AppState, resource: K8sResou
   clearResourceSelections(state.resourceMap, resource.id);
 
   state.selectedPath = undefined;
-  state.selectedResource = undefined;
+  state.selectedResourceId = undefined;
 
   if (resource) {
     resource.isSelected = true;
-    state.selectedResource = resource.id;
+    state.selectedResourceId = resource.id;
 
     if (isKustomizationResource(resource)) {
       getKustomizationRefs(state.resourceMap, resource.id, true).forEach(e => {

--- a/src/redux/services/selection.ts
+++ b/src/redux/services/selection.ts
@@ -13,7 +13,7 @@ export function clearResourceSelections(resourceMap: ResourceMapType, excludeIte
   Object.values(resourceMap).forEach(e => {
     e.isHighlighted = false;
     if (!excludeItemId || e.id !== excludeItemId) {
-      e.selected = false;
+      e.isSelected = false;
     }
   });
 }
@@ -47,7 +47,7 @@ export function updateSelectionAndHighlights(state: AppState, resource: K8sResou
   state.selectedResource = undefined;
 
   if (resource) {
-    resource.selected = true;
+    resource.isSelected = true;
     state.selectedResource = resource.id;
 
     if (isKustomizationResource(resource)) {

--- a/src/redux/services/selection.ts
+++ b/src/redux/services/selection.ts
@@ -11,7 +11,7 @@ import {getKustomizationRefs, isKustomizationResource} from '@redux/services/kus
 
 export function clearResourceSelections(resourceMap: ResourceMapType, excludeItemId?: string) {
   Object.values(resourceMap).forEach(e => {
-    e.highlight = false;
+    e.isHighlighted = false;
     if (!excludeItemId || e.id !== excludeItemId) {
       e.selected = false;
     }
@@ -28,7 +28,7 @@ export function highlightChildrenResources(fileEntry: FileEntry, resourceMap: Re
     .filter(child => child)
     .forEach(child => {
       getResourcesForPath(child.filePath, resourceMap).forEach(e => {
-        e.highlight = true;
+        e.isHighlighted = true;
       });
       if (child.children) {
         highlightChildrenResources(child, resourceMap, fileMap);
@@ -52,11 +52,11 @@ export function updateSelectionAndHighlights(state: AppState, resource: K8sResou
 
     if (isKustomizationResource(resource)) {
       getKustomizationRefs(state.resourceMap, resource.id, true).forEach(e => {
-        state.resourceMap[e].highlight = true;
+        state.resourceMap[e].isHighlighted = true;
       });
     } else {
       getLinkedResources(resource).forEach(e => {
-        state.resourceMap[e].highlight = true;
+        state.resourceMap[e].isHighlighted = true;
       });
     }
 

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -20,7 +20,7 @@ export const previewCluster = createAsyncThunk<
   }
 >('main/previewCluster', async (configPath, thunkAPI) => {
   const state: AppState = thunkAPI.getState().main;
-  if (state.previewResource !== configPath) {
+  if (state.previewResourceId !== configPath) {
     try {
       const kc = new k8s.KubeConfig();
       kc.loadFromFile(configPath);

--- a/src/redux/thunks/previewHelmValuesFile.ts
+++ b/src/redux/thunks/previewHelmValuesFile.ts
@@ -23,7 +23,7 @@ export const previewHelmValuesFile = createAsyncThunk<
   const configState = thunkAPI.getState().config;
   const state = thunkAPI.getState().main;
   const kubeconfig = thunkAPI.getState().config.kubeconfig;
-  if (state.previewValuesFile !== valuesFileId) {
+  if (state.previewValuesFileId !== valuesFileId) {
     const valuesFile = state.helmValuesMap[valuesFileId];
     if (valuesFile && valuesFile.filePath) {
       const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;

--- a/src/redux/thunks/previewKustomization.ts
+++ b/src/redux/thunks/previewKustomization.ts
@@ -20,7 +20,7 @@ export const previewKustomization = createAsyncThunk<
   }
 >('main/previewKustomization', async (resourceId, thunkAPI) => {
   const state = thunkAPI.getState().main;
-  if (state.previewResource !== resourceId) {
+  if (state.previewResourceId !== resourceId) {
     const resource = state.resourceMap[resourceId];
     if (resource && resource.filePath) {
       const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;


### PR DESCRIPTION
This PR...

## Changes

on K8sResource:
- rename resource highlighted to isHighlighted
- rename resource selected to isSelected
on ResourceRef:
- rename refType to type
- rename refName to name
- rename refPos to position
on AppState:
- rename targetResource to targetResourceId
- rename selectedResource to selectedResourceId
- rename previewResource to previewResourceId
- rename diffResource to diffResourceId
- rename selectedValuesFile to selectedValuesFileId
- rename previewValuesFile to previewValuesFileId

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
