### PR TITLE
feat: add validationSchemaPrefix to all kind handlers

### DIFF
--- a/src/components/molecules/ValidationErrorsModal/ValidationErrorsModal.tsx
+++ b/src/components/molecules/ValidationErrorsModal/ValidationErrorsModal.tsx
@@ -38,7 +38,7 @@ const ValidationErrorsModal = (props: {errors: ResourceValidationError[]; isVisi
         <StyledErrorList>
           {errors.map(error => {
             return (
-              <li>
+              <li key={`${error.property}:${error.message}`}>
                 <StyledErrorProperty>{error.property}</StyledErrorProperty>
                 <StyledErrorMessage>{error.message}</StyledErrorMessage>
               </li>

--- a/src/kindhandlers/ClusterRole.handler.ts
+++ b/src/kindhandlers/ClusterRole.handler.ts
@@ -7,6 +7,7 @@ const ClusterRoleHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_ACCESS_CONTROL, 'ClusterRoles'],
   clusterApiVersion: 'rbac.authorization.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.rbac.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.RbacAuthorizationV1Api);

--- a/src/kindhandlers/ClusterRoleBinding.handler.ts
+++ b/src/kindhandlers/ClusterRoleBinding.handler.ts
@@ -7,6 +7,7 @@ const ClusterRoleBindingHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_ACCESS_CONTROL, 'ClusterRoleBindings'],
   clusterApiVersion: 'rbac.authorization.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.rbac.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.RbacAuthorizationV1Api);

--- a/src/kindhandlers/ConfigMap.handler.ts
+++ b/src/kindhandlers/ConfigMap.handler.ts
@@ -7,6 +7,7 @@ const ConfigMapHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_CONFIGURATION, 'ConfigMaps'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/CronJob.handler.ts
+++ b/src/kindhandlers/CronJob.handler.ts
@@ -8,6 +8,7 @@ const CronJobHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'CronJobs'],
   clusterApiVersion: 'batch/v1',
+  validationSchemaPrefix: 'io.k8s.api.batch.v2alpha1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.BatchV1Api);

--- a/src/kindhandlers/CustomResourceDefinition.handler.ts
+++ b/src/kindhandlers/CustomResourceDefinition.handler.ts
@@ -7,6 +7,7 @@ const CustomResourceDefinitionHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_CUSTOM_RESOURCES, 'Custom Resources'],
   clusterApiVersion: 'apiextensions.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.ApiextensionsV1Api);

--- a/src/kindhandlers/DaemonSet.handler.ts
+++ b/src/kindhandlers/DaemonSet.handler.ts
@@ -8,6 +8,7 @@ const DaemonSetHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'DaemonSets'],
   clusterApiVersion: 'apps/v1',
+  validationSchemaPrefix: 'io.k8s.api.apps.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.AppsV1Api);

--- a/src/kindhandlers/Deployment.handler.ts
+++ b/src/kindhandlers/Deployment.handler.ts
@@ -8,6 +8,7 @@ const DeploymentHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'Deployments'],
   clusterApiVersion: 'apps/v1',
+  validationSchemaPrefix: 'io.k8s.api.apps.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.AppsV1Api);

--- a/src/kindhandlers/Endpoint.handler.ts
+++ b/src/kindhandlers/Endpoint.handler.ts
@@ -7,6 +7,7 @@ const EndpointHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_NETWORK, 'Endpoints'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/Ingress.handler.ts
+++ b/src/kindhandlers/Ingress.handler.ts
@@ -7,6 +7,7 @@ const IngressHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_NETWORK, 'Ingresses'],
   clusterApiVersion: 'networking.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.networking.v1beta1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.NetworkingV1Api);

--- a/src/kindhandlers/Job.handler.ts
+++ b/src/kindhandlers/Job.handler.ts
@@ -8,6 +8,7 @@ const JobHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'Jobs'],
   clusterApiVersion: 'batch/v1',
+  validationSchemaPrefix: 'io.k8s.api.batch.v2alpha1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.BatchV1Api);

--- a/src/kindhandlers/NetworkPolicy.handler.ts
+++ b/src/kindhandlers/NetworkPolicy.handler.ts
@@ -7,6 +7,7 @@ const NetworkPolicyHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_NETWORK, 'NetworkPolicies'],
   clusterApiVersion: 'networking.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.networking.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.NetworkingV1Api);

--- a/src/kindhandlers/PersistentVolume.handler.ts
+++ b/src/kindhandlers/PersistentVolume.handler.ts
@@ -7,6 +7,7 @@ const PersistentVolumeHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_STORAGE, 'PersistentVolumes'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/PersistentVolumeClaim.handler.ts
+++ b/src/kindhandlers/PersistentVolumeClaim.handler.ts
@@ -7,6 +7,7 @@ const PersistentVolumeClaimHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_STORAGE, 'PersistentVolumeClaims'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/Pod.handler.ts
+++ b/src/kindhandlers/Pod.handler.ts
@@ -8,6 +8,7 @@ const PodHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'Pods'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/ReplicaSet.handler.ts
+++ b/src/kindhandlers/ReplicaSet.handler.ts
@@ -8,6 +8,7 @@ const ReplicaSetHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'ReplicaSets'],
   clusterApiVersion: 'apps/v1',
