### PR TITLE
fix: monaco undo history by resetting the modal + remove focused state

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -79,7 +79,6 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const hiddenInputRef = useRef<HTMLInputElement>(null);
   const [editor, setEditor] = useState(editorRef.current);
-  const [editingResourceId, setEditingResourceId] = useState<string | undefined>(undefined);
 
   const selectResource = (resourceId: string) => {
     if (resourceMap[resourceId]) {
@@ -113,7 +112,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     selectedPath,
     setOrgCode
   );
-  const {onEditorFocus} = useMonacoUiState(editor, selectedResourceId, selectedPath);
+  useMonacoUiState(editor, selectedResourceId, selectedPath);
 
   const onDidChangeMarkers = (e: monaco.Uri[]) => {
     const flag = monaco.editor.getModelMarkers({}).length > 0;
@@ -127,7 +126,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
   const editorDidMount = (e: monaco.editor.IStandaloneCodeEditor) => {
     registerStaticActions(e);
 
-    e.onDidFocusEditorText(onEditorFocus);
+    // e.onDidFocusEditorText(onEditorFocus);
 
     editorRef.current = e as monaco.editor.IStandaloneCodeEditor;
     setEditor(e);
@@ -164,6 +163,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
       const resource = resourceMap[selectedResourceId];
       if (resource) {
         newCode = resource.text;
+        editor?.setModel(monaco.editor.createModel(newCode, 'yaml'));
       }
     } else if (selectedPath && selectedPath !== fileMap[ROOT_FILE_ENTRY].filePath) {
       const filePath = path.join(fileMap[ROOT_FILE_ENTRY].filePath, selectedPath);
@@ -172,14 +172,12 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
       }
     }
 
-    if (!editingResourceId || selectedResourceId !== editingResourceId) {
-      setCode(newCode);
-      setOrgCode(newCode);
-      setDirty(false);
-      setEditingResourceId(selectedResourceId);
-    }
+    setCode(newCode);
+    setOrgCode(newCode);
+    setDirty(false);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fileMap, selectedPath, selectedResourceId, resourceMap]);
+  }, [selectedPath, selectedResourceId]);
 
   useEffect(() => {
     if (editor) {
@@ -229,7 +227,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
       <S.HiddenInputContainer>
         <S.HiddenInput ref={hiddenInputRef} type="text" />
       </S.HiddenInputContainer>
-      {firstCodeLoadedOnEditor && editingResourceId === selectedResourceId && (
+      {firstCodeLoadedOnEditor && (
         <MonacoEditor
           width={width}
           height={editorHeight}

--- a/src/components/molecules/Monaco/useMonacoUiState.ts
+++ b/src/components/molecules/Monaco/useMonacoUiState.ts
@@ -1,7 +1,8 @@
+import {useEffect} from 'react';
+import {monaco} from 'react-monaco-editor';
+
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setMonacoEditor} from '@redux/reducers/ui';
-import {useCallback, useEffect} from 'react';
-import {monaco} from 'react-monaco-editor';
 
 function useMonacoUiState(
   editor: monaco.editor.IStandaloneCodeEditor | null,
@@ -11,24 +12,25 @@ function useMonacoUiState(
   const dispatch = useAppDispatch();
   const monacoEditor = useAppSelector(state => state.ui.monacoEditor);
 
-  const onEditorFocus = () => {
-    dispatch(setMonacoEditor({focused: true}));
-  };
+  // const onEditorFocus = () => {
+  //   dispatch(setMonacoEditor({focused: true}));
+  // };
 
-  const handleClickOutside = useCallback(() => {
-    if (editor && editor.hasTextFocus()) {
-      dispatch(setMonacoEditor({focused: true}));
-    } else {
-      dispatch(setMonacoEditor({focused: false}));
-    }
-  }, [editor, selectedResourceId]);
+  // const handleClickOutside = useCallback(() => {
+  //   if (editor && editor.hasTextFocus()) {
+  //     dispatch(setMonacoEditor({focused: true}));
+  //   } else {
+  //     dispatch(setMonacoEditor({focused: false}));
+  //   }
+  //   // eslint-disable-next-line
+  // }, [selectedResourceId]);
 
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [editor]);
+  // useEffect(() => {
+  //   document.addEventListener('mousedown', handleClickOutside);
+  //   return () => {
+  //     document.removeEventListener('mousedown', handleClickOutside);
+  //   };
+  // }, []);
 
   useEffect(() => {
     const selection = monacoEditor.selection;
@@ -43,7 +45,8 @@ function useMonacoUiState(
       editor.revealLineInCenter(selection.range.startLineNumber);
       dispatch(setMonacoEditor({selection: undefined}));
     }
-  }, [monacoEditor, selectedPath, selectedResourceId]);
+    // eslint-disable-next-line
+  }, [monacoEditor.selection, selectedPath, selectedResourceId]);
 
   useEffect(() => {
     if (!monacoEditor.focused) {
@@ -66,9 +69,10 @@ function useMonacoUiState(
       editor.trigger(null, 'editor.action.startFindReplaceAction', null);
       dispatch(setMonacoEditor({replace: false}));
     }
-  }, [monacoEditor]);
+    // eslint-disable-next-line
+  }, [monacoEditor.undo, monacoEditor.redo, monacoEditor.find, monacoEditor.replace]);
 
-  return {onEditorFocus};
+  // return {onEditorFocus};
 }
 
 export default useMonacoUiState;


### PR DESCRIPTION
This PR...

## Changes

- reset editor's undo history by creating a new TextModel when selected resource is changed
- remove the update of focused state because it causes re-renders and the editor behaves weirdly, we should find a better solution for that

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
