### PR TITLE
fix: added retrieval of custom resource objects from cluster

### DIFF
--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -1,15 +1,19 @@
 import {SetPreviewDataPayload} from '@redux/reducers/main';
+import {extractK8sResources, processParsedResources} from '@redux/services/resource';
 import {AppDispatch, RootState} from '@redux/store';
 import {createPreviewResult, createRejectionWithAlert, getK8sObjectsAsYaml} from '@redux/thunks/utils';
 import {createAsyncThunk} from '@reduxjs/toolkit';
 
 import {AlertEnum} from '@models/alert';
+import {ResourceRefsProcessingOptions} from '@models/appstate';
+import {K8sResource} from '@models/k8sresource';
 
-import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
+import {PREVIEW_PREFIX, YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
 import {ResourceKindHandlers} from '@src/kindhandlers';
 
 import * as k8s from '@kubernetes/client-node';
+import {KubeConfig} from '@kubernetes/client-node';
 
 const previewClusterHandler = async (configPath: string, thunkAPI: any) => {
   const resourceRefsProcessingOptions = thunkAPI.getState().main.resourceRefsProcessingOptions;
@@ -25,7 +29,7 @@ const previewClusterHandler = async (configPath: string, thunkAPI: any) => {
           .then(items => getK8sObjectsAsYaml(items, resourceKindHandler.kind, resourceKindHandler.clusterApiVersion))
       )
     ).then(
-      results => {
+      async results => {
         const fulfilledResults = results.filter(r => r.status === 'fulfilled' && r.value);
 
         if (fulfilledResults.length === 0) {
@@ -47,6 +51,20 @@ const previewClusterHandler = async (configPath: string, thunkAPI: any) => {
           configPath,
           thunkAPI.getState().config.kubeConfig.currentContext
         );
+
+        // if the cluster contains CRDs we need to check if there any corresponding resources also
+        const customResourceDefinitions = Object.values(previewResult.previewResources).filter(
+          r => r.kind === 'CustomResourceDefinition'
+        );
+        if (customResourceDefinitions.length > 0) {
+          await loadCustomResourceObjects(
+            kc,
+            customResourceDefinitions,
+            configPath,
+            previewResult,
+            resourceRefsProcessingOptions
+          );
+        }
 
         if (fulfilledResults.length < results.length) {
           const rejectedResult = results.find(r => r.status === 'rejected');
@@ -95,3 +113,108 @@ export const repreviewCluster = createAsyncThunk<
     state: RootState;
   }
 >('main/repreviewCluster', previewClusterHandler);
+
+/**
+ * Find the default version in line with the algorithm described at
+ * https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-priority
+ */
+
+const crdVersionRegex = /(v)(\d*)(alpha|beta)?(\d*)?/;
+
+function findDefaultVersion(r: K8sResource) {
+  const versionNames: string[] = r.content.spec.versions.map((v: any) => v.name);
+
+  versionNames.sort((a, b) => {
+    const m1 = crdVersionRegex.exec(a);
+    const m2 = crdVersionRegex.exec(b);
+
+    // do both versions match the regex?
+    if (m1 && m2) {
+      // do both have initial version number?
+      if (m1[2] && m2[2]) {
+        // is the initial version the same?
+        if (m1[2] === m2[2]) {
+          // do both have an alpha or beta tag?
+          if (m1[3] && m2[3]) {
+            // is the tag the same?
+            if (m1[3] === m2[3]) {
+              // do both have an alpha or beta version?
+              if (m1[4] && m2[4]) {
+                return parseInt(m1[4], 10) - parseInt(m2[4], 10);
+              }
+              return m1[4] ? 1 : -1;
+            }
+            // compare tags (negate for beta > alpha)
+            return -m1[3].localeCompare(m2[3]);
+          }
+          return m1[3] ? 1 : -1;
+        }
+        // compare version numbers
+        return parseInt(m1[2], 10) - parseInt(m2[2], 10);
+      }
+      return m1[2] ? 1 : -1;
+    }
+    if (m1) return 1;
+    if (m2) return -1;
+
+    return a.localeCompare(b);
+  });
+
+  return versionNames.length > 0 ? versionNames[0] : undefined;
+}
+
+/**
+ * Load custom resource objects for CRDs found in cluster
+ */
+
+async function loadCustomResourceObjects(
+  kc: KubeConfig,
+  customResourceDefinitions: K8sResource[],
+  configPath: string,
+  previewResult: SetPreviewDataPayload,
+  resourceRefsProcessingOptions: ResourceRefsProcessingOptions
+) {
+  const k8sApi = kc.makeApiClient(k8s.CustomObjectsApi);
+
+  try {
+    const customObjects = customResourceDefinitions.map(r =>
+      // retrieve objects using latest version name
+      // @ts-ignore
+      k8sApi
+        .listClusterCustomObject(r.content.spec.group, findDefaultVersion(r) || 'v1', r.content.spec.names.plural)
+        .then(response =>
+          // @ts-ignore
+          getK8sObjectsAsYaml(response.body.items)
+        )
+    );
+
+    if (!previewResult.previewResources) {
+      previewResult.previewResources = {};
+    }
+
+    await Promise.allSettled(customObjects).then(
+      customResults => {
+        const fulfilled = customResults.filter(r => r.status === 'fulfilled' && r.value);
+        if (fulfilled.length > 0) {
+          // @ts-ignore
+          const customResourcesYaml = fulfilled.map(r => r.value).join(YAML_DOCUMENT_DELIMITER_NEW_LINE);
+          const customResources = extractK8sResources(customResourcesYaml, PREVIEW_PREFIX + configPath);
+          customResources.forEach(r => {
+            // @ts-ignore
+            previewResult.previewResources[r.id] = r;
+          });
+
+          // @ts-ignore
+          processParsedResources(previewResult.previewResources, resourceRefsProcessingOptions, {
+            resourceIds: customResources.map(r => r.id),
+          });
+        }
+      },
+      reason => {
+        console.log(reason);
+      }
+    );
+  } catch (e) {
+    console.log(e);
+  }
+}

--- a/src/redux/thunks/utils.ts
+++ b/src/redux/thunks/utils.ts
@@ -16,11 +16,15 @@ import * as k8s from '@kubernetes/client-node';
  * Utility to convert list of objects returned by k8s api to a single YAML document
  */
 
-export function getK8sObjectsAsYaml(items: any[], kind: string, apiVersion: string) {
+export function getK8sObjectsAsYaml(items: any[], kind?: string, apiVersion?: string): string {
   return items
     .map(item => {
       delete item.metadata?.managedFields;
-      return `apiVersion: ${apiVersion}\nkind: ${kind}\n${stringify(item)}`;
+      if (kind && apiVersion) {
+        return `apiVersion: ${apiVersion}\nkind: ${kind}\n${stringify(item)}`;
+      }
+
+      return stringify(item);
     })
     .join(YAML_DOCUMENT_DELIMITER_NEW_LINE);
 }


### PR DESCRIPTION
This PR implements #641 

## How to test it

- retrieve resources from a cluster containing custom resources - they should show up at the bottom of the navigator under an "Unknown" section

## Screenshots

![image](https://user-images.githubusercontent.com/1917063/142069216-545a88e9-9a8f-4a47-b788-dea6dc32e3cf.png)


## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
