### PR TITLE
feat: disabled editing of kubeconfig and/or current context if the user is in cluster mode

### DIFF
--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -7,7 +7,7 @@ import {Collapse, Kubernetes} from './Icons';
 
 type IconProps = {
   name: string;
-  color?: Colors;
+  color?: Colors | '';
 };
 
 type IconsHashTable = {
@@ -20,7 +20,7 @@ const icons: IconsHashTable = {
 };
 
 const Icon: React.FC<IconProps> = props => {
-  const {name, color = Colors.whitePure} = props;
+  const {name, color = ''} = props;
 
   return <AntdIcon component={icons[name]} style={{color}} />;
 };

--- a/src/components/molecules/FilePatternList/FilePatternList.tsx
+++ b/src/components/molecules/FilePatternList/FilePatternList.tsx
@@ -1,7 +1,6 @@
-import React, {useState, useEffect} from 'react';
-import styled from 'styled-components';
-
 import {Button, Input, Tooltip} from 'antd';
+import {useEffect, useState} from 'react';
+import styled from 'styled-components';
 
 import {useFocus} from '@utils/hooks';
 
@@ -11,6 +10,7 @@ type FilePatternListProps = {
   value: string[];
   onChange: (patterns: string[]) => void;
   tooltip: string;
+  isSettingsOpened?: boolean;
 };
 
 const StyledUl = styled.ul`
@@ -24,7 +24,8 @@ const StyledButton = styled(Button)`
 `;
 
 const FilePatternList = (props: FilePatternListProps) => {
-  const {value, onChange, tooltip} = props;
+  const {value, onChange, tooltip, isSettingsOpened} = props;
+
   const [isAddingPattern, setIsAddingPattern] = useState<Boolean>(false);
   const [patternInput, setPatternInput] = useState<string>('');
   const [inputRef, focusInput] = useFocus<Input>();
@@ -64,6 +65,13 @@ const FilePatternList = (props: FilePatternListProps) => {
     }
   }, [isAddingPattern, focusInput]);
 
+  useEffect(() => {
+    if (!isSettingsOpened) {
+      setIsAddingPattern(false);
+      setPatternInput('');
+    }
+  }, [isSettingsOpened]);
+
   return (
     <div>
       <StyledUl>
@@ -77,7 +85,6 @@ const FilePatternList = (props: FilePatternListProps) => {
           />
         ))}
       </StyledUl>
-
       {isAddingPattern ? (
         <>
           <Input

--- a/src/components/molecules/FilePatternList/FilePatternListItem.tsx
+++ b/src/components/molecules/FilePatternList/FilePatternListItem.tsx
@@ -1,11 +1,10 @@
-import React, {useState, useEffect} from 'react';
-
+import {Button, Input} from 'antd';
+import {useEffect, useState} from 'react';
 import styled from 'styled-components';
 
-import {useFocus} from '@utils/hooks';
+import {DeleteOutlined, EditOutlined} from '@ant-design/icons';
 
-import {Input, Button} from 'antd';
-import {EditOutlined, DeleteOutlined} from '@ant-design/icons';
+import {useFocus} from '@utils/hooks';
 
 type FilePatternListItemProps = {
   pattern: string;
@@ -38,7 +37,6 @@ const FilePatternListItem = (props: FilePatternListItemProps) => {
 
   const [isEditing, setIsEditing] = useState<Boolean>(false);
   const [isHovered, setIsHovered] = useState<Boolean>(false);
-
   const [patternInput, setPatternInput] = useState<string>(pattern);
 
   const [inputRef, focusInput] = useFocus<Input>();

--- a/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
+++ b/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
@@ -20,6 +20,7 @@ const Container = styled.div`
   margin: 0;
   padding: 0;
   height: 70vh;
+  overflow: auto;
 `;
 
 const SkeletonContainer = styled.div`

--- a/src/components/organisms/ClustersPane/ClustersPane.tsx
+++ b/src/components/organisms/ClustersPane/ClustersPane.tsx
@@ -1,28 +1,38 @@
-import React, {useRef, useCallback, useEffect, useState} from 'react';
-import {Button, Col, Input, Row, Tooltip, Select} from 'antd';
-import styled from 'styled-components';
+import {Button, Col, Input, Row, Select, Tooltip} from 'antd';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useSelector} from 'react-redux';
-import {isInPreviewModeSelector, isInClusterModeSelector} from '@redux/selectors';
-
-import {BackgroundColors} from '@styles/Colors';
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {MonoPaneTitle, MonoPaneTitleCol, PaneContainer} from '@atoms';
-import {startPreview, stopPreview, restartPreview} from '@redux/services/preview';
-import {setCurrentContext, updateKubeconfig} from '@redux/reducers/appConfig';
-import {BrowseKubeconfigTooltip, ClusterModeTooltip} from '@constants/tooltips';
-import {TOOLTIP_DELAY} from '@constants/constants';
-import {closeFolderExplorer} from '@redux/reducers/ui';
 import {useDebounce} from 'react-use';
