### PR TITLE
feat: use os file dialogs for selecting folders and files

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import {app, BrowserWindow, nativeImage, ipcMain} from 'electron';
+import {app, BrowserWindow, nativeImage, ipcMain, dialog} from 'electron';
 import * as path from 'path';
 import * as isDev from 'electron-is-dev';
 import installExtension, {REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS} from 'electron-devtools-installer';
@@ -50,6 +50,26 @@ ipcMain.on('check-missing-dependency', event => {
   if (missingDependecies.length > 0) {
     event.sender.send('missing-dependency-result', {dependencies: missingDependecies});
   }
+});
+
+ipcMain.handle('select-file', async (event, options: any) => {
+  const browserWindow = BrowserWindow.fromId(event.sender.id);
+  let dialogOptions: Electron.OpenDialogSyncOptions = {};
+  if (options.isDirectoryExplorer) {
+    dialogOptions.properties = ['openDirectory'];
+  } else {
+    if (options.allowMultiple) {
+      dialogOptions.properties = ['multiSelections'];
+    }
+    if (options.acceptedFileExtensions) {
+      dialogOptions.filters = [{name: 'Files', extensions: options.acceptedFileExtensions}];
+    }
+  }
+
+  if (browserWindow) {
+    return dialog.showOpenDialogSync(browserWindow, dialogOptions);
+  }
+  return dialog.showOpenDialogSync(dialogOptions);
 });
 
 /**

--- a/src/hooks/useFileExplorer.tsx
+++ b/src/hooks/useFileExplorer.tsx
@@ -1,6 +1,5 @@
 import {useState, useCallback} from 'react';
 import {FileExplorerOptions, FileExplorerProps} from '@atoms/FileExplorer';
-import {findCommonRootFolder} from '@utils/files';
 
 type FileExplorerSelectResult = {
   filePath?: string;
@@ -15,22 +14,22 @@ export const useFileExplorer = (
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleOnSelect = useCallback(
-    (fileList: FileList) => {
+    (fileList: string[]) => {
       setIsOpen(false);
       if (options?.isDirectoryExplorer) {
         onSelect({
-          folderPath: findCommonRootFolder(fileList),
+          folderPath: fileList[0],
         });
         return;
       }
       if (options?.allowMultiple) {
         onSelect({
-          filePaths: Array.from(fileList).map(f => f.path),
+          filePaths: fileList,
         });
         return;
       }
       onSelect({
-        filePath: fileList[0].path,
+        filePath: fileList[0],
       });
     },
     [setIsOpen, onSelect, options]

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,38 +1,4 @@
 import path from 'path';
-import fs from 'fs';
-
-// algorithm to find common root folder for selected files - since the first entry is not
-// necessarily the selected folder
-// eslint-disable-next-line no-undef
-export function findCommonRootFolder(files: FileList) {
-  let root: any = files[0];
-  let topIndex = -1;
-
-  for (let i = 1; i < files.length; i += 1) {
-    let rootSegments = root.path.split(path.sep);
-    // @ts-ignore
-    let fileSegments = files[i].path.split(path.sep);
-
-    let ix = 0;
-    while (ix < rootSegments.length && ix < fileSegments.length && rootSegments[ix] === fileSegments[ix]) {
-      ix += 1;
-    }
-
-    if (topIndex === -1 || ix < topIndex) {
-      topIndex = ix;
-      root = files[i];
-    }
-  }
-
-  let result = topIndex !== -1 ? root.path.split(path.sep).slice(0, topIndex).join(path.sep) : root.path;
-
-  // in some cases only a file is returned..
-  if (fs.statSync(result).isFile()) {
-    result = path.parse(result).dir;
-  }
-
-  return result;
-}
 
 export function isSubDirectory(parentDir: string, dir: string) {
   const relative = path.relative(parentDir, dir);


### PR DESCRIPTION
This PR replaces the usage of the input file/folder dialogs for selecting folders/files with the electron-provided os file dialogs 

## Changes

-

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
