### PR TITLE
feat: resource ref selection in Monaco editor

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -23,7 +23,7 @@ import useCodeIntel from './useCodeIntel';
 import useEditorKeybindings from './useEditorKeybindings';
 import useResourceYamlSchema from './useResourceYamlSchema';
 import useDebouncedCodeSave from './useDebouncedCodeSave';
-import useEditorUiState from './useEditorUiState';
+import useMonacoUiState from './useMonacoUiState';
 import * as S from './Monaco.styled';
 
 // @ts-ignore
@@ -97,7 +97,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     selectedPath,
     setOrgCode
   );
-  const {onEditorFocus} = useEditorUiState(editor, selectedResourceId);
+  const {onEditorFocus} = useMonacoUiState(editor, selectedResourceId, selectedPath);
 
   const onDidChangeMarkers = (e: monaco.Uri[]) => {
     const flag = monaco.editor.getModelMarkers({}).length > 0;

--- a/src/components/molecules/Monaco/useMonacoUiState.ts
+++ b/src/components/molecules/Monaco/useMonacoUiState.ts
@@ -3,7 +3,11 @@ import {setMonacoEditor} from '@redux/reducers/ui';
 import {useCallback, useEffect} from 'react';
 import {monaco} from 'react-monaco-editor';
 
-function useEditorUiState(editor: monaco.editor.IStandaloneCodeEditor | null, selectedResourceId: string | undefined) {
+function useMonacoUiState(
+  editor: monaco.editor.IStandaloneCodeEditor | null,
+  selectedResourceId: string | undefined,
+  selectedPath: string | undefined
+) {
   const dispatch = useAppDispatch();
   const monacoEditor = useAppSelector(state => state.ui.monacoEditor);
 
@@ -25,6 +29,21 @@ function useEditorUiState(editor: monaco.editor.IStandaloneCodeEditor | null, se
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, []);
+
+  useEffect(() => {
+    const selection = monacoEditor.selection;
+    if (!selection || !editor) {
+      return;
+    }
+    if (
+      (selection.type === 'file' && selection.filePath === selectedPath) ||
+      (selection.type === 'resource' && selection.resourceId === selectedResourceId)
+    ) {
+      editor.setSelection(selection.range);
+      editor.revealLineInCenter(selection.range.startLineNumber);
+      dispatch(setMonacoEditor({selection: undefined}));
+    }
+  }, [monacoEditor, selectedPath, selectedResourceId]);
 
   useEffect(() => {
     if (!monacoEditor.focused) {
@@ -52,4 +71,4 @@ function useEditorUiState(editor: monaco.editor.IStandaloneCodeEditor | null, se
   return {onEditorFocus};
 }
 
-export default useEditorUiState;
+export default useMonacoUiState;

--- a/src/components/molecules/ResourceRefsIconPopover/ResourceRefsIconPopover.tsx
+++ b/src/components/molecules/ResourceRefsIconPopover/ResourceRefsIconPopover.tsx
@@ -1,7 +1,5 @@
 import MonoIcon, {MonoIconTypes} from '@components/atoms/MonoIcon';
 import {K8sResource} from '@models/k8sresource';
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {selectFile, selectK8sResource} from '@redux/reducers/main';
 import {isIncomingRef, isOutgoingRef, isUnsatisfiedRef} from '@redux/services/resourceRefs';
 import {Popover} from 'antd';
 import {useMemo} from 'react';
@@ -16,9 +14,7 @@ const StyledIconsContainer = styled.span`
 
 const ResourceRefsIconPopover = (props: {resource: K8sResource; type: 'incoming' | 'outgoing'}) => {
   const {resource, type} = props;
-  const dispatch = useAppDispatch();
-  const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const fileMap = useAppSelector(state => state.main.fileMap);
+
   const resourceRefs = useMemo(
     () =>
       resource.refs?.filter(r => {
@@ -36,18 +32,6 @@ const ResourceRefsIconPopover = (props: {resource: K8sResource; type: 'incoming'
     return resourceRefs?.some(r => isUnsatisfiedRef(r.type));
   }, [resourceRefs, type]);
 
-  const selectResource = (selectedId: string) => {
-    if (resourceMap[selectedId]) {
-      dispatch(selectK8sResource({resourceId: selectedId}));
-    }
-  };
-
-  const selectFilePath = (filePath: string) => {
-    if (fileMap[filePath]) {
-      dispatch(selectFile({filePath}));
-    }
-  };
-
   if (!resourceRefs || resourceRefs.length === 0) {
     return null;
   }
@@ -57,12 +41,7 @@ const ResourceRefsIconPopover = (props: {resource: K8sResource; type: 'incoming'
       mouseEnterDelay={0.5}
       placement="rightTop"
       content={
-        <RefsPopoverContent
-          resourceRefs={resourceRefs}
-          resourceMap={resourceMap}
-          selectResource={selectResource}
-          selectFilePath={selectFilePath}
-        >
+        <RefsPopoverContent resource={resource} resourceRefs={resourceRefs}>
           {type === 'incoming' ? (
             <>
               Incoming Links <MonoIcon type={MonoIconTypes.IncomingRefs} />

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -8,6 +8,38 @@ export type NewResourceWizardInput = {
   selectedResourceId?: string;
 };
 
+export type MonacoRange = {
+  startLineNumber: number;
+  endLineNumber: number;
+  startColumn: number;
+  endColumn: number;
+};
+
+export type MonacoSelectionResource = {
+  type: 'resource';
+  resourceId: string;
+  range: MonacoRange;
+};
+
+export type MonacoSelectionFile = {
+  type: 'file';
+  filePath: string;
+  range: MonacoRange;
+};
+
+export type MonacoUiSelection = MonacoSelectionResource | MonacoSelectionFile;
+
+export type MonacoUiState = {
+  focused: boolean;
+  undo: boolean;
+  redo: boolean;
+  find: boolean;
+  replace: boolean;
+  apply: boolean;
+  diff: boolean;
+  selection?: MonacoUiSelection;
+};
+
 export type UiState = {
   isSettingsOpen: boolean;
   newResourceWizard: {
@@ -37,15 +69,7 @@ export type UiState = {
   folderExplorer: {
     isOpen: boolean;
   };
-  monacoEditor: {
-    focused: boolean;
-    undo: boolean;
-    redo: boolean;
-    find: boolean;
-    replace: boolean;
-    apply: boolean;
-    diff: boolean;
-  };
+  monacoEditor: MonacoUiState;
   paneConfiguration: PaneConfiguration;
   shouldExpandAllNodes: boolean;
   resetLayout: boolean;

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -1,6 +1,6 @@
 import {createAsyncThunk, createSlice, Draft, PayloadAction} from '@reduxjs/toolkit';
 import {setRootFolder} from '@redux/thunks/setRootFolder';
-import {PaneConfiguration, UiState, NewResourceWizardInput} from '@models/ui';
+import {PaneConfiguration, UiState, NewResourceWizardInput, MonacoUiState} from '@models/ui';
 import initialState from '@redux/initialState';
 import {ResourceValidationError} from '@models/k8sresource';
 import electronStore from '@utils/electronStore';
@@ -110,7 +110,7 @@ export const uiSlice = createSlice({
     closeFolderExplorer: (state: Draft<UiState>) => {
       state.folderExplorer = {isOpen: false};
     },
-    setMonacoEditor: (state: Draft<UiState>, action: PayloadAction<any>) => {
+    setMonacoEditor: (state: Draft<UiState>, action: PayloadAction<Partial<MonacoUiState>>) => {
       state.monacoEditor = {
         ...state.monacoEditor,
         ...action.payload,


### PR DESCRIPTION
This PR...

## Changes

- clicking on a link in the resource refs popover will now select the resource that contains the ref then scroll to and select the ref in the editor

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
