### PR TITLE
fix: Save pane configurations only on value change

### DIFF
--- a/src/components/atoms/SplitView/SplitView.tsx
+++ b/src/components/atoms/SplitView/SplitView.tsx
@@ -262,14 +262,22 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
     setDraggingLeftNav(false);
     setDraggingNavEdit(false);
     setDraggingEditRight(false);
-    dispatch(
-      setPaneConfiguration({
-        leftWidth,
-        navWidth,
-        editWidth,
-        rightWidth,
-      })
-    );
+
+    if (
+      paneConfiguration.leftWidth !== leftWidth ||
+      paneConfiguration.navWidth !== navWidth ||
+      paneConfiguration.editWidth !== editWidth ||
+      paneConfiguration.rightWidth !== rightWidth
+    ) {
+      dispatch(
+        setPaneConfiguration({
+          leftWidth,
+          navWidth,
+          editWidth,
+          rightWidth,
+        })
+      );
+    }
   };
 
   const onMove = (clientX: number) => {


### PR DESCRIPTION
This PR...

## Changes

- Save pane ratio configurations when only values are different

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
