### PR TITLE
fix: yaml document delimiter line endings

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,6 +1,7 @@
 export const PREVIEW_PREFIX = 'preview://';
 export const UNSAVED_PREFIX = 'unsaved://';
-export const YAML_DOCUMENT_DELIMITER = '---\n';
+export const YAML_DOCUMENT_DELIMITER = '---';
+export const YAML_DOCUMENT_DELIMITER_NEW_LINE = '---\n';
 export const ROOT_FILE_ENTRY = '<root>';
 export const APP_MIN_WIDTH = 800;
 export const APP_MIN_HEIGHT = 600;

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -17,6 +17,12 @@ import {processRefs} from './resourceRefs';
  * Parse documents lazily...
  */
 
+function doesTextStartWithYamlDocumentDelimiter(text: string) {
+  return ['\n', '\r\n', '\r'].some(lineEnding => {
+    return text.startsWith(`${YAML_DOCUMENT_DELIMITER}${lineEnding}`);
+  });
+}
+
 export function getParsedDoc(resource: K8sResource) {
   if (!resource.parsedDoc) {
     const lineCounter = new LineCounter();
@@ -254,8 +260,8 @@ export function saveResource(resource: K8sResource, newValue: string, fileMap: F
       const content = fs.readFileSync(absoluteResourcePath, 'utf8');
 
       // need to make sure that document delimiter is still there if this resource was not first in the file
-      if (resource.range.start > 0 && !valueToWrite.startsWith(YAML_DOCUMENT_DELIMITER)) {
-        valueToWrite = `${YAML_DOCUMENT_DELIMITER}${valueToWrite}`;
+      if (resource.range.start > 0 && !doesTextStartWithYamlDocumentDelimiter(valueToWrite)) {
+        valueToWrite = `${YAML_DOCUMENT_DELIMITER}\n${valueToWrite}`;
       }
 
       fs.writeFileSync(

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -3,7 +3,7 @@ import {SetPreviewDataPayload} from '@redux/reducers/main';
 import {AppDispatch, RootState} from '@redux/store';
 import {AppState} from '@models/appstate';
 import * as k8s from '@kubernetes/client-node';
-import {YAML_DOCUMENT_DELIMITER} from '@constants/constants';
+import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 import {AlertEnum} from '@models/alert';
 import {createPreviewRejection, createPreviewResult, getK8sObjectsAsYaml} from '@redux/thunks/utils';
 
@@ -36,7 +36,7 @@ const previewClusterHandler = async (configPath: string, thunkAPI: any) => {
           }
 
           // @ts-ignore
-          const allYaml = fulfilledResults.map(r => r.value).join(YAML_DOCUMENT_DELIMITER);
+          const allYaml = fulfilledResults.map(r => r.value).join(YAML_DOCUMENT_DELIMITER_NEW_LINE);
           const previewResult = createPreviewResult(allYaml, configPath, 'Get Cluster Resources');
 
           if (fulfilledResults.length < results.length) {

--- a/src/redux/thunks/saveUnsavedResource.ts
+++ b/src/redux/thunks/saveUnsavedResource.ts
@@ -68,10 +68,14 @@ export const saveUnsavedResource = createAsyncThunk<
 
   if (fs.existsSync(absoluteFilePath)) {
     const fileContent = await readFilePromise(absoluteFilePath, 'utf-8');
-    const contentToAppend =
-      fileContent.trim().length === 0 || fileContent.trim().endsWith(YAML_DOCUMENT_DELIMITER)
-        ? `${resource.text}`
-        : `\n${YAML_DOCUMENT_DELIMITER}${resource.text}`;
+    let contentToAppend = resource.text;
+    if (fileContent.trim().length > 0) {
+      if (fileContent.trim().endsWith(YAML_DOCUMENT_DELIMITER)) {
+        contentToAppend = `\n${resource.text}`;
+      } else {
+        contentToAppend = `\n${YAML_DOCUMENT_DELIMITER}\n${resource.text}`;
+      }
+    }
     await appendFilePromise(absoluteFilePath, contentToAppend);
   } else {
     await writeFilePromise(absoluteFilePath, resource.text);

--- a/src/redux/thunks/utils.ts
+++ b/src/redux/thunks/utils.ts
@@ -1,4 +1,4 @@
-import {PREVIEW_PREFIX, YAML_DOCUMENT_DELIMITER} from '@constants/constants';
+import {PREVIEW_PREFIX, YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 import {ResourceMapType} from '@models/appstate';
 import {extractK8sResources, processParsedResources} from '@redux/services/resource';
 import {stringify} from 'yaml';
@@ -14,7 +14,7 @@ export function getK8sObjectsAsYaml(items: any[], kind: string, apiVersion: stri
       delete item.metadata?.managedFields;
       return `apiVersion: ${apiVersion}\nkind: ${kind}\n${stringify(item)}`;
     })
-    .join(YAML_DOCUMENT_DELIMITER);
+    .join(YAML_DOCUMENT_DELIMITER_NEW_LINE);
 }
 
 /**


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- saving multi-document files on Windows was adding unnecessary yaml document delimiters, which caused the parsed content to be null

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