+import styled from 'styled-components';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {setCurrentContext, updateKubeconfig} from '@redux/reducers/appConfig';
+import {closeFolderExplorer} from '@redux/reducers/ui';
+import {isInClusterModeSelector, isInPreviewModeSelector} from '@redux/selectors';
+import {restartPreview, startPreview, stopPreview} from '@redux/services/preview';
 import {loadContexts} from '@redux/thunks/loadKubeConfig';
 
+import {MonoPaneTitle, MonoPaneTitleCol, PaneContainer} from '@atoms';
+
+import {TOOLTIP_DELAY} from '@constants/constants';
+import {BrowseKubeconfigTooltip, ClusterModeTooltip} from '@constants/tooltips';
+
+import {BackgroundColors} from '@styles/Colors';
+
 const StyledDiv = styled.div`
-  margin-bottom: 10px;
+  margin-bottom: 20px;
   margin-top: 10px;
+
+  .ant-input {
+    margin-bottom: 15px;
+  }
 `;
 
-const StyledButton = styled(Button)`
-  margin-top: 10px;
+const StyledHeading = styled.h2`
+  font-size: 16px;
+  margin-bottom: 7px;
 `;
+
+const StyledButton = styled(Button)``;
 
 const StyledSelect = styled(Select)`
   width: 100%;
