### PR TITLE
fix: disable new-resource in cluster/preview modes, added <none> opti…

### DIFF
--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -7,6 +7,7 @@ import {
   helmChartsSelector,
   helmValuesSelector,
   kustomizationsSelector,
+  isInPreviewModeSelector,
 } from '@redux/selectors';
 
 import {HelmValuesFile} from '@models/helm';
@@ -148,6 +149,7 @@ const NavigatorPane = () => {
   const helmValues = useSelector(helmValuesSelector);
   const kustomizations = useSelector(kustomizationsSelector);
   const isInClusterMode = useSelector(isInClusterModeSelector);
+  const isInPreviewMode = useSelector(isInPreviewModeSelector);
 
   const [isValidationsErrorsModalVisible, setValidationsErrorsVisible] = useState<boolean>(false);
   const [currentValidationErrors, setCurrentValidationErrors] = useState<ResourceValidationError[]>([]);
@@ -205,7 +207,7 @@ const NavigatorPane = () => {
               <span>Navigator</span>
               <RightButtons>
                 <StyledPlusButton
-                  disabled={!doesRootFileEntryExist()}
+                  disabled={!doesRootFileEntryExist() || isInClusterMode || isInPreviewMode}
                   onClick={onClickNewResource}
                   type="link"
                   size="small"

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -8,6 +8,7 @@ import {createUnsavedResource} from '@redux/services/unsavedResource';
 import {ResourceKindHandlers, getResourceKindHandler} from '@src/kindhandlers';
 import {getNamespaces} from '@redux/services/resource';
 
+const NO_NAMESPACE = '<none>';
 const NewResourceWizard = () => {
   const dispatch = useAppDispatch();
   const isNewResourceWizardOpen = useAppSelector(state => state.ui.isNewResourceWizardOpen);
@@ -15,7 +16,7 @@ const NewResourceWizard = () => {
   const [namespaces, setNamespaces] = useState<string[]>([]);
 
   useEffect(() => {
-    setNamespaces([...new Set(['default', ...getNamespaces(resourceMap)])]);
+    setNamespaces([...new Set([NO_NAMESPACE, 'default', ...getNamespaces(resourceMap)])]);
   }, [resourceMap]);
 
   const [form] = Form.useForm();
@@ -53,7 +54,7 @@ const NewResourceWizard = () => {
       {
         name: data.name,
         kind: data.kind,
-        namespace: data.namespace,
+        namespace: data.namespace === NO_NAMESPACE ? undefined : data.namespace,
         apiVersion: data.apiVersion,
       },
       dispatch
@@ -94,7 +95,7 @@ const NewResourceWizard = () => {
           name="namespace"
           label="Namespace"
           tooltip={{title: 'Select the namespace', icon: <InfoCircleOutlined />}}
-          initialValue="default"
+          initialValue={NO_NAMESPACE}
         >
           <Select>
             {namespaces.map(namespace => (

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -22,8 +22,6 @@ export function createUnsavedResource(
   input: {name: string; kind: string; apiVersion: string; namespace?: string},
   dispatch: AppDispatch
 ) {
-  console.log(input);
-
   // TODO: add logic to use a resource template
   const newResourceId = uuidv4();
   const newResourceText = createDefaultResourceText(input);

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -11,7 +11,7 @@ apiVersion: ${input.apiVersion ? input.apiVersion : 'apps/v1'}
 kind: ${input.kind}
 metadata:
   name: ${input.name}
-  namespace: ${input.namespace ? input.namespace : 'default'}
+  ${input.namespace ? `namespace: ${input.namespace}` : ''}
   `.trim();
 }
 
@@ -22,6 +22,8 @@ export function createUnsavedResource(
   input: {name: string; kind: string; apiVersion: string; namespace?: string},
   dispatch: AppDispatch
 ) {
+  console.log(input);
+
   // TODO: add logic to use a resource template
   const newResourceId = uuidv4();
   const newResourceText = createDefaultResourceText(input);


### PR DESCRIPTION
…on to namespace

This PR...

## Changes

- disables new-resource in cluster/preview modes
- adds a <none> option to the namespace field when creating new resources

## Fixes

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
