### PR TITLE
fix: changed helm/kustomize commands to run in default folder

### DIFF
--- a/electron/commands.ts
+++ b/electron/commands.ts
@@ -14,8 +14,7 @@ import {KustomizeCommandType} from '@redux/services/kustomize';
 export const runKustomize = (folder: string, kustomizeCommand: KustomizeCommandType, event: Electron.IpcMainEvent) => {
   try {
     let cmd = kustomizeCommand === 'kubectl' ? 'kubectl kustomize' : 'kustomize build ';
-    let stdout = execSync(`${cmd} .`, {
-      cwd: folder,
+    let stdout = execSync(`${cmd} ${folder}`, {
       env: {
         NODE_ENV: PROCESS_ENV.NODE_ENV,
         PUBLIC_URL: PROCESS_ENV.PUBLIC_URL,
@@ -59,7 +58,6 @@ export const selectFile = (event: Electron.IpcMainInvokeEvent, options: any) => 
 export const runHelm = (args: any, event: Electron.IpcMainEvent) => {
   try {
     let stdout = execSync(args.helmCommand, {
-      cwd: args.cwd,
       env: {
         NODE_ENV: PROCESS_ENV.NODE_ENV,
         PUBLIC_URL: PROCESS_ENV.PUBLIC_URL,

--- a/src/redux/thunks/previewHelmValuesFile.ts
+++ b/src/redux/thunks/previewHelmValuesFile.ts
@@ -37,9 +37,8 @@ export const previewHelmValuesFile = createAsyncThunk<
       const args = {
         helmCommand:
           configState.settings.helmPreviewMode === 'template'
-            ? `helm template -f ${valuesFile.name} ${chart.name} .`
-            : `helm install -f ${valuesFile.name} ${chart.name} . --dry-run`,
-        cwd: folder,
+            ? `helm template -f ${folder}${path.sep}${valuesFile.name} ${chart.name} ${folder}`
+            : `helm install -f ${folder}${path.sep}${valuesFile.name} ${chart.name} ${folder} --dry-run`,
         kubeconfig,
       };
 


### PR DESCRIPTION
This PR...

## Changes

- instead of attempting to run kustomize/helm in the root folder of a helm chart or kustomization it will run commands in the default folder and pass the path to those folders as arguments. 

## Fixes

- #521 - run commands for files on network shares on Windows

## How to test it

- load manifests from a windows share and attempt to preview contained kustomizations or helm charts

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
