### PR TITLE
refactor: navigator pane improvements

### DIFF
--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/NavSectionItem.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/NavSectionItem.tsx
@@ -72,7 +72,6 @@ function NavSectionItem<ItemType, ScopeType>(props: {
           onMouseLeave={() => setIsHovered(false)}
           isSelected={isSelected}
           isHighlighted={isHighlighted}
-          isVisible={isVisible}
           isHovered={isHovered}
           level={level}
           isLastItem={isLastItem}

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/styled.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionItem/styled.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 export const ItemContainer = styled.li<{
   isSelected: boolean;
   isHighlighted: boolean;
-  isVisible: boolean;
   isHovered: boolean;
   level: number;
   isLastItem: boolean;
@@ -18,12 +17,6 @@ export const ItemContainer = styled.li<{
       if (props.isLastItem) {
         return `margin-bottom: 12px;`;
       }
-    }}
-    ${props => {
-      if (props.isVisible) {
-        return 'transition: opacity 500ms ease-in;';
-      }
-      return 'transition: opacity 500ms ease-out;';
     }}
     ${props => {
       if (!props.isSelected && props.isHighlighted) {

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
@@ -31,6 +31,70 @@ function loopSubsectionNamesDeep(
   });
 }
 
+function NavSectionHeader(props: {
+  name: string;
+  isSectionSelected: boolean;
+  isCollapsed: boolean;
+  isSectionHighlighted: boolean;
+  isLastSection: boolean;
+  hasSubsections: boolean;
+  isSectionInitialized: boolean;
+  isSectionVisible: boolean;
+  isCollapsedMode: 'collapsed' | 'expanded' | 'mixed';
+  level: number;
+  expandSection: () => void;
+  collapseSection: () => void;
+}) {
+  const {
+    name,
+    isSectionSelected,
+    isCollapsed,
+    isSectionHighlighted,
+    isLastSection,
+    hasSubsections,
+    isSectionInitialized,
+    isSectionVisible,
+    isCollapsedMode,
+    level,
+    expandSection,
+    collapseSection,
+  } = props;
+  const [isHovered, setIsHovered] = useState<boolean>(false);
+
+  return (
+    <S.NameContainer
+      isHovered={isHovered}
+      isSelected={isSectionSelected && isCollapsed}
+      isHighlighted={isSectionHighlighted && isCollapsed}
+      isLastSection={isLastSection}
+      hasSubsections={hasSubsections}
+      isCollapsed={isCollapsed}
+      isInitialized={isSectionInitialized}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      isVisible={isSectionVisible}
+    >
+      <S.Name
+        isSelected={isSectionSelected && isCollapsed}
+        isHighlighted={isSectionSelected && isCollapsed}
+        level={level}
+      >
+        {name}
+      </S.Name>
+      {isHovered && isSectionInitialized && (
+        <S.Collapsible>
+          {(isCollapsedMode === 'collapsed' || isCollapsedMode === 'mixed') && (
+            <PlusSquareOutlined onClick={expandSection} />
+          )}
+          {(isCollapsedMode === 'expanded' || isCollapsedMode === 'mixed') && (
+            <MinusSquareOutlined onClick={collapseSection} style={{marginLeft: '5px'}} />
+          )}
+        </S.Collapsible>
+      )}
+    </S.NameContainer>
+  );
+}
+
 function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<ItemType, ScopeType>) {
   const dispatch = useAppDispatch();
   const {navSection, level, isLastSection, onVisible, onHidden} = props;
@@ -190,36 +254,20 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
 
   return (
     <>
-      <S.NameContainer
-        isHovered={isHovered}
-        isSelected={isSectionSelected && isCollapsed}
-        isHighlighted={isSectionHighlighted && isCollapsed}
+      <NavSectionHeader
+        name={name}
+        isSectionSelected={isSectionSelected}
+        isCollapsed={isCollapsed}
+        isSectionHighlighted={isSectionHighlighted}
         isLastSection={isLastSection}
         hasSubsections={Boolean(subsections && subsections.length > 0)}
-        isCollapsed={isCollapsed}
-        isInitialized={isSectionInitialized}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        isVisible={isSectionVisible}
-      >
-        <S.Name
-          isSelected={isSectionSelected && isCollapsed}
-          isHighlighted={isSectionSelected && isCollapsed}
-          level={level}
-        >
-          {name}
-        </S.Name>
-        {isHovered && isSectionInitialized && (
-          <S.Collapsible>
-            {(isCollapsedMode === 'collapsed' || isCollapsedMode === 'mixed') && (
-              <PlusSquareOutlined onClick={expandSection} />
-            )}
-            {(isCollapsedMode === 'expanded' || isCollapsedMode === 'mixed') && (
-              <MinusSquareOutlined onClick={collapseSection} style={{marginLeft: '5px'}} />
-            )}
-          </S.Collapsible>
-        )}
-      </S.NameContainer>
+        isSectionInitialized={isSectionInitialized}
+        isSectionVisible={isSectionVisible}
+        isCollapsedMode={isCollapsedMode}
+        level={level}
+        expandSection={expandSection}
+        collapseSection={collapseSection}
+      />
       {!isCollapsed &&
         isSectionVisible &&
         itemHandler &&

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
@@ -185,6 +185,7 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
         )}
       </S.NameContainer>
       {!isCollapsed &&
+        isSectionVisible &&
         itemHandler &&
         Object.keys(groupedItems).length === 0 &&
         items.map((item, index) => (
@@ -200,6 +201,7 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
           />
         ))}
       {!isCollapsed &&
+        isSectionVisible &&
         itemHandler &&
         Object.entries(groupedItems).map(
           ([groupName, groupItems]) =>

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
@@ -47,6 +47,7 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
     isSectionVisible,
     isSectionHighlighted,
     isSectionSelected,
+    isSectionInitialized,
     itemHandler,
     itemCustomization,
     subsections,
@@ -193,9 +194,10 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
         isHovered={isHovered}
         isSelected={isSectionSelected && isCollapsed}
         isHighlighted={isSectionHighlighted && isCollapsed}
-        isLastSection={isLastSection && isSectionVisible}
+        isLastSection={isLastSection}
         hasSubsections={Boolean(subsections && subsections.length > 0)}
         isCollapsed={isCollapsed}
+        isInitialized={isSectionInitialized}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
         isVisible={isSectionVisible}
@@ -207,7 +209,7 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
         >
           {name}
         </S.Name>
-        {isHovered && (
+        {isHovered && isSectionInitialized && (
           <S.Collapsible>
             {(isCollapsedMode === 'collapsed' || isCollapsedMode === 'mixed') && (
               <PlusSquareOutlined onClick={expandSection} />

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/NavSectionRenderer.tsx
@@ -118,7 +118,6 @@ function NavSectionRenderer<ItemType, ScopeType>(props: NavSectionRendererProps<
     shouldSectionExpand,
   } = useNavSection<ItemType, ScopeType>(navSection, hiddenSubsectionNames);
 
-  const [isHovered, setIsHovered] = useState<boolean>(false);
   const collapsedNavSectionNames = useAppSelector(state => state.ui.navPane.collapsedNavSectionNames);
 
   const allVisibileNestedSubsectionNames = useMemo(() => {

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/styled.tsx
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/styled.tsx
@@ -10,6 +10,7 @@ export const NameContainer = styled.li<{
   isCollapsed?: boolean;
   hasSubsections?: boolean;
   isVisible?: boolean;
+  isInitialized?: boolean;
 }>`
   display: flex;
   justify-content: space-between;
@@ -23,7 +24,7 @@ export const NameContainer = styled.li<{
     return 'visibility: visible;';
   }}
   ${props => {
-    if (props.isLastSection && props.isCollapsed && !props.hasSubsections) {
+    if (props.isLastSection && (props.isCollapsed || !props.isInitialized) && !props.hasSubsections) {
       return `margin-bottom: 12px;`;
     }
   }}

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/useNavSection.ts
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/useNavSection.ts
@@ -166,7 +166,8 @@ export function useNavSection<ItemType, ScopeType>(
   }, [subsections, hiddenSubsectionNames]);
 
   const isSectionVisible = useMemo(() => {
-    if (!isVisible) {
+    const shouldBeVisible = isVisible ? isVisible(scope, items) : true;
+    if (shouldBeVisible) {
       return (
         isAnySubsectionVisible ||
         (Object.keys(groupedItems).length > 0 &&
@@ -174,7 +175,7 @@ export function useNavSection<ItemType, ScopeType>(
         (items.length > 0 && items.some(i => isItemVisible(i)))
       );
     }
-    return isVisible(scope, items);
+    return false;
   }, [scope, items, groupedItems, isVisible, isAnySubsectionVisible]);
 
   return {

--- a/src/components/organisms/NavigatorPane/NavSectionRenderer/useNavSection.ts
+++ b/src/components/organisms/NavigatorPane/NavSectionRenderer/useNavSection.ts
@@ -37,6 +37,7 @@ export function useNavSection<ItemType, ScopeType>(
     itemCustomization,
     isLoading,
     isVisible,
+    isInitialized,
     subsectionNames,
   } = navSection;
 
@@ -165,7 +166,17 @@ export function useNavSection<ItemType, ScopeType>(
     return subsections.some(s => !hiddenSubsectionNames.includes(s.name));
   }, [subsections, hiddenSubsectionNames]);
 
+  const isSectionInitialized = useMemo(() => {
+    if (!isInitialized) {
+      return true;
+    }
+    return isInitialized(scope, items);
+  }, [scope, items, isInitialized]);
+
   const isSectionVisible = useMemo(() => {
+    if (!isSectionInitialized) {
+      return true;
+    }
     const shouldBeVisible = isVisible ? isVisible(scope, items) : true;
     if (shouldBeVisible) {
       return (
@@ -191,6 +202,7 @@ export function useNavSection<ItemType, ScopeType>(
     isSectionHighlighted,
     isSectionLoading,
     isSectionVisible,
+    isSectionInitialized,
     itemHandler,
     itemCustomization,
     shouldSectionExpand,

--- a/src/models/navsection.ts
+++ b/src/models/navsection.ts
@@ -35,6 +35,7 @@ export interface NavSection<ItemType, ScopeType = any> {
   getItemsGrouped?: (scope: ScopeType) => Record<string, ItemType[]>;
   isLoading?: (scope: ScopeType, items: ItemType[]) => boolean;
   isVisible?: (scope: ScopeType, items: ItemType[]) => boolean;
+  isInitialized?: (scope: ScopeType, items: ItemType[]) => boolean;
   itemHandler?: NavSectionItemHandler<ItemType, ScopeType>;
   itemCustomization?: NavSectionItemCustomization<ItemType>;
 }

--- a/src/navsections/K8sResourceNavSection/K8sResourceNavSection.ts
+++ b/src/navsections/K8sResourceNavSection/K8sResourceNavSection.ts
@@ -6,6 +6,8 @@ import {ResourceKindHandler} from '@models/resourcekindhandler';
 import {PreviewLoaderType} from '@models/appstate';
 import {useAppSelector} from '@redux/hooks';
 import navSectionMap from '@src/navsections/navSectionMap';
+import {activeResourcesSelector} from '@redux/selectors';
+import {useSelector} from 'react-redux';
 import {makeResourceKindNavSection} from './ResourceKindNavSection';
 
 const subsectionNames = navSectionNames.representation[navSectionNames.K8S_RESOURCES];
@@ -27,6 +29,7 @@ ResourceKindHandlers.forEach(kindHandler => {
 export type K8sResourceNavSectionScope = {
   isFolderLoading: boolean;
   previewLoader: PreviewLoaderType;
+  activeResources: K8sResource[];
 };
 
 const subsections = subsectionNames.map(subsectionName => {
@@ -36,11 +39,18 @@ const subsections = subsectionNames.map(subsectionName => {
 
   kindHandlerSections.forEach(k => navSectionMap.register(k));
 
-  return {
+  const subsection: NavSection<K8sResource, {activeResources: K8sResource[]}> = {
     name: subsectionName,
-    useScope: () => {},
+    useScope: () => {
+      const activeResources = useSelector(activeResourcesSelector);
+      return {activeResources};
+    },
+    isInitialized: scope => {
+      return scope.activeResources.length > 0;
+    },
     subsectionNames: kindHandlerSections.map(k => k.name),
   };
+  return subsection;
 });
 
 subsections.forEach(s => navSectionMap.register(s));
@@ -50,10 +60,14 @@ const K8sResourceNavSection: NavSection<K8sResource, K8sResourceNavSectionScope>
   useScope: () => {
     const isFolderLoading = useAppSelector(state => state.ui.isFolderLoading);
     const previewLoader = useAppSelector(state => state.main.previewLoader);
-    return {isFolderLoading, previewLoader};
+    const activeResources = useSelector(activeResourcesSelector);
+    return {isFolderLoading, previewLoader, activeResources};
   },
   isLoading: scope => {
     return scope.isFolderLoading || scope.previewLoader.isLoading;
+  },
+  isInitialized: scope => {
+    return scope.activeResources.length > 0;
   },
   subsectionNames,
 };

--- a/src/navsections/K8sResourceNavSection/ResourceKindNavSection.ts
+++ b/src/navsections/K8sResourceNavSection/ResourceKindNavSection.ts
@@ -78,6 +78,9 @@ export function makeResourceKindNavSection(
     getItems: scope => {
       return scope.activeResources.filter(r => r.kind === kindHandler.kind);
     },
+    isInitialized: scope => {
+      return scope.activeResources.length > 0;
+    },
     itemHandler: {
       getName: item => item.name,
       getIdentifier: item => item.id,


### PR DESCRIPTION
This PR...

## Changes

- add logic to support showing all sections/subsections as empty before a folder is loaded (via new isInitialized handler)
- improve performance by avoiding entire re-renders of the section components

## Fixes

- spacing between section by properly finding the last visible section

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
