### PR TITLE
Navigator improvements, fixed resource filters

### DIFF
--- a/src/components/molecules/ClusterDiff/ClusterDiff.tsx
+++ b/src/components/molecules/ClusterDiff/ClusterDiff.tsx
@@ -12,7 +12,7 @@ import {ClusterToLocalResourcesMatch} from '@models/appstate';
 // import {MonoPaneTitle} from '@components/atoms';
 // import HelmChartSectionBlueprint, {HelmChartScopeType} from '@src/navsections/HelmChartSectionBlueprint';
 // import KustomizationSectionBlueprint, {KustomizationScopeType} from '@src/navsections/KustomizationSectionBlueprint';
-import {SectionRenderer} from '@components/molecules';
+import {ResourceFilterIconWithPopover, SectionRenderer} from '@components/molecules';
 
 import {ReloadOutlined} from '@ant-design/icons';
 
@@ -36,9 +36,9 @@ const LeftPane = styled.div`
   flex-grow: 1;
 `;
 
-// const FilterContainer = styled.span`
-//   margin-left: 10px;
-// `;
+const FilterContainer = styled.span`
+  margin-left: 10px;
+`;
 
 const RefreshButton = styled(Button)`
   margin-top: 1px;
@@ -74,9 +74,9 @@ function ClusterDiff() {
           <Divider type="vertical" style={{height: 40, marginLeft: 16}} />
           <S.TitleBarRightButtons>
             <ClusterDiffNamespaceFilter />
-            {/* <FilterContainer>
+            <FilterContainer>
               <ResourceFilterIconWithPopover />
-            </FilterContainer> */}
+            </FilterContainer>
           </S.TitleBarRightButtons>
         </S.TitleBar>
         <Divider style={{margin: '8px 0'}} />

--- a/src/components/molecules/ClusterDiff/ClusterDiff.tsx
+++ b/src/components/molecules/ClusterDiff/ClusterDiff.tsx
@@ -5,19 +5,12 @@ import styled from 'styled-components';
 import {useAppDispatch} from '@redux/hooks';
 import {loadClusterDiff} from '@redux/thunks/loadClusterDiff';
 
-// import {HelmValuesFile} from '@models/helm';
-// import {K8sResource} from '@models/k8sresource';
 import {ClusterToLocalResourcesMatch} from '@models/appstate';
 
-// import {MonoPaneTitle} from '@components/atoms';
-// import HelmChartSectionBlueprint, {HelmChartScopeType} from '@src/navsections/HelmChartSectionBlueprint';
-// import KustomizationSectionBlueprint, {KustomizationScopeType} from '@src/navsections/KustomizationSectionBlueprint';
 import {ResourceFilterIconWithPopover, SectionRenderer} from '@components/molecules';
 
 import {ReloadOutlined} from '@ant-design/icons';
 
-// import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
-// import AppContext from '@src/AppContext';
 import ClusterDiffSectionBlueprint, {ClusterDiffScopeType} from '@src/navsections/ClusterDiffSectionBlueprint';
 
 import * as S from './ClusterDiff.styled';
@@ -27,10 +20,6 @@ const Container = styled.div<{height?: number}>`
   display: flex;
   ${props => props.height && `height: ${props.height};`}
 `;
-
-// const RightPane = styled.div`
-//   width: 300px;
-// `;
 
 const LeftPane = styled.div`
   flex-grow: 1;
@@ -56,10 +45,6 @@ const ListContainer = styled.div`
 
 function ClusterDiff() {
   const dispatch = useAppDispatch();
-  // const {windowSize} = useContext(AppContext);
-  // const windowHeight = windowSize.height;
-  // const navigatorHeight = windowHeight - NAVIGATOR_HEIGHT_OFFSET;
-
   const onClickRefresh = () => {
     dispatch(loadClusterDiff());
   };
@@ -90,32 +75,6 @@ function ClusterDiff() {
           </S.List>
         </ListContainer>
       </LeftPane>
-      {/* <Divider type="vertical" style={{height: '100vh', margin: 0}} />
-      <RightPane>
-        <S.TitleBar>
-          <MonoPaneTitle>Navigator</MonoPaneTitle>
-        </S.TitleBar>
-        <S.List height={navigatorHeight}>
-          <SectionRenderer<HelmValuesFile, HelmChartScopeType>
-            sectionBlueprint={HelmChartSectionBlueprint}
-            level={0}
-            isLastSection={false}
-            itemRendererOptions={{
-              disablePrefix: true,
-              disableSuffix: true,
-            }}
-          />
-          <SectionRenderer<K8sResource, KustomizationScopeType>
-            sectionBlueprint={KustomizationSectionBlueprint}
-            level={0}
-            isLastSection={false}
-            itemRendererOptions={{
-              disablePrefix: true,
-              disableSuffix: true,
-            }}
-          />
-        </S.List>
-      </RightPane> */}
     </Container>
   );
 }

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -92,7 +92,7 @@ export interface SectionBlueprint<RawItemType, ScopeType = any> {
     isLoading?: (scope: ScopeType, items: RawItemType[]) => boolean;
     isVisible?: (scope: ScopeType, items: RawItemType[]) => boolean;
     isInitialized?: (scope: ScopeType, items: RawItemType[]) => boolean;
-    isEmpty?: (scope: ScopeType, items: RawItemType[]) => boolean;
+    isEmpty?: (scope: ScopeType, items: RawItemType[], itemInstances?: ItemInstance[]) => boolean;
     shouldBeVisibleBeforeInitialized?: boolean;
   };
   customization?: SectionCustomization;

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
@@ -1,7 +1,10 @@
 import {ClusterToLocalResourcesMatch, ResourceFilterType, ResourceMapType} from '@models/appstate';
 import {SectionBlueprint} from '@models/navigator';
