### PR TITLE
Fix saving an unsaved resource and refactor resource delete

### DIFF
--- a/src/components/molecules/NavigatorRowLabel/ActionsMenu.tsx
+++ b/src/components/molecules/NavigatorRowLabel/ActionsMenu.tsx
@@ -6,12 +6,15 @@ import {removeResource} from '@redux/reducers/main';
 import {AppDispatch} from '@redux/store';
 import {ExclamationCircleOutlined} from '@ant-design/icons';
 import {isFileResource} from '@redux/services/resource';
+import {getResourcesForPath} from '@redux/services/fileEntry';
+import {PreviewType, ResourceMapType} from '@models/appstate';
 
-function deleteResourceWithConfirm(resource: K8sResource, dispatch: AppDispatch) {
+function deleteResourceWithConfirm(resource: K8sResource, resourceMap: ResourceMapType, dispatch: AppDispatch) {
   let title = `Are you sure you want to delete ${resource.name}?`;
 
   if (isFileResource(resource)) {
-    if (!resource.range) {
+    const resourcesFromPath = getResourcesForPath(resource.filePath, resourceMap);
+    if (resourcesFromPath.length === 1) {
       title = `This action will delete the ${resource.filePath} file.\n${title}`;
     }
   } else {
@@ -30,17 +33,22 @@ function deleteResourceWithConfirm(resource: K8sResource, dispatch: AppDispatch)
     onCancel() {},
   });
 }
-const ActionsMenu = (props: {resource: K8sResource}) => {
-  const {resource} = props;
+const ActionsMenu = (props: {
+  resource: K8sResource;
+  resourceMap: ResourceMapType;
+  isInPreviewMode: boolean;
+  previewType?: PreviewType;
+}) => {
+  const {resource, resourceMap, isInPreviewMode, previewType} = props;
   const dispatch = useAppDispatch();
 
   const deleteResource = () => {
-    deleteResourceWithConfirm(resource, dispatch);
+    deleteResourceWithConfirm(resource, resourceMap, dispatch);
   };
 
   return (
     <Menu>
-      <Menu.Item onClick={deleteResource} key="delete">
+      <Menu.Item disabled={isInPreviewMode && previewType !== 'cluster'} onClick={deleteResource} key="delete">
         Delete
       </Menu.Item>
     </Menu>

--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -361,9 +361,19 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
           </StyledIconsContainer>
         </Popover>
       )}
-      {isHovered && (!isInPreviewMode || (isInPreviewMode && previewType === 'cluster')) && (
+      {isHovered && (
         <StyledMenuToggle>
-          <Dropdown overlay={<ActionsMenu resource={resource} />} trigger={['click']}>
+          <Dropdown
+            overlay={
+              <ActionsMenu
+                resource={resource}
+                resourceMap={resourceMap}
+                isInPreviewMode={isInPreviewMode}
+                previewType={previewType}
+              />
+            }
+            trigger={['click']}
+          >
             <MoreOutlined />
           </Dropdown>
         </StyledMenuToggle>

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -47,6 +47,8 @@ type PathSelectionHistoryEntry = {
 
 type SelectionHistoryEntry = ResourceSelectionHistoryEntry | PathSelectionHistoryEntry;
 
+type PreviewType = 'kustomization' | 'cluster' | 'helm';
+
 interface AppState {
   /** maps filePath to FileEntry
    * - filePath is relative to selected rootFolder
@@ -74,7 +76,7 @@ interface AppState {
   /** the currently selected values file */
   selectedValuesFileId?: string;
   /** the current type of preview */
-  previewType?: 'kustomization' | 'cluster' | 'helm';
+  previewType?: PreviewType;
   /** information used to load the preview */
   previewLoader: PreviewLoaderType;
   /** the resource currently being previewed */
@@ -95,4 +97,5 @@ export type {
   HelmValuesMapType,
   PreviewLoaderType,
   SelectionHistoryEntry,
+  PreviewType,
 };

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -388,6 +388,7 @@ export const mainSlice = createSlice({
       const resourceFileEntry = state.fileMap[relativeFilePath];
       if (resource) {
         resource.filePath = relativeFilePath;
+        resource.range = action.payload.resourceRange;
       }
       if (resourceFileEntry) {
         resourceFileEntry.timestamp = action.payload.fileTimestamp;

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -423,17 +423,18 @@ export function removeResourceFromFile(
   }
   const absoluteFilePath = getAbsoluteResourcePath(removedResource, fileMap);
 
-  if (!removedResource.range) {
-    fs.unlinkSync(absoluteFilePath);
-    return;
-  }
-
   // get list of resourceIds in file sorted by startPosition
   const resourceIds = getResourcesForPath(removedResource.filePath, resourceMap)
     .sort((a, b) => {
       return a.range && b.range ? a.range.start - b.range.start : 0;
     })
     .map(r => r.id);
+
+  // delete the file if there's only one resource in it
+  if (!removedResource.range || resourceIds.length === 1) {
+    fs.unlinkSync(absoluteFilePath);
+    return;
+  }
 
   // recalculate ranges for resources below the removed resource
   let newRangeStart = 0;


### PR DESCRIPTION
This PR...

## Changes

- show ActionsMenu on all resources and disable Delete action instead

## Fixes

- save resource range for the unsaved resource and for existing one if needed
- delete file only if it has a single resource

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
