### PR TITLE
fix: Add env.ts to handle environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ k8sdumps
 
 .vscode
 /site
+
+env.ts

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,9 @@
+/* eslint-disable import/order */
 /* eslint-disable import/first */
 import moduleAlias from 'module-alias';
+import * as ElectronLog from 'electron-log';
 
+Object.assign(console, ElectronLog.functions);
 moduleAlias.addAliases({
   '@constants': `${__dirname}/../src/constants`,
   '@models': `${__dirname}/../src/models`,
@@ -10,12 +13,18 @@ moduleAlias.addAliases({
   '@root': `${__dirname}/../`,
 });
 
+import ENV from '../env';
+
+if (!ENV.env || ENV.env === 'development') {
+  process.env.NODE_ENV = 'development';
+} else {
+  process.env.NODE_ENV = 'production';
+}
+
 import {app, BrowserWindow, nativeImage, ipcMain, dialog} from 'electron';
 import * as path from 'path';
-import * as isDev from 'electron-is-dev';
 import installExtension, {REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS} from 'electron-devtools-installer';
 import {execSync} from 'child_process';
-import * as ElectronLog from 'electron-log';
 import * as Splashscreen from '@trodi/electron-splashscreen';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
@@ -25,13 +34,11 @@ import {checkMissingDependencies} from '@utils/index';
 import terminal from '../cli/terminal';
 import {createMenu} from './menu';
 
-// console.log(store);
-
-Object.assign(console, ElectronLog.functions);
-
 const ElectronStore = require('electron-store');
 
 const {MONOKLE_RUN_AS_NODE} = process.env;
+
+const isDev = process.env.NODE_ENV === 'development';
 
 const userHomeDir = app.getPath('home');
 const APP_DEPENDENCIES = ['kubectl', 'helm'];

--- a/env.example.ts
+++ b/env.example.ts
@@ -1,0 +1,9 @@
+interface Environment {
+  env: string;
+}
+
+const env: Environment = {
+  env: '',
+};
+
+export default env;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "dagre": "0.8.5",
         "dayjs": "1.10.6",
         "electron-devtools-installer": "3.2.0",
-        "electron-is-dev": "2.0.0",
         "electron-log": "4.4.1",
         "electron-redux": "^1.5.4",
         "electron-store": "8.0.0",
@@ -40616,11 +40615,6 @@
         "tslib": "^2.1.0",
         "unzip-crx-3": "^0.2.0"
       }
-    },
-    "electron-is-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-      "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
     },
     "electron-log": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "dagre": "0.8.5",
     "dayjs": "1.10.6",
     "electron-devtools-installer": "3.2.0",
-    "electron-is-dev": "2.0.0",
     "electron-log": "4.4.1",
     "electron-redux": "^1.5.4",
     "electron-store": "8.0.0",


### PR DESCRIPTION
This PR...

## Changes

- The way of handling environment variables

## Fixes

- NODE_ENV undefined issue

## How to test it

- Copy env.example.ts file as env.ts and set env as production and get the build.

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
