### PR TITLE
fix: fixed Endpoints ResourceKindHandler to use correct name and prefix

### DIFF
--- a/src/kindhandlers/Endpoints.handler.ts
+++ b/src/kindhandlers/Endpoints.handler.ts
@@ -2,12 +2,12 @@ import * as k8s from '@kubernetes/client-node';
 import {ResourceKindHandler} from '@models/resourcekindhandler';
 import {NAV_K8S_RESOURCES, SECTION_NETWORK} from '@constants/navigator';
 
-const EndpointHandler: ResourceKindHandler = {
-  kind: 'Endpoint',
+const EndpointsHandler: ResourceKindHandler = {
+  kind: 'Endpoints',
   apiVersionMatcher: '**',
   navigatorPath: [NAV_K8S_RESOURCES, SECTION_NETWORK, 'Endpoints'],
   clusterApiVersion: 'v1',
-  validationSchemaPrefix: 'io.k8s.api.discovery.v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
   description: '',
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, name: string, namespace: string): Promise<any> {
     const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
@@ -31,4 +31,4 @@ const EndpointHandler: ResourceKindHandler = {
   ],
 };
 
-export default EndpointHandler;
+export default EndpointsHandler;

--- a/src/kindhandlers/index.ts
+++ b/src/kindhandlers/index.ts
@@ -7,7 +7,7 @@ import CronJobHandler from './CronJob.handler';
 import CustomResourceDefinitionHandler from './CustomResourceDefinition.handler';
 import DaemonSetHandler from './DaemonSet.handler';
 import DeploymentHandler from './Deployment.handler';
-import EndpointHandler from './Endpoint.handler';
+import EndpointsHandler from './Endpoints.handler';
 import IngressHandler from './Ingress.handler';
 import JobHandler from './Job.handler';
 import NetworkPolicyHandler from './NetworkPolicy.handler';
@@ -31,7 +31,7 @@ export const ResourceKindHandlers: ResourceKindHandler[] = [
   CustomResourceDefinitionHandler,
   DaemonSetHandler,
   DeploymentHandler,
-  EndpointHandler,
+  EndpointsHandler,
   IngressHandler,
   JobHandler,
   NetworkPolicyHandler,


### PR DESCRIPTION
This PR fixes Endpoints ResourceKindHandler to use correct name and prefix

## Changes

-

## Fixes

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
