### PR TITLE
fix: Set initial value on new version check

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -137,7 +137,7 @@ ipcMain.on('quit-and-install', () => {
 
 export const checkNewVersion = async (initial?: boolean) => {
   try {
-    mainStore.dispatch(updateNewVersion({code: NewVersionCode.Checking, data: null}));
+    mainStore.dispatch(updateNewVersion({code: NewVersionCode.Checking, data: {initial: Boolean(initial)}}));
     await autoUpdater.checkForUpdates();
   } catch (error: any) {
     if (error.errno === -2) {


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- Sets initial value on version check.

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
