### PR TITLE
fix: Selection flashing on both source editor and file explorer

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -360,16 +360,18 @@ const Monaco = (props: {editorHeight: string}) => {
         </HiddenInputContainer>
       </MonacoButtons>
       <MonacoContainer ref={containerRef}>
-        <MonacoEditor
-          width={width}
-          height={editorHeight}
-          language="yaml"
-          theme={KUBESHOP_MONACO_THEME}
-          value={code}
-          options={options}
-          onChange={onChange}
-          editorDidMount={editorDidMount}
-        />
+        {firstCodeLoadedOnEditor && (
+          <MonacoEditor
+            width={width}
+            height={editorHeight}
+            language="yaml"
+            theme={KUBESHOP_MONACO_THEME}
+            value={code}
+            options={options}
+            onChange={onChange}
+            editorDidMount={editorDidMount}
+          />
+        )}
       </MonacoContainer>
     </>
   );

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -295,7 +295,7 @@ const FileTreePane = () => {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedResourceId]);
+  }, [selectedResourceId, tree]);
 
   useEffect(() => {
     // removes any highlight when a file is selected


### PR DESCRIPTION
This PR...

## Changes

*

## Fixes

* Set and keep selection on file explorer
* Prevent selection flashing on first resource select on source editor

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
