### PR TITLE
Catalinhoha/feature/resource validation

### DIFF
--- a/src/components/atoms/MonoIcon/MonoIcon.tsx
+++ b/src/components/atoms/MonoIcon/MonoIcon.tsx
@@ -1,25 +1,25 @@
 import React from 'react';
-import styled from 'styled-components';
 import MonokleIncomingRefs from '@assets/MonokleIncomingRefs.svg';
 import MonokleOutgoingRefs from '@assets/MonokleOutgoingRefs.svg';
 import MonokleWarning from '@assets/MonokleWarning.svg';
+import {ExclamationCircleOutlined} from '@ant-design/icons';
 
 export enum MonoIconTypes {
   IncomingRefs,
   OutgoingRefs,
   Warning,
+  Error,
 }
 
 export type MonoIconProps = {
   type: MonoIconTypes;
-  marginRight?: number;
-  marginLeft?: number;
+  style?: React.CSSProperties;
 };
 
-const StyledImage = styled.img`
-  display: inline-block;
-  height: 12px;
-`;
+const defaultStyle: React.CSSProperties = {
+  display: 'inline-block',
+  height: '12px',
+};
 
 const getIconSvg = (type: MonoIconTypes) => {
   switch (type) {
@@ -33,20 +33,39 @@ const getIconSvg = (type: MonoIconTypes) => {
       return MonokleWarning;
 
     default:
-      return null;
+      return undefined;
+  }
+};
+
+const createImageComponent = (type: MonoIconTypes, style?: React.CSSProperties) => {
+  const iconSvg = getIconSvg(type);
+  if (!iconSvg) {
+    return null;
+  }
+
+  return <img src={iconSvg} style={style} />;
+};
+
+const getIconComponent = (type: MonoIconTypes, style?: React.CSSProperties) => {
+  switch (type) {
+    case MonoIconTypes.Error: {
+      return <ExclamationCircleOutlined style={style} />;
+    }
+    default:
+      return createImageComponent(type, style);
   }
 };
 
 const MonoIcon = (props: MonoIconProps) => {
-  const {type, marginRight, marginLeft} = props;
+  const {type, style} = props;
 
-  const iconSvg = getIconSvg(type);
+  const fullStyle = {
+    ...defaultStyle,
+    ...style,
+  };
 
-  if (iconSvg) {
-    return <StyledImage src={iconSvg} style={{marginRight, marginLeft}} alt={MonoIconTypes[type]} />;
-  }
-
-  return null;
+  const IconComponent = getIconComponent(type, fullStyle);
+  return IconComponent;
 };
 
 export default MonoIcon;

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -56,6 +56,16 @@ const StyledRefText = styled(Text)`
   }
 `;
 
+const StyledLabelContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIconsContainer = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
 const StyledSpan = styled.span<{isSelected: boolean; isHighlighted: boolean}>`
   cursor: pointer;
   ${props => {
@@ -73,7 +83,7 @@ const OutgoingRefLink = (props: RefLinkProps) => {
   const {text, onClick} = props;
   return (
     <div onClick={onClick}>
-      <MonoIcon type={MonoIconTypes.OutgoingRefs} marginRight={5} />
+      <MonoIcon type={MonoIconTypes.OutgoingRefs} style={{marginRight: 5}} />
       <StyledRefText>{text}</StyledRefText>
     </div>
   );
@@ -83,7 +93,7 @@ const IncomingRefLink = (props: RefLinkProps) => {
   const {text, onClick} = props;
   return (
     <div onClick={onClick}>
-      <MonoIcon type={MonoIconTypes.IncomingRefs} marginRight={5} />
+      <MonoIcon type={MonoIconTypes.IncomingRefs} style={{marginRight: 5}} />
       <StyledRefText>{text}</StyledRefText>
     </div>
   );
@@ -93,7 +103,7 @@ const UnsatisfiedRefLink = (props: {text: string}) => {
   const {text} = props;
   return (
     <div>
-      <MonoIcon type={MonoIconTypes.Warning} marginRight={5} />
+      <MonoIcon type={MonoIconTypes.Warning} style={{marginRight: 5}} />
       <StyledUnsatisfiedRefText>{text}</StyledUnsatisfiedRefText>
     </div>
   );
@@ -229,8 +239,12 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
     dispatch(selectK8sResource({resourceId: resId}));
   };
 
+  if (!resource) {
+    return null;
+  }
+
   return (
-    <>
+    <StyledLabelContainer>
       {resource && resource.refs && hasIncomingRefs && (
         <Popover
           mouseEnterDelay={0.5}
@@ -245,9 +259,9 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
             </PopoverContent>
           }
         >
-          <span>
-            <MonoIcon type={MonoIconTypes.IncomingRefs} marginRight={5} />
-          </span>
+          <StyledIconsContainer>
+            <MonoIcon type={MonoIconTypes.IncomingRefs} style={{marginRight: 5}} />
+          </StyledIconsContainer>
         </Popover>
       )}
       <StyledSpan
@@ -274,13 +288,16 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
             </PopoverContent>
           }
         >
-          <span>
-            <MonoIcon type={MonoIconTypes.OutgoingRefs} marginLeft={5} />
-            {hasUnsatisfiedRefs && <MonoIcon type={MonoIconTypes.Warning} marginLeft={5} />}
-          </span>
+          <StyledIconsContainer>
+            <MonoIcon type={MonoIconTypes.OutgoingRefs} style={{marginLeft: 5}} />
+            {hasUnsatisfiedRefs && <MonoIcon type={MonoIconTypes.Warning} style={{marginLeft: 5}} />}
+          </StyledIconsContainer>
         </Popover>
       )}
-    </>
+      {resource && resource.validation && !resource.validation.isValid && (
+        <MonoIcon type={MonoIconTypes.Error} style={{marginLeft: 5, color: Colors.redError}} />
+      )}
+    </StyledLabelContainer>
   );
 };
 

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -5,6 +5,16 @@ import {Document, LineCounter, ParsedNode, Scalar} from 'yaml';
 
 export type RefNode = {scalar: Scalar; key: string; parentKeyPath: string};
 
+type ResourceValidationError = {
+  property: string;
+  message: string;
+};
+
+type ResourceValidation = {
+  isValid: boolean;
+  errors: ResourceValidationError[];
+};
+
 interface K8sResource {
   id: string; // an internally generated UUID - used for references/lookups in resourceMap
   filePath: string; // the path relative to the root folder to the file containing this resource - set to preview://<id> for internally generated resources
@@ -22,7 +32,7 @@ interface K8sResource {
     start: number;
     length: number;
   };
-
+  validation?: ResourceValidation;
   parsedDoc?: Document.Parsed<ParsedNode>; // temporary object used for parsing refs
   lineCounter?: LineCounter; // temporary object used for ref positioning
   refNodeByPath?: Record<string, RefNode>; // temporary object used for parsing refs
@@ -47,4 +57,4 @@ interface RefPosition {
   length: number;
 }
 
-export type {K8sResource, ResourceRef, RefPosition};
+export type {K8sResource, ResourceRef, RefPosition, ResourceValidation, ResourceValidationError};

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -10,6 +10,7 @@ import log from 'loglevel';
 import {isUnsatisfiedRef} from '@redux/services/resourceRefs';
 import {getDependentResourceKinds} from '@src/kindhandlers';
 import {v4 as uuidv4} from 'uuid';
+import {validateResource} from './validation';
 import {processRefs} from './resourceRefs';
 
 /**
@@ -340,6 +341,15 @@ export function processParsedResources(
   resourceMap: ResourceMapType,
   options?: {resourceIds?: string[]; resourceKinds?: string[]}
 ) {
+  if (options && options.resourceIds && options.resourceIds.length > 0) {
+    Object.values(resourceMap)
+      .filter(r => options.resourceIds?.includes(r.id))
+      .forEach(resource => validateResource(resource));
+  } else {
+    Object.values(resourceMap).forEach(resource => {
+      validateResource(resource);
+    });
+  }
   processRefs(resourceMap, options);
   clearResourcesTemporaryObjects(resourceMap);
 }

--- a/src/redux/services/validation.ts
+++ b/src/redux/services/validation.ts
@@ -1,0 +1,18 @@
+import {validate} from 'json-schema';
+import {K8sResource} from '@models/k8sresource';
+import {getResourceSchema} from './schema';
+
+export function validateResource(resource: K8sResource) {
+  const resourceSchema = getResourceSchema(resource);
+  if (!resourceSchema) {
+    return;
+  }
+  const validationResult = validate(resource.content, resourceSchema);
+  resource.validation = {
+    isValid: validationResult.valid,
+    errors: validationResult.errors.map(err => ({
+      property: err.property,
+      message: err.message,
+    })),
+  };
+}


### PR DESCRIPTION
This PR...

## Changes

- add functionality to validate resources on each (re)processing and saves the result on the resource objects
- display error icon on the rows of invalid resources
- TODO: show popup with the errors when icon is hovered 

## Fixes

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
