### PR TITLE
fix: create unsatisifed refs for invalid kustomization resources ref

### DIFF
--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -88,6 +88,8 @@ function processKustomizationResourceRef(
       // resource is file -> check for contained resources
       linkParentKustomization(fileEntry, kustomization, resourceMap, refNode);
     }
+  } else {
+    createFileRef(kustomization, refNode, kpath, fileMap);
   }
 }
 


### PR DESCRIPTION
This PR fixed #768 

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