+
 import {isResourcePassingFilter} from '@utils/resources';
+
 import sectionBlueprintMap from '../sectionBlueprintMap';
+import ClusterDiffSectionEmptyDisplay from './ClusterDiffSectionEmptyDisplay';
 import ClusterDiffSectionNameDisplay from './ClusterDiffSectionNameDisplay';
 import ResourceMatchNameDisplay from './ResourceMatchNameDisplay';
 
@@ -54,10 +57,17 @@ const ClusterDiffSectionBlueprint: SectionBlueprint<ClusterToLocalResourcesMatch
     isLoading(scope) {
       return scope.isPreviewLoading;
     },
+    isEmpty(_, __, itemInstances) {
+      const isSectionEmpty = Boolean(itemInstances && itemInstances.every(i => !i.isVisible));
+      return isSectionEmpty;
+    },
   },
   customization: {
     nameDisplay: {
       component: ClusterDiffSectionNameDisplay,
+    },
+    emptyDisplay: {
+      component: ClusterDiffSectionEmptyDisplay,
     },
     disableHoverStyle: true,
   },

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionEmptyDisplay.tsx
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionEmptyDisplay.tsx
@@ -1,0 +1,23 @@
+import React, {useMemo} from 'react';
+
+import {useAppSelector} from '@redux/hooks';
+
+function ClusterDiffSectionEmptyDisplay() {
+  const resourceFilter = useAppSelector(state => state.main.resourceFilter);
+
+  const appliedFilters = useMemo(() => {
+    return Object.entries(resourceFilter)
+      .map(([key, value]) => {
+        return {filterName: key, filterValue: value};
+      })
+      .filter(filter => filter.filterValue && Object.values(filter.filterValue).length);
+  }, [resourceFilter]);
+
+  if (appliedFilters.length === 0) {
+    return null;
+  }
+
+  return <p>No resources match the active filters.</p>;
+}
+
+export default ClusterDiffSectionEmptyDisplay;

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
 
+import {useAppSelector} from '@redux/hooks';
+import {activeResourcesSelector} from '@redux/selectors';
+
 function K8sResourceSectionEmptyDisplay() {
+  const activeResources = useAppSelector(activeResourcesSelector);
+
   return (
     <>
       <h1>K8s Resources</h1>
-      <p>No resources found in the current folder.</p>
+      {activeResources.length === 0 ? (
+        <p>No resources found in the current folder.</p>
+      ) : (
+        <p>No resources match the active filters.</p>
+      )}
     </>
   );
 }

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionNameSuffix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionNameSuffix.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {useAppSelector} from '@redux/hooks';
-import {isInPreviewModeSelector} from '@redux/selectors';
+import {isInClusterModeSelector, isInPreviewModeSelector} from '@redux/selectors';
 
 import Colors, {BackgroundColors} from '@styles/Colors';
 
