### PR TITLE
Increase items' onClick area in navigator

### DIFF
--- a/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
@@ -1,11 +1,17 @@
-import React, {useCallback, useState, useRef, useEffect, useContext} from 'react';
-import ScrollIntoView, {ScrollContainerRef} from '@components/molecules/ScrollIntoView';
-import AppContext from '@src/AppContext';
-import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
-import {ItemBlueprint} from '@models/navigator';
+import React, {useCallback, useContext, useEffect, useRef, useState} from 'react';
+
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {useItemCustomization} from './useItemCustomization';
+
+import {ItemBlueprint} from '@models/navigator';
+
+import ScrollIntoView, {ScrollContainerRef} from '@components/molecules/ScrollIntoView';
+
+import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
+
+import AppContext from '@src/AppContext';
+
 import * as S from './styled';
+import {useItemCustomization} from './useItemCustomization';
 
 export type ItemRendererOptions = {
   disablePrefix?: boolean;
@@ -111,6 +117,7 @@ function ItemRenderer<ItemType, ScopeType>(props: ItemRendererProps<ItemType, Sc
             <Suffix.Component itemInstance={itemInstance} options={Suffix.options} />
           </S.SuffixContainer>
         )}
+        <S.BlankSpace onClick={onClick} />
         {QuickAction.Component &&
           !options?.disableQuickAction &&
           (QuickAction.options?.isVisibleOnHover ? isHovered : true) && (

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import Colors from '@styles/Colors';
 
-export const ItemContainer = styled.li<{
+type ItemContainerProps = {
   isSelected: boolean;
   isHighlighted: boolean;
   disableHoverStyle: boolean;
@@ -10,7 +10,9 @@ export const ItemContainer = styled.li<{
   level: number;
   isLastItem: boolean;
   hasOnClick: boolean;
-}>`
+};
+
+export const ItemContainer = styled.li<ItemContainerProps>`
   display: flex;
   align-items: center;
   width: 100%;
@@ -44,13 +46,15 @@ export const ItemContainer = styled.li<{
   padding-left: ${props => `${props.level * 12}px;`};
 `;
 
-export const ItemName = styled.span<{
+type ItemNameProps = {
   isSelected: boolean;
   isHighlighted: boolean;
   isDirty: boolean;
   isDisabled: boolean;
   level: number;
-}>`
+};
+
+export const ItemName = styled.span<ItemNameProps>`
   padding: 2px 0;
   font-size: 12px;
   overflow: hidden;
@@ -96,4 +100,9 @@ export const QuickActionContainer = styled.span`
 
 export const ContextMenuContainer = styled.span`
   margin-left: auto;
+`;
+
+export const BlankSpace = styled.span`
+  flex-grow: 1;
+  height: 20px;
 `;


### PR DESCRIPTION
This PR...

## Changes

- this increases the space that can be clicked to trigger the onClick event on an item in navigator sections
- before this, we could select resources only by clicking their text, now we can click on the blank space in the row as well

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
