### PR TITLE
refactor: redux-logger configuration

### DIFF
--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -1,4 +1,5 @@
 import asyncLib from 'async';
+import log from 'loglevel';
 import {shallowEqual} from 'react-redux';
 import {Middleware} from 'redux';
 
@@ -134,7 +135,7 @@ const processSectionBlueprints = (state: RootState, dispatch: AppDispatch) => {
 
   if (Object.values(isChangedByScopeKey).every(isChanged => isChanged === false)) {
     // eslint-disable-next-line no-console
-    console.log('fullScope did not change.');
+    log.debug('fullScope did not change.');
     return;
   }
 
@@ -145,7 +146,7 @@ const processSectionBlueprints = (state: RootState, dispatch: AppDispatch) => {
     );
     if (!hasSectionScopeChanged) {
       // eslint-disable-next-line no-console
-      console.log(`Section ${sectionBlueprint.id} scope did not change`);
+      log.debug(`Section ${sectionBlueprint.id} scope did not change`);
       return;
     }
     const sectionScope = pickPartialRecord(fullScope, scopeKeysBySectionId[sectionBlueprint.id]);
@@ -250,7 +251,7 @@ export const sectionBlueprintMiddleware: Middleware = store => next => action =>
     action?.type === collapseSectionIds.type
   ) {
     // eslint-disable-next-line no-console
-    console.log('Not processing.');
+    log.debug('Not processing.');
     return;
   }
   const state: RootState = store.getState();

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,7 +1,7 @@
 import {forwardToMain, replayActionRenderer} from 'electron-redux';
-import logger from 'redux-logger';
+import {createLogger} from 'redux-logger';
 
-import {configureStore} from '@reduxjs/toolkit';
+import {Middleware, configureStore} from '@reduxjs/toolkit';
 
 import {sectionBlueprintMiddleware} from '@src/navsections/sectionBlueprintMiddleware';
 
@@ -9,9 +9,20 @@ import {alertSlice} from './reducers/alert';
 import {configSlice} from './reducers/appConfig';
 import {logsSlice} from './reducers/logs';
 import {mainSlice} from './reducers/main';
-import {navigatorSlice} from './reducers/navigator';
+import {navigatorSlice, updateNavigatorInstanceState} from './reducers/navigator';
 import {uiSlice} from './reducers/ui';
 import {uiCoachSlice} from './reducers/uiCoach';
+
+const middlewares: Middleware[] = [];
+
+if (process.env.NODE_ENV === `development`) {
+  const reduxLoggerMiddleware = createLogger({
+    predicate: (getState, action) => action.type !== updateNavigatorInstanceState.type,
+    collapsed: (getState, action, logEntry) => !logEntry?.error,
+  });
+
+  middlewares.push(reduxLoggerMiddleware);
+}
 
 const store = configureStore({
   reducer: {
@@ -25,7 +36,7 @@ const store = configureStore({
   },
   middleware: getDefaultMiddleware => [
     forwardToMain,
-    ...getDefaultMiddleware().concat(logger),
+    ...getDefaultMiddleware().concat(middlewares),
     sectionBlueprintMiddleware,
   ],
 });


### PR DESCRIPTION
This PR...

## Changes

- collapse all redux-logger logs by default if they don't have any errors
- disable redux-logger in production

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
