### PR TITLE
fix: Include @babel path on production

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,6 @@
       "!**/node_modules/babel-runtime/**/*",
       "!**/node_modules/yaml-language-server/lib/umd/**/*",
       "!**/node_modules/antd/es/**/*",
-      "!**/node_modules/@babel/**/*",
       "!**/node_modules/@jest/**/*",
       "!**/node_modules/monaco-editor/min/**/*",
       "!**/node_modules/monaco-editor/min-maps/**/*",


### PR DESCRIPTION
This PR...

## Changes

- Removed ignored path on package.json `@babel`

## Fixes

- Module not found error on application bootup

## How to test it

- Install and run the built application

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
