### PR TITLE
Navigate through selection history

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,5 +42,5 @@ Monokle current supports the following keyboard shortcuts:
 - Toggle Left Pane: Ctrl/Cmd B
 - Toggle Right Pane: Ctrl/Cmd ALT B
 - Save (in editors): Ctrl/Cmd S
-- Navigate Back (in Selection History): ALT ArrowLeft
-- Navigate Forward (in Selection History): ALT ArrowRight
+- Navigate Back (Selection History): ALT ArrowLeft
+- Navigate Forward (Selection History): ALT ArrowRight

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,3 +42,5 @@ Monokle current supports the following keyboard shortcuts:
 - Toggle Left Pane: Ctrl/Cmd B
 - Toggle Right Pane: Ctrl/Cmd ALT B
 - Save (in editors): Ctrl/Cmd S
+- Navigate Back (in Selection History): ALT ArrowLeft
+- Navigate Forward (in Selection History): ALT ArrowRight

--- a/src/components/molecules/GraphView/GraphView.tsx
+++ b/src/components/molecules/GraphView/GraphView.tsx
@@ -94,9 +94,7 @@ const GraphView = (props: {editorHeight: string}) => {
   function getElementData(resource: K8sResource) {
     let data: any[] = [mapResourceToElement(resource)];
     if (resource.refs) {
-      const refs = resource.refs
-        .filter(ref => !isUnsatisfiedRef(ref.type))
-        .map(ref => mapRefToElement(resource, ref));
+      const refs = resource.refs.filter(ref => !isUnsatisfiedRef(ref.type)).map(ref => mapRefToElement(resource, ref));
       data = data.concat(refs);
     }
     return data;
@@ -133,7 +131,7 @@ const GraphView = (props: {editorHeight: string}) => {
   const onSelectionChange = (elements: any) => {
     if (elements && elements[0]) {
       elements[0].data.wasSelectedInGraphView = true;
-      dispatch(selectK8sResource(elements[0].id));
+      dispatch(selectK8sResource({resourceId: elements[0].id}));
     }
   };
 

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -19,6 +19,7 @@ import YamlWorker from 'worker-loader!monaco-yaml/lib/esm/yaml.worker';
 import {getResourceSchema} from '@redux/services/schema';
 import {logMessage} from '@redux/services/log';
 import {updateFileEntry, updateResource, selectK8sResource} from '@redux/reducers/main';
+import {selectFromHistory} from '@redux/thunks/selectionHistory';
 import {parseAllDocuments} from 'yaml';
 import {ROOT_FILE_ENTRY} from '@constants/constants';
 import {KUBESHOP_MONACO_THEME} from '@utils/monaco';
@@ -121,6 +122,28 @@ const Monaco = (props: {editorHeight: string}) => {
       keybindings: [monaco.KeyCode.Escape],
       run: () => {
         hiddenInputRef.current?.focus();
+      },
+    });
+
+    // register action to navigate back in the selection history
+    e.addAction({
+      id: 'monokle-navigate-back',
+      label: 'Navigate Back',
+      /* eslint-disable no-bitwise */
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.LeftArrow],
+      run: () => {
+        dispatch(selectFromHistory({direction: 'left'}));
+      },
+    });
+
+    // register action to navigate forward in the selection history
+    e.addAction({
+      id: 'monokle-navigate-forward',
+      label: 'Navigate Forward',
+      /* eslint-disable no-bitwise */
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.RightArrow],
+      run: () => {
+        dispatch(selectFromHistory({direction: 'right'}));
       },
     });
 

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -100,7 +100,7 @@ const Monaco = (props: {editorHeight: string}) => {
   const dispatch = useAppDispatch();
 
   const selectResource = (resourceId: string) => {
-    dispatch(selectK8sResource(resourceId));
+    dispatch(selectK8sResource({resourceId}));
   };
 
   const onDidChangeMarkers = (e: monaco.Uri[]) => {

--- a/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
+++ b/src/components/molecules/NavigatorHelmRow/NavigatorHelmRow.tsx
@@ -130,7 +130,7 @@ const NavigatorHelmRow = (props: NavigatorHelmRowProps) => {
 
   function onSelectValuesFile(id: string) {
     if (!previewValuesFile || previewValuesFile === id) {
-      dispatch(selectHelmValuesFile(id));
+      dispatch(selectHelmValuesFile({valuesFileId: id}));
     }
   }
 

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -226,7 +226,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
   }, [isSelected, selectedResourceId]);
 
   const selectResource = (resId: string) => {
-    dispatch(selectK8sResource(resId));
+    dispatch(selectK8sResource({resourceId: resId}));
   };
 
   return (

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -112,11 +112,13 @@ const ActionsPane = (props: {contentHeight: string}) => {
   const [key, setKey] = useState('source');
   const dispatch = useAppDispatch();
 
-  const isLeftArrowEnabled = selectionHistory.length > 0 && currentSelectionHistoryIndex !== 0;
+  const isLeftArrowEnabled =
+    selectionHistory.length > 1 &&
+    (currentSelectionHistoryIndex === undefined || (currentSelectionHistoryIndex && currentSelectionHistoryIndex > 0));
   const isRightArrowEnabled =
-    selectionHistory.length > 0 &&
-    currentSelectionHistoryIndex &&
-    currentSelectionHistoryIndex < selectionHistory.length - 2;
+    selectionHistory.length > 1 &&
+    currentSelectionHistoryIndex !== undefined &&
+    currentSelectionHistoryIndex < selectionHistory.length - 1;
 
   const onClickLeftArrow = () => {
     dispatch(selectFromHistory({direction: 'left'}));

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -21,6 +21,7 @@ import {FileMapType, ResourceMapType} from '@models/appstate';
 import {ThunkDispatch} from 'redux-thunk';
 import {ApplyTooltip, DiffTooltip} from '@constants/tooltips';
 import {performResourceDiff} from '@redux/thunks/diffResource';
+import {selectFromHistory} from '@redux/thunks/selectionHistory';
 import {TOOLTIP_DELAY} from '@constants/constants';
 
 const {TabPane} = Tabs;
@@ -103,11 +104,27 @@ const ActionsPane = (props: {contentHeight: string}) => {
   const [selectedResource, setSelectedResource] = useState<K8sResource>();
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const fileMap = useAppSelector(state => state.main.fileMap);
-  const dispatch = useAppDispatch();
   const kubeconfig = useAppSelector(state => state.config.kubeconfigPath);
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const uiState = useAppSelector(state => state.ui);
+  const currentSelectionHistoryIndex = useAppSelector(state => state.main.currentSelectionHistoryIndex);
+  const selectionHistory = useAppSelector(state => state.main.selectionHistory);
   const [key, setKey] = useState('source');
+  const dispatch = useAppDispatch();
+
+  const isLeftArrowEnabled = selectionHistory.length > 0 && currentSelectionHistoryIndex !== 0;
+  const isRightArrowEnabled =
+    selectionHistory.length > 0 &&
+    currentSelectionHistoryIndex &&
+    currentSelectionHistoryIndex < selectionHistory.length - 2;
+
+  const onClickLeftArrow = () => {
+    dispatch(selectFromHistory({direction: 'left'}));
+  };
+
+  const onClickRightArrow = () => {
+    dispatch(selectFromHistory({direction: 'right'}));
+  };
 
   const applySelectedResource = useCallback(() => {
     if (selectedResource) {
@@ -141,8 +158,20 @@ const ActionsPane = (props: {contentHeight: string}) => {
             <TitleBarContainer>
               <span>Editor</span>
               <RightButtons>
-                <StyledLeftArrowButton type="link" size="small" icon={<ArrowLeftOutlined />} />
-                <StyledRightArrowButton type="link" size="small" icon={<ArrowRightOutlined />} />
+                <StyledLeftArrowButton
+                  onClick={onClickLeftArrow}
+                  disabled={!isLeftArrowEnabled}
+                  type="link"
+                  size="small"
+                  icon={<ArrowLeftOutlined />}
+                />
+                <StyledRightArrowButton
+                  onClick={onClickRightArrow}
+                  disabled={!isRightArrowEnabled}
+                  type="link"
+                  size="small"
+                  icon={<ArrowRightOutlined />}
+                />
 
                 <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ApplyTooltip} placement="bottomLeft">
                   <Button

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -1,7 +1,13 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {Tabs, Col, Row, Button, Skeleton, Modal, Tooltip} from 'antd';
 import styled from 'styled-components';
-import {CodeOutlined, ContainerOutlined, ExclamationCircleOutlined} from '@ant-design/icons';
+import {
+  CodeOutlined,
+  ContainerOutlined,
+  ExclamationCircleOutlined,
+  ArrowLeftOutlined,
+  ArrowRightOutlined,
+} from '@ant-design/icons';
 
 import Monaco from '@molecules/Monaco';
 import FormEditor from '@molecules/FormEditor';
@@ -55,6 +61,14 @@ const StyledSkeleton = styled(Skeleton)`
   margin: 20px;
   padding: 8px;
   width: 95%;
+`;
+
+const StyledLeftArrowButton = styled(Button)`
+  margin-right: 5px;
+`;
+
+const StyledRightArrowButton = styled(Button)`
+  margin-right: 10px;
 `;
 
 export function applyWithConfirm(
@@ -127,6 +141,9 @@ const ActionsPane = (props: {contentHeight: string}) => {
             <TitleBarContainer>
               <span>Editor</span>
               <RightButtons>
+                <StyledLeftArrowButton type="link" size="small" icon={<ArrowLeftOutlined />} />
+                <StyledRightArrowButton type="link" size="small" icon={<ArrowRightOutlined />} />
+
                 <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ApplyTooltip} placement="bottomLeft">
                   <Button
                     loading={Boolean(applyingResource)}

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -56,7 +56,9 @@ const createNode = (fileEntry: FileEntry, fileMap: FileMapType, resourceMap: Res
     title: (
       <NodeContainer>
         <NodeTitleContainer>
-          <span className={fileEntry.isExcluded ? 'excluded-file-entry-name' : 'file-entry-name'}>{fileEntry.name}</span>
+          <span className={fileEntry.isExcluded ? 'excluded-file-entry-name' : 'file-entry-name'}>
+            {fileEntry.name}
+          </span>
           {resources.length > 0 ? (
             <StyledNumberOfResources className="file-entry-nr-of-resources" type="secondary">
               {resources.length}
@@ -343,7 +345,7 @@ const FileTreePane = () => {
         stopPreview(dispatch);
       }
       dispatch(setSelectingFile(true));
-      dispatch(selectFile(info.node.key));
+      dispatch(selectFile({filePath: info.node.key}));
     }
   };
 

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -12,6 +12,8 @@ import {toggleSettings, toggleLeftMenu, toggleRightMenu} from '@redux/reducers/u
 import {startPreview, stopPreview} from '@redux/services/preview';
 import {setRootFolder} from '@redux/thunks/setRootFolder';
 
+import {selectFromHistory} from '@redux/thunks/selectionHistory';
+
 import {makeOnUploadHandler} from '@utils/fileUpload';
 
 const HotKeysHandler = () => {
@@ -68,6 +70,14 @@ const HotKeysHandler = () => {
 
   useHotkeys(hotkeys.TOGGLE_RIGHT_PANE, () => {
     dispatch(toggleRightMenu());
+  });
+
+  useHotkeys(hotkeys.SELECT_FROM_HISTORY_BACK, () => {
+    dispatch(selectFromHistory({direction: 'left'}));
+  });
+
+  useHotkeys(hotkeys.SELECT_FROM_HISTORY_FORWARD, () => {
+    dispatch(selectFromHistory({direction: 'right'}));
   });
 
   return (

--- a/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/KustomizationsSection.tsx
@@ -20,12 +20,12 @@ const KustomizationsSection = (props: KustomizationsSectionProps) => {
   const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
 
   const selectResource = (resourceId: string) => {
-    dispatch(selectK8sResource(resourceId));
+    dispatch(selectK8sResource({resourceId}));
   };
 
   const selectPreview = (id: string) => {
     if (id !== selectedResourceId) {
-      dispatch(selectK8sResource(id));
+      dispatch(selectK8sResource({resourceId: id}));
     }
     if (id !== previewResource) {
       startPreview(id, 'kustomization', dispatch);

--- a/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
+++ b/src/components/organisms/NavigatorPane/components/ResourcesSection.tsx
@@ -45,7 +45,7 @@ const ResourcesSection = () => {
   };
 
   const selectResource = (resourceId: string) => {
-    dispatch(selectK8sResource(resourceId));
+    dispatch(selectK8sResource({resourceId}));
   };
 
   const [expandedSubsectionsBySection, setExpandedSubsectionsBySection] = useState<Record<string, string[]>>(

--- a/src/constants/hotkeys.ts
+++ b/src/constants/hotkeys.ts
@@ -7,6 +7,8 @@ const hotkeys = {
   TOGGLE_LEFT_PANE: 'ctrl+b,command+b',
   TOGGLE_RIGHT_PANE: 'ctrl+alt+b,command+alt+b',
   SAVE: 'ctrl+s,command+s',
+  SELECT_FROM_HISTORY_BACK: 'alt+left',
+  SELECT_FROM_HISTORY_FORWARD: 'alt+right',
 };
 
 export default hotkeys;

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -35,22 +35,36 @@ type PreviewLoaderType = {
   targetResourceId?: string;
 };
 
+type ResourceSelectionHistoryEntry = {
+  type: 'resource';
+  selectedResourceId: string;
+};
+
+type PathSelectionHistoryEntry = {
+  type: 'path';
+  selectedPath: string;
+};
+
+type SelectionHistoryEntry = ResourceSelectionHistoryEntry | PathSelectionHistoryEntry;
+
 interface AppState {
   fileMap: FileMapType; // maps filePath to FileEntry, filePath is relative to selected rootFolder
   resourceMap: ResourceMapType; // maps resource ids to resources
-  selectedResourceId?: string; // the id of the currently selected resource
-  selectedPath?: string; // the currently selected path
-  previewType?: 'kustomization' | 'cluster' | 'helm';
-  previewResourceId?: string; // the resource currently being previewed
-  previewLoader: PreviewLoaderType;
-  diffResourceId?: string; // the resource currently being diffed
-  diffContent?: string; // the diff content for the resource being diffed
   helmChartMap: HelmChartMapType; // maps chart ids to helm charts
   helmValuesMap: HelmValuesMapType; // maps values ids to helm values files
-  selectedValuesFileId?: string; // the currently selected values file
-  previewValuesFileId?: string; // the values file currently being previewed
-  isSelectingFile: boolean; // if we are currently in the process of selecting a file - used for one-time UI updates
   isApplyingResource: boolean; // if we are currently applying a resource - room for improvement...
+  isSelectingFile: boolean; // if we are currently in the process of selecting a file - used for one-time UI updates
+  currentSelectionHistoryIndex?: number; // index of current selection from the history, or undefined if last selection was not virtual
+  selectionHistory: SelectionHistoryEntry[];
+  selectedResourceId?: string; // the id of the currently selected resource
+  selectedPath?: string; // the currently selected path
+  selectedValuesFileId?: string; // the currently selected values file
+  previewType?: 'kustomization' | 'cluster' | 'helm';
+  previewLoader: PreviewLoaderType;
+  previewResourceId?: string; // the resource currently being previewed
+  previewValuesFileId?: string; // the values file currently being previewed
+  diffResourceId?: string; // the resource currently being diffed
+  diffContent?: string; // the diff content for the resource being diffed
 }
 
 export type {AppState, ResourceMapType, FileMapType, HelmChartMapType, HelmValuesMapType, PreviewLoaderType};

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -67,4 +67,12 @@ interface AppState {
   diffContent?: string; // the diff content for the resource being diffed
 }
 
-export type {AppState, ResourceMapType, FileMapType, HelmChartMapType, HelmValuesMapType, PreviewLoaderType};
+export type {
+  AppState,
+  ResourceMapType,
+  FileMapType,
+  HelmChartMapType,
+  HelmValuesMapType,
+  PreviewLoaderType,
+  SelectionHistoryEntry,
+};

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -9,6 +9,7 @@ import {ResourceKindHandlers} from '@src/kindhandlers';
 import {NAV_K8S_RESOURCES_SECTIONS_ORDER} from '@constants/navigator';
 
 const initialAppState: AppState = {
+  selectionHistory: [],
   resourceMap: {},
   fileMap: {},
   helmChartMap: {},

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -226,6 +226,8 @@ export const mainSlice = createSlice({
     clearPreview: (state: Draft<AppState>) => {
       setPreviewData({}, state);
       state.previewType = undefined;
+      state.currentSelectionHistoryIndex = undefined;
+      state.selectionHistory = [];
     },
     startPreviewLoader: (state: Draft<AppState>, action: PayloadAction<StartPreviewLoaderPayload>) => {
       state.previewLoader.isLoading = true;
@@ -243,6 +245,8 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
+        state.currentSelectionHistoryIndex = undefined;
+        state.selectionHistory = [];
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -255,6 +259,8 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
+        state.currentSelectionHistoryIndex = undefined;
+        state.selectionHistory = [];
       })
       .addCase(previewHelmValuesFile.rejected, (state, action) => {
         state.previewLoader.isLoading = false;
@@ -267,6 +273,8 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
+        state.currentSelectionHistoryIndex = undefined;
+        state.selectionHistory = [];
       })
       .addCase(previewCluster.rejected, state => {
         state.previewLoader.isLoading = false;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -246,7 +246,16 @@ export const mainSlice = createSlice({
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
         state.currentSelectionHistoryIndex = undefined;
-        state.selectionHistory = [];
+        if (state.previewResourceId) {
+          state.selectionHistory = [
+            {
+              type: 'resource',
+              selectedResourceId: state.previewResourceId,
+            },
+          ];
+        } else {
+          state.selectionHistory = [];
+        }
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -260,7 +269,6 @@ export const mainSlice = createSlice({
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
         state.currentSelectionHistoryIndex = undefined;
-        state.selectionHistory = [];
       })
       .addCase(previewHelmValuesFile.rejected, (state, action) => {
         state.previewLoader.isLoading = false;
@@ -274,7 +282,16 @@ export const mainSlice = createSlice({
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
         state.currentSelectionHistoryIndex = undefined;
-        state.selectionHistory = [];
+        if (state.previewResourceId) {
+          state.selectionHistory = [
+            {
+              type: 'resource',
+              selectedResourceId: state.previewResourceId,
+            },
+          ];
+        } else {
+          state.selectionHistory = [];
+        }
       })
       .addCase(previewCluster.rejected, state => {
         state.previewLoader.isLoading = false;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -12,6 +12,7 @@ import {setRootFolder} from '@redux/thunks/setRootFolder';
 import {performResourceDiff} from '@redux/thunks/diffResource';
 import {previewHelmValuesFile} from '@redux/thunks/previewHelmValuesFile';
 import {selectFromHistory} from '@redux/thunks/selectionHistory';
+import {resetSelectionHistory} from '@redux/services/selectionHistory';
 import {AlertType} from '@models/alert';
 import initialState from '../initialState';
 import {clearResourceSelections, highlightChildrenResources, updateSelectionAndHighlights} from '../services/selection';
@@ -245,17 +246,7 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
-        state.currentSelectionHistoryIndex = undefined;
-        if (state.previewResourceId) {
-          state.selectionHistory = [
-            {
-              type: 'resource',
-              selectedResourceId: state.previewResourceId,
-            },
-          ];
-        } else {
-          state.selectionHistory = [];
-        }
+        resetSelectionHistory(state, {initialResources: [state.previewResourceId]});
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -269,6 +260,7 @@ export const mainSlice = createSlice({
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
         state.currentSelectionHistoryIndex = undefined;
+        resetSelectionHistory(state);
       })
       .addCase(previewHelmValuesFile.rejected, (state, action) => {
         state.previewLoader.isLoading = false;
@@ -281,17 +273,7 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
-        state.currentSelectionHistoryIndex = undefined;
-        if (state.previewResourceId) {
-          state.selectionHistory = [
-            {
-              type: 'resource',
-              selectedResourceId: state.previewResourceId,
-            },
-          ];
-        } else {
-          state.selectionHistory = [];
-        }
+        resetSelectionHistory(state, {initialResources: [state.previewResourceId]});
       })
       .addCase(previewCluster.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -310,8 +292,7 @@ export const mainSlice = createSlice({
       state.selectedPath = undefined;
       state.previewResourceId = undefined;
       state.previewType = undefined;
-      state.currentSelectionHistoryIndex = undefined;
-      state.selectionHistory = [];
+      resetSelectionHistory(state);
     });
 
     builder.addCase(performResourceDiff.fulfilled, (state, action) => {

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -246,7 +246,7 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
-        resetSelectionHistory(state, {initialResources: [state.previewResourceId]});
+        resetSelectionHistory(state, {initialResourceIds: [state.previewResourceId]});
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -273,7 +273,7 @@ export const mainSlice = createSlice({
         setPreviewData(action.payload, state);
         state.previewLoader.isLoading = false;
         state.previewLoader.targetResourceId = undefined;
-        resetSelectionHistory(state, {initialResources: [state.previewResourceId]});
+        resetSelectionHistory(state, {initialResourceIds: [state.previewResourceId]});
       })
       .addCase(previewCluster.rejected, state => {
         state.previewLoader.isLoading = false;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -285,6 +285,8 @@ export const mainSlice = createSlice({
       state.selectedPath = undefined;
       state.previewResourceId = undefined;
       state.previewType = undefined;
+      state.currentSelectionHistoryIndex = undefined;
+      state.selectionHistory = [];
     });
 
     builder.addCase(performResourceDiff.fulfilled, (state, action) => {

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -303,7 +303,8 @@ export const mainSlice = createSlice({
     });
 
     builder.addCase(selectFromHistory.fulfilled, (state, action) => {
-      state.currentSelectionHistoryIndex = action.payload;
+      state.currentSelectionHistoryIndex = action.payload.nextSelectionHistoryIndex;
+      state.selectionHistory = action.payload.newSelectionHistory;
     });
   },
 });

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -62,7 +62,6 @@ export type StartPreviewLoaderPayload = {
 
 function updateSelectionHistory(type: 'resource' | 'path', isVirtualSelection: boolean, state: AppState) {
   if (isVirtualSelection) {
-    state.currentSelectionHistoryIndex = undefined;
     return;
   }
   if (type === 'resource' && state.selectedResourceId) {
@@ -77,6 +76,7 @@ function updateSelectionHistory(type: 'resource' | 'path', isVirtualSelection: b
       selectedPath: state.selectedPath,
     });
   }
+  state.currentSelectionHistoryIndex = undefined;
 }
 
 export const mainSlice = createSlice({

--- a/src/redux/services/selectionHistory.ts
+++ b/src/redux/services/selectionHistory.ts
@@ -1,0 +1,25 @@
+import {SelectionHistoryEntry, AppState} from '@models/appstate';
+
+type resetSelectionHistoryOptions = {
+  initialPaths?: (string | undefined)[];
+  initialResources?: (string | undefined)[];
+  initialEntries?: SelectionHistoryEntry[];
+};
+
+export function resetSelectionHistory(state: AppState, options?: resetSelectionHistoryOptions) {
+  state.currentSelectionHistoryIndex = undefined;
+  if (!options) {
+    return;
+  }
+  const newSelectionHistory = [];
+  if (options.initialEntries) {
+    newSelectionHistory.push(...options.initialEntries);
+  }
+  if (options.initialPaths) {
+    newSelectionHistory.push(...options.initialPaths.filter(path => path !== undefined));
+  }
+  if (options.initialResources) {
+    newSelectionHistory.push(...options.initialResources.filter(res => res !== undefined));
+  }
+  return newSelectionHistory;
+}

--- a/src/redux/services/selectionHistory.ts
+++ b/src/redux/services/selectionHistory.ts
@@ -2,7 +2,7 @@ import {SelectionHistoryEntry, AppState} from '@models/appstate';
 
 type resetSelectionHistoryOptions = {
   initialPaths?: (string | undefined)[];
-  initialResources?: (string | undefined)[];
+  initialResourceIds?: (string | undefined)[];
   initialEntries?: SelectionHistoryEntry[];
 };
 
@@ -11,15 +11,29 @@ export function resetSelectionHistory(state: AppState, options?: resetSelectionH
   if (!options) {
     return;
   }
-  const newSelectionHistory = [];
+  const newSelectionHistory: SelectionHistoryEntry[] = [];
   if (options.initialEntries) {
     newSelectionHistory.push(...options.initialEntries);
   }
   if (options.initialPaths) {
-    newSelectionHistory.push(...options.initialPaths.filter(path => path !== undefined));
+    options.initialPaths.forEach(path => {
+      if (path !== undefined) {
+        newSelectionHistory.push({
+          type: 'path',
+          selectedPath: path,
+        });
+      }
+    });
   }
-  if (options.initialResources) {
-    newSelectionHistory.push(...options.initialResources.filter(res => res !== undefined));
+  if (options.initialResourceIds) {
+    options.initialResourceIds.forEach(resourceId => {
+      if (resourceId !== undefined) {
+        newSelectionHistory.push({
+          type: 'resource',
+          selectedResourceId: resourceId,
+        });
+      }
+    });
   }
-  return newSelectionHistory;
+  state.selectionHistory = newSelectionHistory;
 }

--- a/src/redux/thunks/selectionHistory.ts
+++ b/src/redux/thunks/selectionHistory.ts
@@ -17,14 +17,6 @@ export const selectFromHistory = createAsyncThunk<
   let currentSelectionHistoryIndex = mainState.currentSelectionHistoryIndex;
   const selectionHistory = mainState.selectionHistory;
 
-  const canNavigateLeft =
-    selectionHistory.length > 1 &&
-    (currentSelectionHistoryIndex === undefined || (currentSelectionHistoryIndex && currentSelectionHistoryIndex > 0));
-  const canNavigateRight =
-    selectionHistory.length > 1 &&
-    currentSelectionHistoryIndex !== undefined &&
-    currentSelectionHistoryIndex < selectionHistory.length - 1;
-
   let removedSelectionHistoryEntriesCount = 0;
   const newSelectionHistory = selectionHistory.filter(historyEntry => {
     if (historyEntry.type === 'resource') {
@@ -47,6 +39,14 @@ export const selectFromHistory = createAsyncThunk<
   ) {
     currentSelectionHistoryIndex -= removedSelectionHistoryEntriesCount;
   }
+
+  const canNavigateLeft =
+    selectionHistory.length > 1 &&
+    (currentSelectionHistoryIndex === undefined || (currentSelectionHistoryIndex && currentSelectionHistoryIndex > 0));
+  const canNavigateRight =
+    selectionHistory.length > 1 &&
+    currentSelectionHistoryIndex !== undefined &&
+    currentSelectionHistoryIndex < selectionHistory.length - 1;
 
   if (
     newSelectionHistory.length === 0 ||

--- a/src/redux/thunks/selectionHistory.ts
+++ b/src/redux/thunks/selectionHistory.ts
@@ -1,0 +1,50 @@
+import {selectFile, selectK8sResource} from '@redux/reducers/main';
+import {AppDispatch, RootState} from '@redux/store';
+import {createAsyncThunk} from '@reduxjs/toolkit';
+
+export const selectFromHistory = createAsyncThunk<
+  number | undefined,
+  {direction: 'left' | 'right'},
+  {dispatch: AppDispatch; state: RootState}
+>('main/selectFromHistory', async (payload, thunkAPI) => {
+  const mainState = thunkAPI.getState().main;
+  const direction = payload.direction;
+  const currentSelectionHistoryIndex = mainState.currentSelectionHistoryIndex;
+  const selectionHistory = mainState.selectionHistory;
+
+  if (selectionHistory.length === 0) {
+    return;
+  }
+
+  let nextSelectionHistoryIndex: number | null = null;
+
+  if (direction === 'left') {
+    if (currentSelectionHistoryIndex === 0) {
+      return;
+    }
+    nextSelectionHistoryIndex = currentSelectionHistoryIndex
+      ? currentSelectionHistoryIndex - 1
+      : selectionHistory.length - 2;
+  } else if (direction === 'right') {
+    if (!currentSelectionHistoryIndex || currentSelectionHistoryIndex === selectionHistory.length - 1) {
+      return;
+    }
+    nextSelectionHistoryIndex = currentSelectionHistoryIndex + 1;
+  }
+
+  if (!nextSelectionHistoryIndex) {
+    return;
+  }
+
+  const selectionHistoryEntry = selectionHistory[nextSelectionHistoryIndex];
+  if (selectionHistoryEntry.type === 'resource') {
+    thunkAPI.dispatch(
+      selectK8sResource({resourceId: selectionHistoryEntry.selectedResourceId, isVirtualSelection: true})
+    );
+  }
+  if (selectionHistoryEntry.type === 'path') {
+    thunkAPI.dispatch(selectFile({filePath: selectionHistoryEntry.selectedPath, isVirtualSelection: true}));
+  }
+
+  return nextSelectionHistoryIndex;
+});

--- a/src/redux/thunks/selectionHistory.ts
+++ b/src/redux/thunks/selectionHistory.ts
@@ -22,17 +22,16 @@ export const selectFromHistory = createAsyncThunk<
     if (currentSelectionHistoryIndex === 0) {
       return;
     }
-    nextSelectionHistoryIndex = currentSelectionHistoryIndex
-      ? currentSelectionHistoryIndex - 1
-      : selectionHistory.length - 2;
+    nextSelectionHistoryIndex =
+      currentSelectionHistoryIndex !== undefined ? currentSelectionHistoryIndex - 1 : selectionHistory.length - 2;
   } else if (direction === 'right') {
-    if (!currentSelectionHistoryIndex || currentSelectionHistoryIndex === selectionHistory.length - 1) {
+    if (currentSelectionHistoryIndex === undefined || currentSelectionHistoryIndex === selectionHistory.length - 1) {
       return;
     }
     nextSelectionHistoryIndex = currentSelectionHistoryIndex + 1;
   }
 
-  if (!nextSelectionHistoryIndex) {
+  if (nextSelectionHistoryIndex === null) {
     return;
   }
 


### PR DESCRIPTION
This PR...

## Changes

- implemented logic to allow user to navigate through the history of selections
- added left and right arrows to the Editor's title bar
- added both global and monaco hotkeys for navigation (ALT+ArrowLeft and ALT+ArrowRight)

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
