### PR TITLE
Olelensmar/fix/kubeconfig debounce

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -21,6 +21,7 @@ import {applyResourceWithConfirm} from '@redux/services/applyResourceWithConfirm
 import {applyHelmChartWithConfirm} from '@redux/services/applyHelmChartWithConfirm';
 import {setMonacoEditor} from '@redux/reducers/ui';
 
+import {isKustomizationPatch} from '@redux/services/kustomize';
 import {
   StyledLeftArrowButton,
   StyledRightArrowButton,
@@ -245,7 +246,10 @@ const ActionsPane = (props: {contentHeight: string}) => {
                     size="small"
                     ghost
                     onClick={applySelection}
-                    disabled={!selectedResourceId && !selectedPath}
+                    disabled={
+                      (!selectedResourceId && !selectedPath) ||
+                      (selectedResource && isKustomizationPatch(selectedResource))
+                    }
                   >
                     Apply
                   </Button>
@@ -256,7 +260,7 @@ const ActionsPane = (props: {contentHeight: string}) => {
                     type="primary"
                     ghost
                     onClick={diffSelectedResource}
-                    disabled={!selectedResourceId}
+                    disabled={!selectedResourceId || (selectedResource && isKustomizationPatch(selectedResource))}
                   >
                     Diff
                   </DiffButton>

--- a/src/components/organisms/ClustersPane/ClustersPane.tsx
+++ b/src/components/organisms/ClustersPane/ClustersPane.tsx
@@ -13,6 +13,7 @@ import {BrowseKubeconfigTooltip, ClusterModeTooltip} from '@constants/tooltips';
 import {TOOLTIP_DELAY} from '@constants/constants';
 import {closeFolderExplorer} from '@redux/reducers/ui';
 import {loadContexts} from '@redux/thunks/loadKubeConfig';
+import {useDebounce} from 'react-use';
 
 const StyledDiv = styled.div`
   margin-bottom: 10px;
@@ -111,12 +112,15 @@ const ClustersPane = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uiState]);
 
-  useEffect(() => {
-    if (kubeconfig) {
-      dispatch(loadContexts(kubeconfig));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [kubeconfig]);
+  useDebounce(
+    () => {
+      if (kubeconfig) {
+        dispatch(loadContexts(kubeconfig));
+      }
+    },
+    2000,
+    [kubeconfig]
+  );
 
   return (
     <>

--- a/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
@@ -60,9 +60,10 @@ const SettingsDrawer = () => {
 
   const resourceRefsProcessingOptions = useAppSelector(state => state.main.resourceRefsProcessingOptions);
   const appConfig = useAppSelector(state => state.config);
+  const kubeconfig = useAppSelector(state => state.config.kubeconfigPath);
   const folderReadsMaxDepth = useAppSelector(state => state.config.folderReadsMaxDepth);
   const [currentFolderReadsMaxDepth, setCurrentFolderReadsMaxDepth] = useState<number>(5);
-
+  const [currentKubeConfig, setCurrentKubeConfig] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -121,9 +122,23 @@ const SettingsDrawer = () => {
     fileInput && fileInput.current?.click();
   };
 
+  useEffect(() => {
+    setCurrentKubeConfig(kubeconfig);
+  }, [kubeconfig]);
+
+  useDebounce(
+    () => {
+      if (currentKubeConfig !== kubeconfig) {
+        dispatch(updateKubeconfig(currentKubeConfig));
+      }
+    },
+    1000,
+    [currentKubeConfig]
+  );
+
   const onUpdateKubeconfig = (e: any) => {
     let value = e.target.value;
-    dispatch(updateKubeconfig(value));
+    setCurrentKubeConfig(value);
   };
 
   const onSelectFile = (e: React.SyntheticEvent) => {
@@ -158,7 +173,7 @@ const SettingsDrawer = () => {
       <StyledDiv>
         <StyledSpan>KUBECONFIG</StyledSpan>
         <Tooltip title={KubeconfigPathTooltip}>
-          <Input value={appConfig.kubeconfigPath} onChange={onUpdateKubeconfig} />
+          <Input value={currentKubeConfig} onChange={onUpdateKubeconfig} />
         </Tooltip>
         <StyledButton onClick={openFileSelect}>Browse</StyledButton>
         <HiddenInput type="file" onChange={onSelectFile} ref={fileInput} />

--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -2,7 +2,6 @@ import {createSlice, Draft, PayloadAction, createAsyncThunk} from '@reduxjs/tool
 import {AppConfig, Themes, TextSizes, Languages, NewVersionCode} from '@models/appconfig';
 import electronStore from '@utils/electronStore';
 import {loadContexts} from '@redux/thunks/loadKubeConfig';
-import {monitorKubeConfig} from '@redux/services/kubeConfigMonitor';
 import {KubeConfig} from '@models/kubeConfig';
 import {KustomizeCommandType} from '@redux/services/kustomize';
 import initialState from '../initialState';
@@ -16,7 +15,7 @@ export const updateStartupModalVisible = createAsyncThunk(
 );
 
 export const updateKubeconfig = createAsyncThunk('config/updateKubeconfig', async (kubeconfig: string, thunkAPI) => {
-  monitorKubeConfig(kubeconfig, thunkAPI.dispatch);
+  // monitorKubeConfig(kubeconfig, thunkAPI.dispatch);
   electronStore.set('appConfig.kubeconfig', kubeconfig);
   thunkAPI.dispatch(configSlice.actions.setKubeconfig(kubeconfig));
 });

--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -4,6 +4,7 @@ import electronStore from '@utils/electronStore';
 import {loadContexts} from '@redux/thunks/loadKubeConfig';
 import {KubeConfig} from '@models/kubeConfig';
 import {KustomizeCommandType} from '@redux/services/kustomize';
+import {monitorKubeConfig} from '@redux/services/kubeConfigMonitor';
 import initialState from '../initialState';
 
 export const updateStartupModalVisible = createAsyncThunk(
@@ -15,7 +16,7 @@ export const updateStartupModalVisible = createAsyncThunk(
 );
 
 export const updateKubeconfig = createAsyncThunk('config/updateKubeconfig', async (kubeconfig: string, thunkAPI) => {
-  // monitorKubeConfig(kubeconfig, thunkAPI.dispatch);
+  monitorKubeConfig(kubeconfig, thunkAPI.dispatch);
   electronStore.set('appConfig.kubeconfig', kubeconfig);
   thunkAPI.dispatch(configSlice.actions.setKubeconfig(kubeconfig));
 });

--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -38,6 +38,14 @@ export function isKustomizationResource(r: K8sResource | undefined) {
 }
 
 /**
+ * Checks if the specified resource is a kustomization patch
+ */
+
+export function isKustomizationPatch(r: K8sResource) {
+  return r.name.startsWith('Patch: ');
+}
+
+/**
  * Checks if the specified fileEntry is a kustomization file
  */
 

--- a/src/redux/thunks/loadKubeConfig.ts
+++ b/src/redux/thunks/loadKubeConfig.ts
@@ -12,22 +12,26 @@ export const loadContexts = createAsyncThunk<
     dispatch: AppDispatch;
     state: RootState;
   }
->('main/loadContexts', (configPath: string, thunkAPI: any) => {
-  const stats = fs.statSync(configPath);
+>('main/loadContexts', async (configPath: string, thunkAPI: any) => {
+  try {
+    const stats = await fs.promises.stat(configPath);
 
-  if (stats.isFile()) {
-    try {
-      const kc = new k8s.KubeConfig();
-      kc.loadFromFile(configPath);
+    if (stats.isFile()) {
+      try {
+        const kc = new k8s.KubeConfig();
+        kc.loadFromFile(configPath);
 
-      const kubeConfig: KubeConfig = {
-        contexts: <Array<KubeConfigContext>>kc.contexts,
-        currentContext: kc.currentContext,
-      };
-      return kubeConfig;
-    } catch (e: any) {
-      return createRejectionWithAlert(thunkAPI, 'Loading kube config file failed', e.message);
+        const kubeConfig: KubeConfig = {
+          contexts: <Array<KubeConfigContext>>kc.contexts,
+          currentContext: kc.currentContext,
+        };
+        return kubeConfig;
+      } catch (e: any) {
+        return createRejectionWithAlert(thunkAPI, 'Loading kubeconfig file failed', e.message);
+      }
     }
+  } catch (e) {
+    //
   }
 
   return thunkAPI.reject();


### PR DESCRIPTION
This PR adds a debounce to the kubeconfig input fields and makes context loading and monitoring async

## Changes

-

## Fixes

#567 

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
