### PR TITLE
fix: Reflect changes made in Form editor

### DIFF
--- a/src/components/molecules/FormEditor/FormEditor.tsx
+++ b/src/components/molecules/FormEditor/FormEditor.tsx
@@ -1,18 +1,19 @@
 import React, {useCallback, useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
+import {useDebounce} from 'react-use';
+import styled from 'styled-components';
+import {stringify} from 'yaml';
+
 import {useAppDispatch} from '@redux/hooks';
-import {withTheme} from '@rjsf/core';
+import {updateResource} from '@redux/reducers/main';
+import {isInPreviewModeSelector, selectedResourceSelector} from '@redux/selectors';
+import {loadResource} from '@redux/services';
+import {logMessage} from '@redux/services/log';
+import {mergeManifests} from '@redux/services/manifest-utils';
 
 // @ts-ignore
 import {Theme as AntDTheme} from '@rjsf/antd';
-import {loadResource} from '@redux/services';
-import {useDebounce} from 'react-use';
-import {updateResource} from '@redux/reducers/main';
-import {logMessage} from '@redux/services/log';
-import {stringify} from 'yaml';
-import {mergeManifests} from '@redux/services/manifest-utils';
-import styled from 'styled-components';
-import {useSelector} from 'react-redux';
-import {isInPreviewModeSelector, selectedResourceSelector} from '@redux/selectors';
+import {withTheme} from '@rjsf/core';
 import isDeepEqual from 'fast-deep-equal/es6/react';
 
 const Form = withTheme(AntDTheme);
@@ -197,7 +198,7 @@ const FormEditor = (props: {contentHeight: string}) => {
 
   useEffect(() => {
     if (selectedResource) {
-      setFormData({currFormData: selectedResource.content, orgFormData: undefined});
+      setFormData({currFormData: selectedResource.content, orgFormData: formData.orgFormData || undefined});
     }
   }, [selectedResource]);
 

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -177,7 +177,14 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     setDirty(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPath, selectedResourceId ? resourceMap[selectedResourceId] : undefined]);
+  }, [selectedPath, selectedResourceId]);
+
+  useEffect(() => {
+    if (selectedResourceId && resourceMap[selectedResourceId].text !== code) {
+      setCode(resourceMap[selectedResourceId].text);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resourceMap]);
 
   useEffect(() => {
     if (editor) {

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -177,7 +177,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     setDirty(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPath, selectedResourceId]);
+  }, [selectedPath, selectedResourceId ? resourceMap[selectedResourceId] : undefined]);
 
   useEffect(() => {
     if (editor) {

--- a/src/redux/services/fileMonitor.ts
+++ b/src/redux/services/fileMonitor.ts
@@ -1,8 +1,11 @@
-import {watch, FSWatcher} from 'chokidar';
-import {AppConfig} from '@models/appconfig';
+import {FSWatcher, watch} from 'chokidar';
+
+import {multipleFilesChanged, multiplePathsAdded, multiplePathsRemoved} from '@redux/reducers/main';
 import {AppDispatch} from '@redux/store';
+
+import {AppConfig} from '@models/appconfig';
+
 import {debounceWithPreviousArgs} from '@utils/helpers';
-import {multiplePathsAdded, multipleFilesChanged, multiplePathsRemoved} from '@redux/reducers/main';
 
 let watcher: FSWatcher;
 
@@ -20,7 +23,7 @@ export function monitorRootFolder(folder: string, appConfig: AppConfig, dispatch
     ignoreInitial: true,
     persistent: true,
     usePolling: true,
-    interval: 2000,
+    interval: 1000,
   });
 
   watcher


### PR DESCRIPTION
This PR...

## Changes

- Listen to resource changes in Manoco editor
- Don't set orgFormData to undefined whenever selectedResource changes
- Change fileMonitor interval to 1 second

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
