### PR TITLE
fix: Prevent update not found meesage to appear on every boot up

### DIFF
--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -106,7 +106,11 @@ export const configSlice = createSlice({
       state.settings.helmPreviewMode = action.payload;
     },
     setNewVersion: (state: Draft<AppConfig>, action: PayloadAction<{code: NewVersionCode; data: any}>) => {
-      state.newVersion = action.payload;
+      state.newVersion.code = action.payload.code;
+      state.newVersion.data = {
+        ...(state.newVersion.data && {}),
+        ...action.payload.data,
+      };
     },
     setLoadLastFolderOnStartup: (state: Draft<AppConfig>, action: PayloadAction<boolean>) => {
       state.settings.loadLastFolderOnStartup = action.payload;


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- Inherits initial new version check and prevents to modal show up at every boot up

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
