### PR TITLE
fix: prevent going next line on narrow widths

### DIFF
--- a/src/components/atoms/MonoPaneTitle/MonoPaneTitle.tsx
+++ b/src/components/atoms/MonoPaneTitle/MonoPaneTitle.tsx
@@ -1,6 +1,6 @@
+import {Typography} from 'antd';
 import React from 'react';
 import styled from 'styled-components';
-import {Typography} from 'antd';
 
 import {FontColors} from '@styles/Colors';
 
@@ -10,6 +10,7 @@ export type MonoSectionPaneProps = {};
 
 const MonoPaneTitle = styled((props: MonoSectionPaneProps) => <Text {...props} />)`
   &.ant-typography {
+    white-space: nowrap;
     display: block;
     margin-bottom: 0;
     padding-top: 7px;

--- a/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
+++ b/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
@@ -16,6 +16,7 @@ import Colors from '@styles/Colors';
 
 const Container = styled.span`
   width: 100%;
+  white-space: nowrap;
 `;
 
 const WarningContainer = styled.span`


### PR DESCRIPTION
This PR...

## Changes

- Add white-space: nowrap for preventing next line issue on warn icons

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
