### PR TITLE
fix: Splash screen backgorund && check window.isDestroyed

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -309,7 +309,7 @@ terminal()
   .catch(e => console.log(e));
 
 export const setWindowTitle = (store: any, window: BrowserWindow) => {
-  if (!store || !window) {
+  if (window.isDestroyed()) {
     return;
   }
   const state = store.getState();

--- a/public/Splashscreen.css
+++ b/public/Splashscreen.css
@@ -1,5 +1,6 @@
 body {
   font-family: 'Source Sans Pro', sans-serif;
+  background-color: black;
 }
 @keyframes loading-dots-1 {
   from {


### PR DESCRIPTION
This PR...

## Changes

- Set background colour black to SplashScreen body
- Check if the window is destroyed

## Fixes

- 

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
