### PR TITLE
feat: save and display target resource kind for unsatisfied refs

### DIFF
--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -109,7 +109,9 @@ const RefLink = (props: {resourceRef: ResourceRef; resourceMap: ResourceMapType;
 
   let linkText = targetName;
 
-  if (resourceRef.targetResourceId) {
+  if (resourceRef.targetResourceKind) {
+    linkText = `${resourceRef.targetResourceKind}: ${targetName}`;
+  } else if (resourceRef.targetResourceId) {
     const resourceKind = resourceMap[resourceRef.targetResourceId].kind;
     linkText = `${resourceKind}: ${targetName}`;
   }
@@ -121,7 +123,7 @@ const RefLink = (props: {resourceRef: ResourceRef; resourceMap: ResourceMapType;
     return <IncomingRefLink onClick={onClick} text={linkText} />;
   }
   if (isUnsatisfiedRef(resourceRef.type)) {
-    return <UnsatisfiedRefLink text={targetName} />;
+    return <UnsatisfiedRefLink text={linkText} />;
   }
 
   return null;
@@ -147,10 +149,22 @@ const PopoverContent = (props: {
       <StyledDivider />
       {resourceRefs
         .sort((a, b) => {
-          if (a.targetResourceId && b.targetResourceId) {
-            const resourceA = resourceMap[a.targetResourceId];
-            const resourceB = resourceMap[b.targetResourceId];
-            return resourceA.kind.localeCompare(resourceB.kind);
+          let kindA;
+          let kindB;
+          if (a.targetResourceKind) {
+            kindA = a.targetResourceKind;
+          } else if (a.targetResourceId) {
+            const targetResourceA = resourceMap[a.targetResourceId];
+            kindA = targetResourceA?.kind;
+          }
+          if (b.targetResourceKind) {
+            kindB = b.targetResourceKind;
+          } else if (b.targetResourceId) {
+            const targetResourceB = resourceMap[b.targetResourceId];
+            kindB = targetResourceB?.kind;
+          }
+          if (kindA && kindB) {
+            return kindA.localeCompare(kindB);
           }
           return 0;
         })

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -38,6 +38,7 @@ interface ResourceRef {
   type: ResourceRefType; // the type of ref (see enum)
   name: string; // the ref value - for example the name of a configmap
   targetResourceId?: string; // the resource this is referring to (empty for unsatisfied refs)
+  targetResourceKind?: string; // the resource kind of the target resource
   position?: RefPosition; // the position in the document of the refName (undefined for incoming file refs)
 }
 

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -134,7 +134,8 @@ export function createResourceRef(
   resource: K8sResource,
   refType: ResourceRefType,
   refNode?: NodeWrapper,
-  targetResourceId?: string
+  targetResourceId?: string,
+  targetResourceKind?: string
 ) {
   if (refNode || targetResourceId) {
     resource.refs = resource.refs || [];
@@ -151,6 +152,7 @@ export function createResourceRef(
         name: refName,
         position: refNode?.getNodePosition(),
         targetResourceId,
+        targetResourceKind,
       });
     }
   } else {
@@ -168,8 +170,8 @@ export function linkResources(
   sourceRef: NodeWrapper,
   targetRef?: NodeWrapper
 ) {
-  createResourceRef(source, ResourceRefType.Outgoing, sourceRef, target.id);
-  createResourceRef(target, ResourceRefType.Incoming, targetRef, source.id);
+  createResourceRef(source, ResourceRefType.Outgoing, sourceRef, target.id, target.kind);
+  createResourceRef(target, ResourceRefType.Incoming, targetRef, source.id, source.kind);
 }
 
 /**

--- a/src/redux/services/resourceRefs.ts
+++ b/src/redux/services/resourceRefs.ts
@@ -139,7 +139,9 @@ function handleRefMappingByParentKey(
       createResourceRef(
         sourceResource,
         ResourceRefType.Unsatisfied,
-        new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter)
+        new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter),
+        undefined,
+        outgoingRefMapper.target.kind
       );
     });
   } else {
@@ -177,7 +179,9 @@ function handleRefMappingByParentKey(
         createResourceRef(
           sourceResource,
           ResourceRefType.Unsatisfied,
-          new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter)
+          new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter),
+          undefined,
+          outgoingRefMapper.target.kind
         );
       }
     });
@@ -203,7 +207,9 @@ function handleRefMappingByKey(
     createResourceRef(
       sourceResource,
       ResourceRefType.Unsatisfied,
-      new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter)
+      new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter),
+      undefined,
+      outgoingRefMapper.target.kind
     );
   } else {
     let hasSatisfiedRefs = false;
@@ -229,7 +235,9 @@ function handleRefMappingByKey(
       createResourceRef(
         sourceResource,
         ResourceRefType.Unsatisfied,
-        new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter)
+        new NodeWrapper(sourceRefNode.scalar, sourceResource.lineCounter),
+        undefined,
+        outgoingRefMapper.target.kind
       );
     }
   }


### PR DESCRIPTION
This PR...

## Changes

- saves target resource kind on ResourceRef
- displays the target resource kind on NavigatorRowLabel

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
