### PR TITLE
feat: logic to customize empty sections in navigator

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -1,8 +1,12 @@
 import React, {useCallback, useEffect, useMemo} from 'react';
-import {ItemGroupInstance, SectionBlueprint, SectionInstance} from '@models/navigator';
+
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import navSectionMap from '@src/navsections/sectionBlueprintMap';
 import {collapseSectionIds, expandSectionIds} from '@redux/reducers/navigator';
+
+import {ItemGroupInstance, SectionBlueprint, SectionInstance} from '@models/navigator';
+
+import navSectionMap from '@src/navsections/sectionBlueprintMap';
+
 import ItemRenderer, {ItemRendererOptions} from './ItemRenderer';
 import SectionHeader from './SectionHeader';
 import * as S from './styled';
@@ -26,7 +30,7 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
 
   const dispatch = useAppDispatch();
 
-  const {NameDisplay} = useSectionCustomization(sectionBlueprint.customization);
+  const {NameDisplay, EmptyDisplay} = useSectionCustomization(sectionBlueprint.customization);
 
   const collapsedSectionIds = useAppSelector(state => state.navigator.collapsedSectionIds);
 
@@ -135,6 +139,22 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
 
   if (sectionInstance?.isLoading) {
     return <S.Skeleton />;
+  }
+
+  if (sectionInstance?.isEmpty) {
+    if (EmptyDisplay && EmptyDisplay.Component) {
+      return (
+        <S.EmptyDisplayContainer level={level}>
+          <EmptyDisplay.Component sectionInstance={sectionInstance} />
+        </S.EmptyDisplayContainer>
+      );
+    }
+    return (
+      <S.EmptyDisplayContainer level={level}>
+        <h1>{sectionBlueprint.name}</h1>
+        <p>Section is empty.</p>
+      </S.EmptyDisplayContainer>
+    );
   }
 
   return (

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -1,7 +1,9 @@
-import Colors, {FontColors} from '@styles/Colors';
-import styled from 'styled-components';
 import {Skeleton as RawSkeleton} from 'antd';
+import styled from 'styled-components';
+
 import {PlusSquareOutlined as RawPlusSquareOutlined} from '@ant-design/icons';
+
+import Colors, {FontColors} from '@styles/Colors';
 
 type NameContainerProps = {
   isSelected?: boolean;
@@ -101,4 +103,10 @@ export const ItemsLength = styled.span`
   margin-left: 8px;
   color: ${FontColors.grey};
   font-size: 14px;
+`;
+
+export const EmptyDisplayContainer = styled.div<{level: number}>`
+  margin-left: ${props => {
+    return `${16 + 8 * props.level}px`;
+  }};
 `;

--- a/src/components/molecules/SectionRenderer/useSectionCustomization.ts
+++ b/src/components/molecules/SectionRenderer/useSectionCustomization.ts
@@ -1,8 +1,13 @@
 import {useMemo} from 'react';
+
 import {SectionCustomization} from '@models/navigator';
 
 export function useSectionCustomization(customization: SectionCustomization = {}) {
   const NameDisplay = useMemo(() => ({Component: customization.nameDisplay?.component}), [customization.nameDisplay]);
+  const EmptyDisplay = useMemo(
+    () => ({Component: customization.emptyDisplay?.component}),
+    [customization.emptyDisplay]
+  );
 
-  return {NameDisplay};
+  return {NameDisplay, EmptyDisplay};
 }

--- a/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
+++ b/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
@@ -173,7 +173,7 @@ function ClusterDiffModal() {
         <>
           <span onClick={closeResourceDiff} style={{cursor: 'pointer'}}>
             <ArrowLeftOutlined style={{marginRight: 8}} />
-            Back to Cluster Comparison
+            Back to Cluster Compare
           </span>
         </>
       );

--- a/src/components/organisms/NavigatorPane/ClusterComparisonButton.tsx
+++ b/src/components/organisms/NavigatorPane/ClusterComparisonButton.tsx
@@ -49,7 +49,7 @@ function ClusterComparisonButton() {
         style={{marginLeft: 8}}
         disabled={!isFolderOpen || isInClusterMode}
       >
-        {Number(navWidth.toFixed(2)) < 0.3 ? '' : 'Cluster Comparison'}
+        {Number(navWidth.toFixed(2)) < 0.3 ? '' : 'Cluster Compare'}
       </Button>
     </Tooltip>
   );

--- a/src/constants/tooltips.ts
+++ b/src/constants/tooltips.ts
@@ -7,9 +7,9 @@ export const FileExplorerTooltip = 'Show/hide File Exlorer';
 export const ClusterExplorerTooltip = 'Show/hide Cluster Preview';
 export const PluginManagerTooltip = 'Show/hide Plugin Manager';
 export const ClusterDiffTooltip = 'Compare your local resources with resources in your configured cluster';
-export const ClusterDiffDisabledTooltip = 'Browse for a folder to enable the Cluster Comparison';
+export const ClusterDiffDisabledTooltip = 'Browse for a folder to enable the Cluster Compare';
 export const ClusterDiffDisabledInClusterPreviewTooltip =
-  'Cluster Comparison is disabled while previewing Cluster resources';
+  'Cluster Compare is disabled while previewing Cluster resources';
 export const BrowseKubeconfigTooltip = 'Browse for kubeconfig file';
 export const ClusterModeTooltip = `Retrieve and show resources in selected context (${KEY_CTRL_CMD}+I)`;
 export const KustomizationPreviewTooltip = 'Preview the output of this Kustomize file';

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -1,5 +1,6 @@
-import {AppDispatch, RootState} from '@redux/store';
 import React from 'react';
+
+import {AppDispatch, RootState} from '@redux/store';
 
 export type ItemCustomComponentProps = {
   itemInstance: ItemInstance;
@@ -46,6 +47,9 @@ export interface SectionCustomization {
   nameDisplay?: {
     component: SectionCustomComponent;
   };
+  emptyDisplay?: {
+    component: SectionCustomComponent;
+  };
   disableHoverStyle?: boolean;
 }
 
@@ -85,6 +89,7 @@ export interface SectionBlueprint<RawItemType, ScopeType = any> {
     isLoading?: (scope: ScopeType, items: RawItemType[]) => boolean;
     isVisible?: (scope: ScopeType, items: RawItemType[]) => boolean;
     isInitialized?: (scope: ScopeType, items: RawItemType[]) => boolean;
+    isEmpty?: (scope: ScopeType, items: RawItemType[]) => boolean;
     shouldBeVisibleBeforeInitialized?: boolean;
   };
   customization?: SectionCustomization;
@@ -121,6 +126,7 @@ export interface SectionInstance {
   isInitialized: boolean;
   isSelected: boolean;
   isHighlighted: boolean;
+  isEmpty: boolean;
   shouldExpand: boolean;
 }
 

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
@@ -1,10 +1,14 @@
-import navSectionNames from '@constants/navSectionNames';
 import {K8sResource} from '@models/k8sresource';
-import {ResourceKindHandlers} from '@src/kindhandlers';
-import {ResourceKindHandler} from '@models/resourcekindhandler';
-import sectionBlueprintMap from '@src/navsections/sectionBlueprintMap';
 import {SectionBlueprint} from '@models/navigator';
-import {PREVIEW_PREFIX} from '@constants/constants';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+import {PREVIEW_PREFIX, ROOT_FILE_ENTRY} from '@constants/constants';
+import navSectionNames from '@constants/navSectionNames';
+
+import {ResourceKindHandlers} from '@src/kindhandlers';
+import sectionBlueprintMap from '@src/navsections/sectionBlueprintMap';
+
+import K8sResourceSectionEmptyDisplay from './K8sResourceSectionEmptyDisplay';
 import {makeResourceKindNavSection} from './ResourceKindSectionBlueprint';
 
 const childSectionNames = navSectionNames.representation[navSectionNames.K8S_RESOURCES];
@@ -25,6 +29,7 @@ ResourceKindHandlers.forEach(kindHandler => {
 
 export type K8sResourceScopeType = {
   isFolderLoading: boolean;
+  isFolderOpen: boolean;
   isPreviewLoading: boolean;
   activeResourcesLength: number;
 };
@@ -67,6 +72,7 @@ const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScop
   getScope: state => {
     return {
       isFolderLoading: state.ui.isFolderLoading,
+      isFolderOpen: Boolean(state.main.fileMap[ROOT_FILE_ENTRY]),
       isPreviewLoading: state.main.previewLoader.isLoading,
       activeResourcesLength: Object.values(state.main.resourceMap).filter(
         r =>
@@ -82,7 +88,15 @@ const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScop
     isInitialized: scope => {
       return scope.activeResourcesLength > 0;
     },
+    isEmpty: scope => {
+      return scope.isFolderOpen && scope.activeResourcesLength === 0;
+    },
     shouldBeVisibleBeforeInitialized: true,
+  },
+  customization: {
+    emptyDisplay: {
+      component: K8sResourceSectionEmptyDisplay,
+    },
   },
 };
 

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function K8sResourceSectionEmptyDisplay() {
+  return (
+    <>
+      <h1>K8s Resources</h1>
+      <p>No resources found in the current folder.</p>
+    </>
+  );
+}
+
+export default K8sResourceSectionEmptyDisplay;

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -1,9 +1,12 @@
+import asyncLib from 'async';
 import {shallowEqual} from 'react-redux';
 import {Middleware} from 'redux';
+
 import {collapseSectionIds, expandSectionIds, updateNavigatorInstanceState} from '@redux/reducers/navigator';
-import {ItemInstance, NavigatorInstanceState, SectionInstance} from '@models/navigator';
 import {AppDispatch, RootState} from '@redux/store';
-import asyncLib from 'async';
+
+import {ItemInstance, NavigatorInstanceState, SectionInstance} from '@models/navigator';
+
 import sectionBlueprintMap from './sectionBlueprintMap';
 
 const fullScopeCache: Record<string, any> = {};
@@ -202,6 +205,7 @@ const processSectionBlueprints = (state: RootState, dispatch: AppDispatch) => {
       isInitialized: isSectionInitialized,
       isSelected: isSectionSelected,
       isHighlighted: isSectionHighlighted,
+      isEmpty: Boolean(sectionBuilder?.isEmpty ? sectionBuilder.isEmpty(sectionScope, rawItems) : false),
       shouldExpand: Boolean(
         itemInstances?.some(itemInstance => itemInstance.isVisible && itemInstance.shouldScrollIntoView)
       ),

--- a/src/redux/thunks/loadClusterDiff.ts
+++ b/src/redux/thunks/loadClusterDiff.ts
@@ -15,7 +15,7 @@ export type LoadClusterDiffPayload = {
   alert?: AlertType;
 };
 
-const CLUSTER_DIFF_FAILED = 'Cluster Comparison Failed';
+const CLUSTER_DIFF_FAILED = 'Cluster Compare Failed';
 
 export const loadClusterDiff = createAsyncThunk<
   LoadClusterDiffPayload,


### PR DESCRIPTION
This PR...

## Changes

- add isEmpty method to the section builder
- allow sections to provide a React component to render when a section is empty

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/141292304-58302543-d9b9-43ab-ac35-0cd0288d15a3.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
