### PR TITLE
rename resource improvements

### DIFF
--- a/src/components/organisms/RenameResourceModal/RenameResourceModal.tsx
+++ b/src/components/organisms/RenameResourceModal/RenameResourceModal.tsx
@@ -4,6 +4,7 @@ import {useAppSelector, useAppDispatch} from '@redux/hooks';
 import {closeRenameResourceModal} from '@redux/reducers/ui';
 import {renameResource} from '@redux/services/renameResource';
 import styled from 'styled-components';
+import {K8sResource} from '@models/k8sresource';
 
 const CheckboxContainer = styled.div`
   margin-top: 10px;
@@ -13,23 +14,31 @@ const RenameResourceModel = () => {
   const dispatch = useAppDispatch();
   const uiState = useAppSelector(state => state.ui.renameResourceModal);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
   const [newResourceName, setNewResourceName] = useState<string>();
   const [shouldUpdateRefs, setShouldUpdateRefs] = useState<boolean>(false);
   const inputNameRef = useRef<any>();
+  const [resource, setResource] = useState<K8sResource>();
 
   useEffect(() => {
-    if (uiState?.isOpen) {
-      setNewResourceName(undefined);
-      setShouldUpdateRefs(false);
-      inputNameRef?.current?.focus();
+    if (uiState) {
+      const newResource = resourceMap[uiState.resourceId];
+      if (newResource) {
+        setResource(newResource);
+        setNewResourceName(newResource.name);
+      }
     }
-  }, [uiState?.isOpen]);
+    if (!uiState || uiState?.isOpen === false) {
+      setResource(undefined);
+      setNewResourceName(undefined);
+    }
+    setShouldUpdateRefs(false);
+    inputNameRef?.current?.focus();
+  }, [uiState, resourceMap]);
 
   if (!uiState) {
     return null;
   }
-
-  const resource = resourceMap[uiState.resourceId];
 
   if (!resource) {
     return null;
@@ -39,7 +48,7 @@ const RenameResourceModel = () => {
     if (!newResourceName || resource.name === newResourceName) {
       return;
     }
-    renameResource(resource.id, newResourceName, shouldUpdateRefs, resourceMap, dispatch);
+    renameResource(resource.id, newResourceName, shouldUpdateRefs, resourceMap, dispatch, selectedResourceId);
     dispatch(closeRenameResourceModal());
   };
 

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -51,6 +51,7 @@ export type SetRootFolderPayload = {
 export type UpdateResourcePayload = {
   resourceId: string;
   content: string;
+  preventSelectionAndHighlightsUpdate?: boolean;
 };
 
 export type UpdateFileEntryPayload = {
@@ -197,8 +198,10 @@ export const mainSlice = createSlice({
             resource.content = parseDocument(action.payload.content).toJS();
           }
           reprocessResources([resource.id], state.resourceMap, state.fileMap);
-          resource.isSelected = false;
-          updateSelectionAndHighlights(state, resource);
+          if (!action.payload.preventSelectionAndHighlightsUpdate) {
+            resource.isSelected = false;
+            updateSelectionAndHighlights(state, resource);
+          }
         }
       } catch (e) {
         log.error(e);

--- a/src/redux/services/renameResource.ts
+++ b/src/redux/services/renameResource.ts
@@ -9,7 +9,8 @@ export const renameResource = (
   newResourceName: string,
   shouldUpdateRefs: boolean,
   resourceMap: ResourceMapType,
-  dispatch: AppDispatch
+  dispatch: AppDispatch,
+  selectedResourceId?: string
 ) => {
   const resource = resourceMap[resourceId];
   if (!resource || !resource.content) {
@@ -41,8 +42,20 @@ export const renameResource = (
         }
         newDependentResourceText += `${line.replace(ref.name, newResourceName)}\n`;
       });
-      dispatch(updateResource({resourceId: dependentResource.id, content: newDependentResourceText}));
+      dispatch(
+        updateResource({
+          resourceId: dependentResource.id,
+          content: newDependentResourceText,
+          preventSelectionAndHighlightsUpdate: selectedResourceId !== dependentResource.id,
+        })
+      );
     });
   }
-  dispatch(updateResource({resourceId, content: newResourceText}));
+  dispatch(
+    updateResource({
+      resourceId,
+      content: newResourceText,
+      preventSelectionAndHighlightsUpdate: selectedResourceId !== resourceId,
+    })
+  );
 };


### PR DESCRIPTION
This PR...

## Changes

- option to prevent updating selection and highlights after a resource is updated
- get and set the default resource name when renaming

## Fixes

- resource selection after renaming a resource

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
