### PR TITLE
Improved Cluster Compare UX

### DIFF
--- a/src/components/molecules/ClusterDiff/ClusterDiff.tsx
+++ b/src/components/molecules/ClusterDiff/ClusterDiff.tsx
@@ -1,15 +1,10 @@
-import {Button, Divider} from 'antd';
+import {Divider} from 'antd';
 import React from 'react';
 import styled from 'styled-components';
-
-import {useAppDispatch} from '@redux/hooks';
-import {loadClusterDiff} from '@redux/thunks/loadClusterDiff';
 
 import {ClusterToLocalResourcesMatch} from '@models/appstate';
 
 import {ResourceFilterIconWithPopover, SectionRenderer} from '@components/molecules';
-
-import {ReloadOutlined} from '@ant-design/icons';
 
 import ClusterDiffSectionBlueprint, {ClusterDiffScopeType} from '@src/navsections/ClusterDiffSectionBlueprint';
 
@@ -29,11 +24,6 @@ const FilterContainer = styled.span`
   margin-left: 10px;
 `;
 
-const RefreshButton = styled(Button)`
-  margin-top: 1px;
-  margin-left: 8px;
-`;
-
 const ListContainer = styled.div`
   overflow-y: scroll;
   height: 70vh;
@@ -44,19 +34,10 @@ const ListContainer = styled.div`
 `;
 
 function ClusterDiff() {
-  const dispatch = useAppDispatch();
-  const onClickRefresh = () => {
-    dispatch(loadClusterDiff());
-  };
-
   return (
     <Container>
       <LeftPane>
         <S.TitleBar>
-          <RefreshButton icon={<ReloadOutlined />} onClick={onClickRefresh} size="small" type="primary" ghost>
-            Refresh
-          </RefreshButton>
-          <Divider type="vertical" style={{height: 40, marginLeft: 16}} />
           <S.TitleBarRightButtons>
             <ClusterDiffNamespaceFilter />
             <FilterContainer>

--- a/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
+++ b/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
@@ -15,6 +15,8 @@ import {ClusterDiff, ResourceDiff} from '@molecules';
 
 import {ArrowLeftOutlined} from '@ant-design/icons';
 
+import Colors, {BackgroundColors} from '@styles/Colors';
+
 const Container = styled.div`
   display: block;
   margin: 0;
@@ -27,10 +29,23 @@ const SkeletonContainer = styled.div`
   padding: 10px;
 `;
 
-const StyledModal = styled(Modal)`
+const StyledModal = styled(Modal)<{previewing: boolean}>`
   & .ant-modal-body {
     padding: 8px;
   }
+  ${props =>
+    props.previewing &&
+    `
+    & .ant-modal-header {
+      background: ${BackgroundColors.previewModeBackground};
+    }
+    & .ant-modal-title {
+      color: ${Colors.blackPure} !important;
+    }
+    & .ant-modal-close-x {
+      color: ${Colors.blackPure} !important;
+    }
+  `}
 `;
 
 type ResourceDiffState = {
@@ -205,6 +220,7 @@ function ClusterDiffModal() {
       onCancel={onCancel}
       footer={<Button onClick={closeModal}>Close</Button>}
       centered
+      previewing={isInPreviewMode}
     >
       <Container>
         {!hasClusterDiffLoaded ? (

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionNameDisplay.tsx
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionNameDisplay.tsx
@@ -1,6 +1,11 @@
-import {Tag} from 'antd';
+import {Button, Tag} from 'antd';
 import React from 'react';
 import styled from 'styled-components';
+
+import {useAppDispatch} from '@redux/hooks';
+import {loadClusterDiff} from '@redux/thunks/loadClusterDiff';
+
+import {ReloadOutlined} from '@ant-design/icons';
 
 const NameDisplayContainer = styled.div`
   margin-left: 16px;
@@ -31,7 +36,17 @@ const StyledTag = styled(Tag)`
   font-weight: 600;
 `;
 
+const ReloadButton = styled(Button)`
+  margin-top: 1px;
+  margin-left: 8px;
+`;
+
 function ResourceDiffSectionNameDisplay() {
+  const dispatch = useAppDispatch();
+  const onClickReload = () => {
+    dispatch(loadClusterDiff());
+  };
+
   return (
     <NameDisplayContainer>
       <TagsContainer>
@@ -41,6 +56,9 @@ function ResourceDiffSectionNameDisplay() {
         <Spacing />
         <TagWrapper>
           <StyledTag>Cluster Resources</StyledTag>
+          <ReloadButton icon={<ReloadOutlined />} onClick={onClickReload} size="small" type="primary" ghost>
+            Reload
+          </ReloadButton>
         </TagWrapper>
       </TagsContainer>
     </NameDisplayContainer>


### PR DESCRIPTION
This PR...

## Changes

- change header color while comparing a preview
- moved reload button next to cluster resources tag

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/142178803-af9039c6-774e-4e44-824b-e41d145c44c1.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