@@ -45,6 +55,7 @@ const ClustersContainer = styled.div`
 
 const ClustersPane = () => {
   const dispatch = useAppDispatch();
+
   const previewResource = useAppSelector(state => state.main.previewResourceId);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
   const isInClusterMode = useSelector(isInClusterModeSelector);
@@ -53,9 +64,11 @@ const ClustersPane = () => {
   const kubeconfig = useAppSelector(state => state.config.kubeconfigPath);
   const kubeConfig = useAppSelector(state => state.config.kubeConfig);
   const uiState = useAppSelector(state => state.ui);
-  const [currentKubeConfig, setCurrentKubeConfig] = useState<string>('');
 
+  const [currentKubeConfig, setCurrentKubeConfig] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
+
+  const isEditingDisabled = uiState.isClusterDiffVisible;
 
   useEffect(() => {
     setCurrentKubeConfig(kubeconfig);
@@ -72,11 +85,17 @@ const ClustersPane = () => {
   );
 
   const openFileSelect = () => {
+    if (isEditingDisabled) {
+      return;
+    }
     fileInput && fileInput.current?.click();
   };
 
   const onSelectFile = (e: React.SyntheticEvent) => {
     e.preventDefault();
+    if (isEditingDisabled) {
+      return;
+    }
     if (fileInput.current?.files && fileInput.current.files.length > 0) {
       const file: any = fileInput.current.files[0];
       if (file.path) {
@@ -87,6 +106,9 @@ const ClustersPane = () => {
   };
 
   const onUpdateKubeconfig = (e: any) => {
+    if (isEditingDisabled) {
+      return;
+    }
     let value = e.target.value;
     setCurrentKubeConfig(value);
   };
@@ -106,6 +128,9 @@ const ClustersPane = () => {
   };
 
   const handleContextChange = (context: any) => {
+    if (isEditingDisabled) {
+      return;
+    }
     dispatch(setCurrentContext(context));
   };
 
@@ -146,38 +171,40 @@ const ClustersPane = () => {
       </TitleRow>
       <PaneContainer>
         <ClustersContainer>
-          <StyledDiv>KUBECONFIG</StyledDiv>
-          <Input value={currentKubeConfig} onChange={onUpdateKubeconfig} />
-          <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={BrowseKubeconfigTooltip} placement="right">
-            <StyledButton ghost type="primary" onClick={openFileSelect}>
-              Browse
-            </StyledButton>
-          </Tooltip>
-          <HiddenInput type="file" onChange={onSelectFile} ref={fileInput} />
-          <StyledDiv>Select to retrieve resources from configured kubeconfig</StyledDiv>
-
           <StyledDiv>
+            <StyledHeading>KUBECONFIG</StyledHeading>
+            <Input value={currentKubeConfig} onChange={onUpdateKubeconfig} disabled={isEditingDisabled} />
+            <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={BrowseKubeconfigTooltip} placement="right">
+              <StyledButton ghost type="primary" onClick={openFileSelect} disabled={isEditingDisabled}>
+                Browse
+              </StyledButton>
+            </Tooltip>
+          </StyledDiv>
+          <StyledDiv>
+            <HiddenInput type="file" onChange={onSelectFile} ref={fileInput} />
+            <StyledHeading>Select to retrieve resources from configured kubeconfig</StyledHeading>
             <StyledSelect
               placeholder="Select a context"
-              disabled={previewType === 'cluster' && previewLoader.isLoading}
+              disabled={(previewType === 'cluster' && previewLoader.isLoading) || isEditingDisabled}
               value={kubeConfig.currentContext}
               options={kubeConfig.contexts.map(context => ({label: context.name, value: context.cluster}))}
               onChange={handleContextChange}
             />
           </StyledDiv>
-
-          <StyledDiv>Select to retrieve resources from selected context</StyledDiv>
-
-          <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ClusterModeTooltip} placement="right">
-            <StyledButton
-              type="primary"
-              ghost
-              loading={previewType === 'cluster' && previewLoader.isLoading}
-              onClick={isInClusterMode ? reconnectToCluster : connectToCluster}
-            >
-              {createClusterObjectsLabel()}
-            </StyledButton>
-          </Tooltip>
+          <StyledDiv>
+            <StyledHeading>Select to retrieve resources from selected context</StyledHeading>
+            <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ClusterModeTooltip} placement="right">
+              <StyledButton
+                type="primary"
+                ghost
+                loading={previewType === 'cluster' && previewLoader.isLoading}
+                onClick={isInClusterMode ? reconnectToCluster : connectToCluster}
+                disabled={isEditingDisabled}
+              >
+                {createClusterObjectsLabel()}
+              </StyledButton>
+            </Tooltip>
+          </StyledDiv>
         </ClustersContainer>
       </PaneContainer>
     </>

--- a/src/components/organisms/ClustersPane/ClustersPane.tsx
+++ b/src/components/organisms/ClustersPane/ClustersPane.tsx
@@ -68,7 +68,7 @@ const ClustersPane = () => {
   const [currentKubeConfig, setCurrentKubeConfig] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
 
-  const isEditingDisabled = uiState.isClusterDiffVisible;
+  const isEditingDisabled = uiState.isClusterDiffVisible || isInClusterMode;
 
   useEffect(() => {
     setCurrentKubeConfig(kubeconfig);
@@ -199,7 +199,6 @@ const ClustersPane = () => {
                 ghost
                 loading={previewType === 'cluster' && previewLoader.isLoading}
                 onClick={isInClusterMode ? reconnectToCluster : connectToCluster}
-                disabled={isEditingDisabled}
               >
                 {createClusterObjectsLabel()}
               </StyledButton>

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -230,7 +230,9 @@ const BrowseButton = styled(Button)``;
 const FileTreePane = () => {
   const {windowSize} = useContext(AppContext);
   const windowHeight = windowSize.height;
+
   const dispatch = useAppDispatch();
+
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const uiState = useAppSelector(state => state.ui);
@@ -248,6 +250,8 @@ const FileTreePane = () => {
   const [highlightNode, setHighlightNode] = React.useState<TreeNode>();
   const [autoExpandParent, setAutoExpandParent] = React.useState(true);
   const treeRef = React.useRef<any>();
+
+  const isButtonDisabled = !fileMap[ROOT_FILE_ENTRY];
 
   const {openFileExplorer, fileExplorerProps} = useFileExplorer(
     ({folderPath}) => {
@@ -439,17 +443,17 @@ const FileTreePane = () => {
                     icon={<ReloadOutlined />}
                     type="primary"
                     ghost
-                    disabled={!fileMap[ROOT_FILE_ENTRY]}
+                    disabled={isButtonDisabled}
                   />
                 </Tooltip>
                 <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ToggleTreeTooltip}>
                   <Button
-                    icon={<Icon name="collapse" color={Colors.blue6} />}
+                    icon={<Icon name="collapse" color={isButtonDisabled ? '' : Colors.blue6} />}
                     onClick={onToggleTree}
                     type="primary"
                     ghost
                     size="small"
-                    disabled={!fileMap[ROOT_FILE_ENTRY]}
+                    disabled={isButtonDisabled}
                   />
                 </Tooltip>
               </RightButtons>

--- a/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
@@ -16,6 +16,7 @@ import {
 } from '@redux/reducers/appConfig';
 import {updateShouldOptionalIgnoreUnsatisfiedRefs} from '@redux/reducers/main';
 import {toggleSettings} from '@redux/reducers/ui';
+import {isInClusterModeSelector} from '@redux/selectors';
 
 // import {Themes, TextSizes, Languages} from '@models/appconfig';
 import FilePatternList from '@molecules/FilePatternList';
@@ -63,11 +64,12 @@ const SettingsDrawer = () => {
   const uiState = useAppSelector(state => state.ui);
   const kubeconfig = useAppSelector(state => state.config.kubeconfigPath);
   const folderReadsMaxDepth = useAppSelector(state => state.config.folderReadsMaxDepth);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const [currentFolderReadsMaxDepth, setCurrentFolderReadsMaxDepth] = useState<number>(5);
   const [currentKubeConfig, setCurrentKubeConfig] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
 
-  const isEditingDisabled = uiState.isClusterDiffVisible;
+  const isEditingDisabled = uiState.isClusterDiffVisible || isInClusterMode;
 
   useEffect(() => {
     setCurrentFolderReadsMaxDepth(folderReadsMaxDepth);


### PR DESCRIPTION
This PR...

## Changes

- Disabled editing of kubeconfig and/or current context if the user is in cluster mode.

## Fixes

- Fixed bug when the user could input some text in the File Pattern input in the Settings Drawer if he opened the Settings Drawer, pressed on the Add File Pattern button, and closed the Settings Drawer.

- Fixed styling of Clusters Pane.