@@ -19,15 +19,27 @@ const S = {
     color: ${Colors.blackPure};
     margin-bottom: 10px;
   `,
+  ClusterOutputTag: styled(Tag)`
+    font-size: 12px;
+    font-weight: 700;
+    background: ${BackgroundColors.clusterModeBackground};
+    color: ${Colors.blackPure};
+    margin-bottom: 10px;
+  `,
 };
 
 function K8sResourceSectionNameSuffix() {
   const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
 
   if (isInPreviewMode) {
     return (
       <S.Container>
-        <S.PreviewOutputTag>Preview Output</S.PreviewOutputTag>
+        {isInClusterMode ? (
+          <S.ClusterOutputTag>Cluster Preview Output</S.ClusterOutputTag>
+        ) : (
+          <S.PreviewOutputTag>Preview Output</S.PreviewOutputTag>
+        )}
       </S.Container>
     );
   }

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -88,9 +88,7 @@ function computeSectionVisibility(
     }
 
     sectionInstance.isVisible =
-      (sectionBlueprint && sectionBlueprint.customization?.emptyDisplay && sectionInstance.isEmpty) ||
-      sectionInstance.isVisible ||
-      Object.values(childSectionVisibilityMap).some(isVisible => isVisible === true);
+      sectionInstance.isVisible || Object.values(childSectionVisibilityMap).some(isVisible => isVisible === true);
   }
 
   if (sectionInstance.visibleItemIds) {
@@ -187,6 +185,9 @@ const processSectionBlueprints = (state: RootState, dispatch: AppDispatch) => {
     const isSectionInitialized = Boolean(
       sectionBuilder?.isInitialized ? sectionBuilder.isInitialized(sectionScope, rawItems) : true
     );
+    const isSectionEmpty = Boolean(
+      sectionBuilder?.isEmpty ? sectionBuilder.isEmpty(sectionScope, rawItems, itemInstances) : false
+    );
     const sectionGroups = sectionBuilder?.getGroups ? sectionBuilder.getGroups(sectionScope) : [];
     const sectionInstanceGroups = sectionGroups.map(g => ({
       ...g,
@@ -201,13 +202,14 @@ const processSectionBlueprints = (state: RootState, dispatch: AppDispatch) => {
       isLoading: Boolean(sectionBuilder?.isLoading ? sectionBuilder.isLoading(sectionScope, rawItems) : false),
       isVisible:
         Boolean(sectionBuilder?.shouldBeVisibleBeforeInitialized === true && !isSectionInitialized) ||
+        (sectionBlueprint && sectionBlueprint.customization?.emptyDisplay && isSectionEmpty) ||
         (isSectionInitialized &&
           Boolean(sectionBuilder?.isVisible ? sectionBuilder.isVisible(sectionScope, rawItems) : true) &&
           (visibleItemIds.length > 0 || visibleGroupIds.length > 0)),
       isInitialized: isSectionInitialized,
       isSelected: isSectionSelected,
       isHighlighted: isSectionHighlighted,
-      isEmpty: Boolean(sectionBuilder?.isEmpty ? sectionBuilder.isEmpty(sectionScope, rawItems) : false),
+      isEmpty: isSectionEmpty,
       shouldExpand: Boolean(
         itemInstances?.some(itemInstance => itemInstance.isVisible && itemInstance.shouldScrollIntoView)
       ),

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -88,7 +88,9 @@ function computeSectionVisibility(
     }
 
     sectionInstance.isVisible =
-      sectionInstance.isVisible || Object.values(childSectionVisibilityMap).some(isVisible => isVisible === true);
+      (sectionBlueprint && sectionBlueprint.customization?.emptyDisplay && sectionInstance.isEmpty) ||
+      sectionInstance.isVisible ||
+      Object.values(childSectionVisibilityMap).some(isVisible => isVisible === true);
   }
 
   if (sectionInstance.visibleItemIds) {

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -11,7 +11,13 @@ import {isUnsatisfiedRef} from '@redux/services/resourceRefs';
 import {AppState, FileMapType, ResourceMapType, ResourceRefsProcessingOptions} from '@models/appstate';
 import {K8sResource, RefPosition, ResourceRefType} from '@models/k8sresource';
 
-import {KUSTOMIZATION_KIND, PREVIEW_PREFIX, UNSAVED_PREFIX, YAML_DOCUMENT_DELIMITER} from '@constants/constants';
+import {
+  CLUSTER_DIFF_PREFIX,
+  KUSTOMIZATION_KIND,
+  PREVIEW_PREFIX,
+  UNSAVED_PREFIX,
+  YAML_DOCUMENT_DELIMITER,
+} from '@constants/constants';
 
 import {getFileStats} from '@utils/files';
 
@@ -229,6 +235,9 @@ export function linkResources(
 export function getNamespaces(resourceMap: ResourceMapType) {
   const namespaces: string[] = [];
   Object.values(resourceMap).forEach(e => {
+    if (e.filePath.startsWith(CLUSTER_DIFF_PREFIX)) {
+      return;
+    }
     if (e.namespace && !namespaces.includes(e.namespace)) {
       namespaces.push(e.namespace);
     }

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -1,10 +1,13 @@
-import _ from 'lodash';
 import flatten from 'flat';
+import _ from 'lodash';
+
 import {ResourceFilterType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
+
+import {CLUSTER_RESOURCE_IGNORED_PATHS} from '@constants/clusterResource';
+
 import {isPassingKeyValueFilter} from '@utils/filter';
 import {removeNestedEmptyObjects} from '@utils/objects';
-import {CLUSTER_RESOURCE_IGNORED_PATHS} from '@constants/clusterResource';
 
 export const makeResourceNameKindNamespaceIdentifier = (resource: K8sResource) =>
   `${resource.name}#${resource.kind}#${resource.namespace ? resource.namespace : 'default'}`;
@@ -22,7 +25,9 @@ export function isResourcePassingFilter(resource: K8sResource, filters: Resource
   }
   if (filters.namespace) {
     const resourceNamespace = resource.namespace || 'default';
-    return resourceNamespace === filters.namespace;
+    if (resourceNamespace !== filters.namespace) {
+      return false;
+    }
   }
   if (filters.labels && Object.keys(filters.labels).length > 0) {
     const resourceLabels = resource.content?.metadata?.labels;


### PR DESCRIPTION
This PR...

## Changes

- changed preview output tag color in cluster preview
- logic to show empty sections that have an emptyDisplay set
- added "No resources match filters" message for both the K8s Section in Navigator and the Cluster Compare
- fixed ResourceFilter component state issues
- fixed resource filtering logic
- added back Resource Filter to the Cluster Compare

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
