### PR TITLE
show only resources which have the selected kind in the NewResourceWizard for templates

### DIFF
--- a/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
+++ b/src/components/molecules/NavigatorRowLabel/NavigatorRowLabel.tsx
@@ -17,6 +17,7 @@ import {isOutgoingRef, isIncomingRef, isUnsatisfiedRef} from '@redux/services/re
 import {isUnsavedResource} from '@redux/services/resource';
 import ScrollIntoView from '@molecules/ScrollIntoView';
 import {isInPreviewModeSelector} from '@redux/selectors';
+import {isKustomizationResource} from '@redux/services/kustomize';
 import ActionsMenu from './ActionsMenu';
 
 const {Text} = Typography;
@@ -366,7 +367,7 @@ const NavigatorRowLabel = (props: NavigatorRowLabelProps) => {
           </StyledIconsContainer>
         </Popover>
       )}
-      {isHovered && (
+      {!isKustomizationResource(resource) && isHovered && (
         <StyledMenuToggle>
           <Dropdown
             overlay={


### PR DESCRIPTION
This PR...

## Changes

- show only resources which have the selected kind in the NewResourceWizard for template selection and reset if kind changes

## Fixes

- hide actions menu for Kustomizations

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
