### PR TITLE
fix: updated resource save actions to use save dialog

### DIFF
--- a/electron/commands.ts
+++ b/electron/commands.ts
@@ -8,6 +8,8 @@ import mainStore from '@redux/main-store';
 import {updateNewVersion} from '@redux/reducers/appConfig';
 import {KustomizeCommandType} from '@redux/services/kustomize';
 
+import {FileExplorerOptions} from '@atoms/FileExplorer';
+
 import {PROCESS_ENV} from '@utils/env';
 
 import autoUpdater from './auto-update';
@@ -37,7 +39,7 @@ export const runKustomize = (folder: string, kustomizeCommand: KustomizeCommandT
  * prompts to select a file using the native dialogs
  */
 
-export const selectFileDialog = (event: Electron.IpcMainInvokeEvent, options: any) => {
+export const selectFileDialog = (event: Electron.IpcMainInvokeEvent, options: FileExplorerOptions) => {
   const browserWindow = BrowserWindow.fromId(event.sender.id);
   let dialogOptions: Electron.OpenDialogSyncOptions = {};
   if (options.isDirectoryExplorer) {
@@ -67,7 +69,7 @@ export const selectFileDialog = (event: Electron.IpcMainInvokeEvent, options: an
  * prompts to select a file using the native dialogs
  */
 
-export const saveFileDialog = (event: Electron.IpcMainInvokeEvent, options: any) => {
+export const saveFileDialog = (event: Electron.IpcMainInvokeEvent, options: FileExplorerOptions) => {
   const browserWindow = BrowserWindow.fromId(event.sender.id);
   let dialogOptions: Electron.SaveDialogSyncOptions = {};
   if (options.acceptedFileExtensions) {

--- a/electron/commands.ts
+++ b/electron/commands.ts
@@ -37,7 +37,7 @@ export const runKustomize = (folder: string, kustomizeCommand: KustomizeCommandT
  * prompts to select a file using the native dialogs
  */
 
-export const selectFile = (event: Electron.IpcMainInvokeEvent, options: any) => {
+export const selectFileDialog = (event: Electron.IpcMainInvokeEvent, options: any) => {
   const browserWindow = BrowserWindow.fromId(event.sender.id);
   let dialogOptions: Electron.OpenDialogSyncOptions = {};
   if (options.isDirectoryExplorer) {
@@ -51,6 +51,8 @@ export const selectFile = (event: Electron.IpcMainInvokeEvent, options: any) => 
     }
   }
 
+  dialogOptions.properties?.push('createDirectory');
+
   if (options.defaultPath) {
     dialogOptions.defaultPath = options.defaultPath;
   }
@@ -59,6 +61,33 @@ export const selectFile = (event: Electron.IpcMainInvokeEvent, options: any) => 
     return dialog.showOpenDialogSync(browserWindow, dialogOptions);
   }
   return dialog.showOpenDialogSync(dialogOptions);
+};
+
+/**
+ * prompts to select a file using the native dialogs
+ */
+
+export const saveFileDialog = (event: Electron.IpcMainInvokeEvent, options: any) => {
+  const browserWindow = BrowserWindow.fromId(event.sender.id);
+  let dialogOptions: Electron.SaveDialogSyncOptions = {};
+  if (options.acceptedFileExtensions) {
+    dialogOptions.filters = [{name: 'Files', extensions: options.acceptedFileExtensions}];
+  }
+
+  dialogOptions.properties?.push('createDirectory');
+
+  if (options.defaultPath) {
+    dialogOptions.defaultPath = options.defaultPath;
+  }
+
+  if (options.title) {
+    dialogOptions.title = options.title;
+  }
+
+  if (browserWindow) {
+    return dialog.showSaveDialogSync(browserWindow, dialogOptions);
+  }
+  return dialog.showSaveDialogSync(dialogOptions);
 };
 
 /**

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -38,7 +38,7 @@ import terminal from '../cli/terminal';
 import {downloadPlugin} from './pluginService';
 import {AlertEnum, AlertType} from '@models/alert';
 import {setAlert} from '@redux/reducers/alert';
-import {checkNewVersion, runHelm, runKustomize, selectFile} from '@root/electron/commands';
+import {checkNewVersion, runHelm, runKustomize, saveFileDialog, selectFileDialog} from '@root/electron/commands';
 import {setAppRehydrating} from '@redux/reducers/main';
 import autoUpdater from './auto-update';
 import { indexOf } from 'lodash';
@@ -76,7 +76,11 @@ ipcMain.on('run-kustomize', (event, cmdOptions: any) => {
 });
 
 ipcMain.handle('select-file', async (event, options: any) => {
-  return selectFile(event, options);
+  return selectFileDialog(event, options);
+});
+
+ipcMain.handle('save-file', async (event, options: any) => {
+  return saveFileDialog(event, options);
 });
 
 ipcMain.on('run-helm', (event, args: any) => {
@@ -186,7 +190,7 @@ export const createWindow = (givenPath?: string) => {
 
     if (missingDependencies.includes('kustomize') && isUserAbleToRunKubectlKustomize) {
       missingDependencies.splice(indexOf(missingDependencies, 'kustomize'), 1);
-      
+
     }
 
     if (missingDependencies.length > 0) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -42,6 +42,7 @@ import {checkNewVersion, runHelm, runKustomize, saveFileDialog, selectFileDialog
 import {setAppRehydrating} from '@redux/reducers/main';
 import autoUpdater from './auto-update';
 import { indexOf } from 'lodash';
+import {FileExplorerOptions} from '@atoms/FileExplorer';
 
 Object.assign(console, ElectronLog.functions);
 
@@ -75,11 +76,11 @@ ipcMain.on('run-kustomize', (event, cmdOptions: any) => {
   runKustomize(cmdOptions.folder, cmdOptions.kustomizeCommand, event);
 });
 
-ipcMain.handle('select-file', async (event, options: any) => {
+ipcMain.handle('select-file', async (event, options: FileExplorerOptions) => {
   return selectFileDialog(event, options);
 });
 
-ipcMain.handle('save-file', async (event, options: any) => {
+ipcMain.handle('save-file', async (event, options: FileExplorerOptions) => {
   return saveFileDialog(event, options);
 });
 

--- a/src/components/atoms/FileExplorer/FileExplorer.tsx
+++ b/src/components/atoms/FileExplorer/FileExplorer.tsx
@@ -5,6 +5,7 @@ import {useEffect} from 'react';
 export type DirectoryOptions = {
   isDirectoryExplorer: true;
   defaultPath?: string;
+  title?: string;
 };
 
 export type FileOptions = {
@@ -12,6 +13,8 @@ export type FileOptions = {
   allowMultiple?: boolean;
   acceptedFileExtensions?: string[];
   defaultPath?: string;
+  title?: string;
+  action?: 'save' | 'open';
 };
 
 export type FileExplorerOptions = DirectoryOptions | FileOptions;
@@ -29,11 +32,22 @@ const FileExplorer = (props: FileExplorerProps) => {
   useEffect(() => {
     if (isOpen) {
       onOpen();
-      ipcRenderer.invoke('select-file', options).then(files => {
-        if (files) {
-          onSelect(files);
-        }
-      });
+
+      // @ts-ignore
+      if (options?.action === 'save') {
+        ipcRenderer.invoke('save-file', options).then(file => {
+          if (file) {
+            console.log(`Saving file to ${file}`);
+            onSelect([file]);
+          }
+        });
+      } else {
+        ipcRenderer.invoke('select-file', options).then(files => {
+          if (files) {
+            onSelect(files);
+          }
+        });
+      }
     }
   }, [isOpen, options, onOpen, onSelect]);
 

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -4,8 +4,17 @@ import {Button, Col, Dropdown, Menu, Row, Tabs, Tooltip} from 'antd';
 
 import {ArrowLeftOutlined, ArrowRightOutlined, BookOutlined, CodeOutlined, ContainerOutlined} from '@ant-design/icons';
 
+import path from 'path';
+
 import {TOOLTIP_DELAY} from '@constants/constants';
-import {ApplyFileTooltip, ApplyTooltip, DiffTooltip, SaveUnsavedResourceTooltip} from '@constants/tooltips';
+import {
+  AddResourceToExistingFileTooltip,
+  ApplyFileTooltip,
+  ApplyTooltip,
+  DiffTooltip,
+  SaveResourceToNewFileTooltip,
+  SaveUnsavedResourceTooltip,
+} from '@constants/tooltips';
 
 import {K8sResource} from '@models/k8sresource';
 
@@ -14,6 +23,7 @@ import {setMonacoEditor} from '@redux/reducers/ui';
 import {applyFileWithConfirm} from '@redux/services/applyFileWithConfirm';
 import {applyHelmChartWithConfirm} from '@redux/services/applyHelmChartWithConfirm';
 import {applyResourceWithConfirm} from '@redux/services/applyResourceWithConfirm';
+import {getRootFolder} from '@redux/services/fileEntry';
 import {isKustomizationPatch, isKustomizationResource} from '@redux/services/kustomize';
 import {isUnsavedResource} from '@redux/services/resource';
 import {performResourceDiff} from '@redux/thunks/diffResource';
@@ -90,26 +100,34 @@ const ActionsPane = (props: {contentHeight: string}) => {
   );
 
   const {openFileExplorer, fileExplorerProps} = useFileExplorer(
-    ({filePath}) => {
-      if (!filePath) {
+    ({existingFilePath}) => {
+      if (!existingFilePath) {
         return;
       }
-      onSelect(filePath);
+      onSelect(existingFilePath);
     },
     {
+      title: `Add Resource ${selectedResource?.name} to file`,
       acceptedFileExtensions: ['.yaml'],
+      action: 'open',
     }
   );
 
   const {openFileExplorer: openDirectoryExplorer, fileExplorerProps: directoryExplorerProps} = useFileExplorer(
-    ({folderPath}) => {
-      if (!folderPath) {
+    ({newFilePath}) => {
+      if (!newFilePath) {
         return;
       }
-      onSelect(folderPath);
+      onSelect(newFilePath);
     },
     {
-      isDirectoryExplorer: true,
+      acceptedFileExtensions: ['.yaml'],
+      title: `Save Resource ${selectedResource?.name} to file`,
+      defaultPath: path.join(
+        getRootFolder(fileMap) || '',
+        `${selectedResource?.name}-${selectedResource?.kind.toLowerCase()}.yaml`
+      ),
+      action: 'save',
     }
   );
 
@@ -119,14 +137,18 @@ const ActionsPane = (props: {contentHeight: string}) => {
     () => (
       <Menu>
         <Menu.Item key="to-existing-file">
-          <Button onClick={() => openFileExplorer()} type="text">
-            To existing file
-          </Button>
+          <Tooltip title={AddResourceToExistingFileTooltip}>
+            <Button onClick={() => openFileExplorer()} type="text">
+              To existing file..
+            </Button>
+          </Tooltip>
         </Menu.Item>
         <Menu.Item key="to-directory">
-          <Button onClick={() => openDirectoryExplorer()} type="text">
-            To new file in directory
-          </Button>
+          <Tooltip title={SaveResourceToNewFileTooltip}>
+            <Button onClick={() => openDirectoryExplorer()} type="text">
+              To new file..
+            </Button>
+          </Tooltip>
         </Menu.Item>
       </Menu>
     ),

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -114,11 +114,11 @@ const ActionsPane = (props: {contentHeight: string}) => {
   );
 
   const {openFileExplorer: openDirectoryExplorer, fileExplorerProps: directoryExplorerProps} = useFileExplorer(
-    ({newFilePath}) => {
-      if (!newFilePath) {
+    ({saveFilePath}) => {
+      if (!saveFilePath) {
         return;
       }
-      onSelect(newFilePath);
+      onSelect(saveFilePath);
     },
     {
       acceptedFileExtensions: ['.yaml'],

--- a/src/constants/tooltips.ts
+++ b/src/constants/tooltips.ts
@@ -38,3 +38,5 @@ export const ClusterDiffApplyTooltip = 'Deploy this resource to your configured 
 export const ClusterDiffSaveTooltip = 'Replace local resource with cluster version';
 export const ClusterDiffCompareTooltip = 'Diff resources - Opens the Diff Modal';
 export const FileExplorerChanged = 'File Explorer has some changes. Reload it to see them.';
+export const SaveResourceToNewFileTooltip = 'Save this resource to a new file';
+export const AddResourceToExistingFileTooltip = 'Add this resource to an existing manifest file';

--- a/src/hooks/useFileExplorer.tsx
+++ b/src/hooks/useFileExplorer.tsx
@@ -8,7 +8,8 @@ import {FileExplorerOptions, FileExplorerProps} from '@atoms/FileExplorer';
 type FileExplorerSelectResult = {
   existingFilePath?: string;
   filePaths?: string[];
-  newFilePath?: string;
+  saveFilePath?: string;
+  folderPath?: string;
 };
 
 export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => void, options: FileExplorerOptions) => {
@@ -20,7 +21,7 @@ export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => 
       setIsOpen(false);
       if (options?.isDirectoryExplorer) {
         onSelect({
-          newFilePath: fileList[0],
+          folderPath: fileList[0],
         });
         return;
       }
@@ -32,7 +33,7 @@ export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => 
       }
       if (options?.action === 'save') {
         onSelect({
-          newFilePath: fileList[0],
+          saveFilePath: fileList[0],
         });
       } else {
         onSelect({

--- a/src/hooks/useFileExplorer.tsx
+++ b/src/hooks/useFileExplorer.tsx
@@ -6,9 +6,9 @@ import {getRootFolder} from '@redux/services/fileEntry';
 import {FileExplorerOptions, FileExplorerProps} from '@atoms/FileExplorer';
 
 type FileExplorerSelectResult = {
-  filePath?: string;
+  existingFilePath?: string;
   filePaths?: string[];
-  folderPath?: string;
+  newFilePath?: string;
 };
 
 export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => void, options: FileExplorerOptions) => {
@@ -20,7 +20,7 @@ export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => 
       setIsOpen(false);
       if (options?.isDirectoryExplorer) {
         onSelect({
-          folderPath: fileList[0],
+          newFilePath: fileList[0],
         });
         return;
       }
@@ -30,9 +30,15 @@ export const useFileExplorer = (onSelect: (result: FileExplorerSelectResult) => 
         });
         return;
       }
-      onSelect({
-        filePath: fileList[0],
-      });
+      if (options?.action === 'save') {
+        onSelect({
+          newFilePath: fileList[0],
+        });
+      } else {
+        onSelect({
+          existingFilePath: fileList[0],
+        });
+      }
     },
     [setIsOpen, onSelect, options]
   );


### PR DESCRIPTION
This PR replaces the current open-dialogs when saving a resource with save dialogs instead...

## Changes

-

## Fixes

- #780 

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
