### PR TITLE
fix: applied validation to the New Resource Wizard's name field

### DIFF
--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -13,7 +13,7 @@ import {createUnsavedResource} from '@redux/services/unsavedResource';
 import {NO_NAMESPACE, useNamespaces} from '@hooks/useNamespaces';
 
 import {useResetFormOnCloseModal} from '@utils/hooks';
-import {openUniqueObjectNameTopic} from '@utils/shell';
+import {openNamespaceTopic, openUniqueObjectNameTopic} from '@utils/shell';
 
 import {ResourceKindHandlers, getResourceKindHandler} from '@src/kindhandlers';
 
@@ -170,7 +170,14 @@ const NewResourceWizard = () => {
         <Form.Item
           name="namespace"
           label="Namespace"
-          tooltip={{title: 'Select the namespace', icon: <InfoCircleOutlined />}}
+          tooltip={{
+            title: () => (
+              <span>
+                Namespace - <a onClick={openNamespaceTopic}>read more</a>
+              </span>
+            ),
+            icon: <InfoCircleOutlined />,
+          }}
           initialValue={NO_NAMESPACE}
         >
           <Select>

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -125,8 +125,16 @@ const NewResourceWizard = () => {
   return (
     <Modal title="Add New Resource" visible={newResourceWizardState.isOpen} onOk={onOk} onCancel={onCancel}>
       <Form form={form} layout="vertical" onValuesChange={onFormValuesChange} onFinish={onFinish}>
-        <Form.Item name="name" label="Name" required>
-          <Input />
+        <Form.Item
+          name="name"
+          label="Name"
+          rules={[
+            {required: true, message: 'This field is required'},
+            {pattern: /^[a-z]$|^([a-z\-.])*[a-z]$/, message: 'Wrong pattern'},
+            {max: 63, type: 'string', message: 'Too long'},
+          ]}
+        >
+          <Input maxLength={63} />
         </Form.Item>
         <Form.Item
           name="kind"

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {Form, Input, Modal, Select} from 'antd';
 
@@ -13,6 +13,7 @@ import {createUnsavedResource} from '@redux/services/unsavedResource';
 import {NO_NAMESPACE, useNamespaces} from '@hooks/useNamespaces';
 
 import {useResetFormOnCloseModal} from '@utils/hooks';
+import {openUniqueObjectNameTopic} from '@utils/shell';
 
 import {ResourceKindHandlers, getResourceKindHandler} from '@src/kindhandlers';
 
@@ -133,6 +134,14 @@ const NewResourceWizard = () => {
             {pattern: /^[a-z]$|^([a-z\-.])*[a-z]$/, message: 'Wrong pattern'},
             {max: 63, type: 'string', message: 'Too long'},
           ]}
+          tooltip={{
+            title: () => (
+              <span>
+                Unique object name - <a onClick={openUniqueObjectNameTopic}>read more</a>
+              </span>
+            ),
+            icon: <InfoCircleOutlined />,
+          }}
         >
           <Input maxLength={63} />
         </Form.Item>

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -29,3 +29,7 @@ export function openDocumentation() {
 export function openUniqueObjectNameTopic() {
   shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names');
 }
+
+export function openNamespaceTopic() {
+  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names');
+}

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -25,3 +25,7 @@ export function openDiscord() {
 export function openDocumentation() {
   shell.openExternal(`https://kubeshop.github.io/monokle?os=${os.type}`);
 }
+
+export function openUniqueObjectNameTopic() {
+  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names');
+}


### PR DESCRIPTION
## Fixes

- applied validation to the New Resource Wizard's name field

## Screenshots
- ![image](https://user-images.githubusercontent.com/25991946/143192334-0653f1e6-7746-43ab-8d97-888f3a3325f3.png)
- ![image](https://user-images.githubusercontent.com/25991946/143192372-5c220459-f90e-4fd1-a092-e6f7c7fea2a4.png)

