### PR TITLE
fix: fixed behavior when context-sensitive pop-up was cropped

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.styled.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.styled.tsx
@@ -1,8 +1,11 @@
+import {Button, Skeleton, Tabs} from 'antd';
 import styled from 'styled-components';
+
 import {PaneContainer} from '@atoms';
-import {Tabs, Button, Skeleton} from 'antd';
 
 export const StyledTabs = styled(Tabs)`
+  overflow: visible;
+
   & .ant-tabs-nav {
     padding: 0 16px;
     margin-bottom: 0px;
@@ -15,7 +18,6 @@ export const StyledTabs = styled(Tabs)`
 
 export const ActionsPaneContainer = styled(PaneContainer)`
   height: 100%;
-  overflow-y: hidden;
 `;
 
 export const TitleBarContainer = styled.div`


### PR DESCRIPTION
## Fixes

- fixed behavior when the context-sensitive pop-up was cropped

## Screenshots

![image](https://user-images.githubusercontent.com/25991946/141800867-22401e35-d758-48e0-8fbe-e514f99973a8.png)