### PR TITLE
feat: Add electronlogger to the project

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,7 +3,11 @@ import * as path from 'path';
 import * as isDev from 'electron-is-dev';
 import installExtension, {REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS} from 'electron-devtools-installer';
 import {execSync} from 'child_process';
+import * as ElectronLog from 'electron-log';
+
 import {APP_MIN_HEIGHT, APP_MIN_WIDTH} from '../src/constants/constants';
+
+Object.assign(console, ElectronLog.functions);
 
 const ElectronStore = require('electron-store');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "monokle",
-  "version": "1.0.0",
+  "version": "v1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "v1.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ant-design/icons": "4.6.2",
@@ -23,6 +23,7 @@
         "dayjs": "^1.10.6",
         "electron-devtools-installer": "^3.2.0",
         "electron-is-dev": "^2.0.0",
+        "electron-log": "^4.4.1",
         "electron-store": "^8.0.0",
         "es6-tween": "^5.5.11",
         "fast-deep-equal": "^3.1.3",
@@ -11073,6 +11074,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/electron-log": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.1.tgz",
+      "integrity": "sha512-nK/DwxPLtwWbggPCm27eMQhYHc3gzoZ+cokBK99diO4WsZJKrv5l44EUW8mRfWpmC8ZubnMyp6GTUIJyTc9AJA=="
     },
     "node_modules/electron-osx-sign": {
       "version": "0.5.0",
@@ -39746,6 +39752,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
       "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
+    },
+    "electron-log": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.1.tgz",
+      "integrity": "sha512-nK/DwxPLtwWbggPCm27eMQhYHc3gzoZ+cokBK99diO4WsZJKrv5l44EUW8mRfWpmC8ZubnMyp6GTUIJyTc9AJA=="
     },
     "electron-osx-sign": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dayjs": "^1.10.6",
     "electron-devtools-installer": "^3.2.0",
     "electron-is-dev": "^2.0.0",
+    "electron-log": "^4.4.1",
     "electron-store": "^8.0.0",
     "es6-tween": "^5.5.11",
     "fast-deep-equal": "^3.1.3",


### PR DESCRIPTION
This PR...

Will add `electron-logger` library to project. So in release mode, we will be able to see log messages of the application or We will be able to request log messages from end-users.

## Changes

- Added related library to the project
- Assigned log functions to console functions. So developers can continue to use log functions as it is.

## Fixes

-

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