+  validationSchemaPrefix: 'io.k8s.api.apps.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.AppsV1Api);

--- a/src/kindhandlers/ReplicationController.handler.ts
+++ b/src/kindhandlers/ReplicationController.handler.ts
@@ -8,6 +8,7 @@ const ReplicationControllerHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'ReplicationControllers'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/Role.handler.ts
+++ b/src/kindhandlers/Role.handler.ts
@@ -7,6 +7,7 @@ const RoleHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_ACCESS_CONTROL, 'Roles'],
   clusterApiVersion: 'rbac.authorization.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.rbac.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.RbacAuthorizationV1Api);

--- a/src/kindhandlers/RoleBinding.handler.ts
+++ b/src/kindhandlers/RoleBinding.handler.ts
@@ -7,6 +7,7 @@ const RoleBindingHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_ACCESS_CONTROL, 'RoleBindings'],
   clusterApiVersion: 'rbac.authorization.k8s.io/v1',
+  validationSchemaPrefix: 'io.k8s.api.rbac.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.RbacAuthorizationV1Api);

--- a/src/kindhandlers/Secret.handler.ts
+++ b/src/kindhandlers/Secret.handler.ts
@@ -7,6 +7,7 @@ const SecretHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_CONFIGURATION, 'Secrets'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/Service.handler.ts
+++ b/src/kindhandlers/Service.handler.ts
@@ -7,6 +7,7 @@ const ServiceHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_NETWORK, 'Services'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/ServiceAccount.handler.ts
+++ b/src/kindhandlers/ServiceAccount.handler.ts
@@ -7,6 +7,7 @@ const ServiceAccountHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_ACCESS_CONTROL, 'Service Accounts'],
   clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);

--- a/src/kindhandlers/StatefulSet.handler.ts
+++ b/src/kindhandlers/StatefulSet.handler.ts
@@ -8,6 +8,7 @@ const StatefulSetHandler: ResourceKindHandler = {
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_WORKLOADS, 'StatefulSets'],
   clusterApiVersion: 'apps/v1',
+  validationSchemaPrefix: 'io.k8s.api.apps.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.AppsV1Api);

--- a/src/models/resourcekindhandler.ts
+++ b/src/models/resourcekindhandler.ts
@@ -104,6 +104,8 @@ interface ResourceKindHandler {
     description: string;
     content: string;
   }[];
+
+  validationSchemaPrefix?: string;
 }
 
 export type {ResourceKindHandler, RefMapper, SymbolMatcher};

--- a/src/redux/services/schema.ts
+++ b/src/redux/services/schema.ts
@@ -2,12 +2,10 @@ import {K8sResource} from '@models/k8sresource';
 import log from 'loglevel';
 import {loadResource} from '@redux/services';
 import {isKustomizationResource} from '@redux/services/kustomize';
+import {getResourceKindHandler} from '@src/kindhandlers';
 
 const k8sSchema = JSON.parse(loadResource('schemas/k8sschemas.json'));
 const kustomizeSchema = JSON.parse(loadResource('schemas/kustomization.json'));
-
-// search for schema kinds with these prefixes
-const kindPrefixes = ['io.k8s.api.apps.v1', 'io.k8s.api.rbac.v1', 'io.k8s.api.core.v1'];
 
 /**
  * Returns a JSON Schema for the specified resource kind
@@ -17,7 +15,9 @@ export function getResourceSchema(resource: K8sResource) {
     return kustomizeSchema;
   }
 
-  let prefix = kindPrefixes.find(p => k8sSchema['definitions'][`${p}.${resource.kind}`]);
+  const resourceKindHandler = getResourceKindHandler(resource.kind);
+  const prefix = resourceKindHandler?.validationSchemaPrefix;
+
   if (prefix) {
     const kindSchema = k8sSchema['definitions'][`${prefix}.${resource.kind}`];
 

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -7,7 +7,7 @@ import {addResource, selectK8sResource} from '@redux/reducers/main';
 
 function createDefaultResourceText(input: {name: string; kind: string; apiVersion?: string; namespace?: string}) {
   return `
-apiVersion: ${input.apiVersion ? input.apiVersion : 'apps/v1'}
+apiVersion: ${input.apiVersion ? input.apiVersion : 'v1'}
 kind: ${input.kind}
 metadata:
   name: ${input.name}


### PR DESCRIPTION
This PR...

## Changes

- add validationSchemaPrefix to all kind handlers
- use validationSchemaPrefix in getResourceSchema

## Fixes

- multiple errors where validation schemas couldn't be found for some resource kinds

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
