### PR TITLE
refactor: add kustomization prefix and suffix icons to show refs

### DIFF
--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/styled.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/styled.tsx
@@ -42,7 +42,7 @@ export const ItemContainer = styled.li<{
         return `background: ${Colors.blackPearl};`;
       }
     }};
-  padding-left: ${props => `${props.level * 10}px;`};
+  padding-left: ${props => `${props.level * 12}px;`};
 `;
 
 export const ItemName = styled.span<{

--- a/src/navsections/KustomizationNavSection/KustomizationNavSection.ts
+++ b/src/navsections/KustomizationNavSection/KustomizationNavSection.ts
@@ -8,6 +8,8 @@ import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {NavSection} from '@models/navsection';
 import {isInClusterModeSelector} from '@redux/selectors';
 import KustomizationQuickAction from './KustomizationQuickAction';
+import KustomizationPrefix from './KustomizationPrefix';
+import KustomizationSuffix from './KustomizationSuffix';
 
 export type KustomizationNavSectionScope = {
   resourceMap: ResourceMapType;
@@ -78,6 +80,8 @@ const KustomizationNavSection: NavSection<K8sResource, KustomizationNavSectionSc
     },
   },
   itemCustomization: {
+    Prefix: KustomizationPrefix,
+    Suffix: KustomizationSuffix,
     QuickAction: KustomizationQuickAction,
   },
 };

--- a/src/navsections/KustomizationNavSection/KustomizationPrefix.tsx
+++ b/src/navsections/KustomizationNavSection/KustomizationPrefix.tsx
@@ -1,0 +1,10 @@
+import {K8sResource} from '@models/k8sresource';
+import {NavSectionItemCustomComponentProps} from '@models/navsection';
+import ResourceRefsIconPopover from '@components/molecules/ResourceRefsIconPopover';
+
+const Prefix = (props: NavSectionItemCustomComponentProps<K8sResource>) => {
+  const {item} = props;
+  return <ResourceRefsIconPopover resource={item} type="incoming" />;
+};
+
+export default Prefix;

--- a/src/navsections/KustomizationNavSection/KustomizationSuffix.tsx
+++ b/src/navsections/KustomizationNavSection/KustomizationSuffix.tsx
@@ -1,0 +1,10 @@
+import {K8sResource} from '@models/k8sresource';
+import {NavSectionItemCustomComponentProps} from '@models/navsection';
+import ResourceRefsIconPopover from '@components/molecules/ResourceRefsIconPopover';
+
+const Suffix = (props: NavSectionItemCustomComponentProps<K8sResource>) => {
+  const {item} = props;
+  return <ResourceRefsIconPopover resource={item} type="outgoing" />;
+};
+
+export default Suffix;


### PR DESCRIPTION
This PR...

## Changes

- add kustomization prefix and suffix icon components to show refs in KustomizationNavSection

## Fixes

-

## How to test it

-

## screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
