### PR TITLE
fix: added hover links to add filters in source editor

### DIFF
--- a/electron/commands.ts
+++ b/electron/commands.ts
@@ -27,6 +27,7 @@ export const runKustomize = (folder: string, kustomizeCommand: KustomizeCommandT
         PUBLIC_URL: PROCESS_ENV.PUBLIC_URL,
         PATH: PROCESS_ENV.PATH,
       },
+      maxBuffer: 1024 * 1024 * 10,
     });
 
     event.sender.send('kustomize-result', {stdout: stdout.toString()});
@@ -105,6 +106,7 @@ export const runHelm = (args: any, event: Electron.IpcMainEvent) => {
         KUBECONFIG: args.kubeconfig,
         PATH: PROCESS_ENV.PATH,
       },
+      maxBuffer: 1024 * 1024 * 10,
     });
 
     event.sender.send('helm-result', {stdout: stdout.toString()});

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -20,11 +20,12 @@ import {Document, ParsedNode, isMap, parseAllDocuments} from 'yaml';
 
 import {ROOT_FILE_ENTRY} from '@constants/constants';
 
+import {ResourceFilterType} from '@models/appstate';
 import {ResourceRef} from '@models/k8sresource';
 import {NewResourceWizardInput} from '@models/ui';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {selectFile, selectK8sResource} from '@redux/reducers/main';
+import {extendResourceFilter, selectFile, selectK8sResource} from '@redux/reducers/main';
 import {openNewResourceWizard} from '@redux/reducers/ui';
 import {isInPreviewModeSelector} from '@redux/selectors';
 
@@ -74,6 +75,7 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const previewType = useAppSelector(state => state.main.previewType);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
+
   const [containerRef, {width: containerWidth, height: containerHeight}] = useMeasure<HTMLDivElement>();
 
   const [code, setCode] = useState('');
@@ -104,6 +106,10 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     }
   };
 
+  const filterResources = (filter: ResourceFilterType) => {
+    dispatch(extendResourceFilter(filter));
+  };
+
   const createResource = (outoingRef: ResourceRef, namespace?: string, targetFolder?: string) => {
     if (outoingRef.target?.type === 'resource' && outoingRef.target.resourceKind) {
       const input: NewResourceWizardInput = {
@@ -127,7 +133,8 @@ const Monaco = (props: {editorHeight: string; diffSelectedResource: () => void; 
     isEditorMounted,
     selectResource,
     selectFilePath,
-    createResource
+    isInPreviewMode ? undefined : createResource,
+    filterResources
   );
   const {registerStaticActions} = useEditorKeybindings(
     editor,

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -1,6 +1,6 @@
 import {monaco} from 'react-monaco-editor';
 
-import {FileMapType, ResourceMapType} from '@models/appstate';
+import {FileMapType, ResourceFilterType, ResourceMapType} from '@models/appstate';
 import {K8sResource, RefPosition, ResourceRef} from '@models/k8sresource';
 
 import {getResourceFolder} from '@redux/services/fileEntry';
@@ -17,6 +17,7 @@ import {
   createInlineDecoration,
   createLinkProvider,
   createMarkdownString,
+  getSymbols,
   getSymbolsBeforePosition,
 } from './editorHelpers';
 
@@ -117,17 +118,173 @@ function areRefPosEqual(a: RefPosition, b: RefPosition) {
   return a.line === b.line && a.column === b.column && a.length === b.length;
 }
 
-export function applyForResource(
+function getSymbolValue(lines: string[], symbol: monaco.languages.DocumentSymbol, includeName?: boolean) {
+  const line = lines[symbol.range.startLineNumber - 1];
+  if (line) {
+    const str = line.substr(symbol.range.startColumn - 1, symbol.range.endColumn - symbol.range.startColumn);
+
+    if (includeName) {
+      return str;
+    }
+
+    const ix = str.indexOf(':', symbol.name.length);
+    return str.substring(ix + 1).trim();
+  }
+}
+
+function addNamespaceFilterLink(
+  lines: string[],
+  symbol: monaco.languages.DocumentSymbol,
+  filterResources: (filter: ResourceFilterType) => void,
+  newDisposables: monaco.IDisposable[]
+) {
+  const namespace = getSymbolValue(lines, symbol);
+  if (namespace) {
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
+      `Filter on namespace [${namespace}]`,
+      () => {
+        filterResources({namespace, labels: {}, annotations: {}});
+      }
+    );
+    newDisposables.push(commandDisposable);
+
+    const hoverDisposable = createHoverProvider(symbol.range, [
+      createMarkdownString('Filter Resources'),
+      commandMarkdownLink,
+    ]);
+    newDisposables.push(hoverDisposable);
+  }
+}
+
+function addKindFilterLink(
+  lines: string[],
+  symbol: monaco.languages.DocumentSymbol,
+  filterResources: (filter: ResourceFilterType) => void,
+  newDisposables: monaco.IDisposable[]
+) {
+  const kind = getSymbolValue(lines, symbol);
+  if (kind) {
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(`Filter on kind [${kind}]`, () => {
+      filterResources({kind, labels: {}, annotations: {}});
+    });
+    newDisposables.push(commandDisposable);
+
+    const hoverDisposable = createHoverProvider(symbol.range, [
+      createMarkdownString('Filter Resources'),
+      commandMarkdownLink,
+    ]);
+    newDisposables.push(hoverDisposable);
+  }
+}
+
+function addLabelFilterLink(
+  lines: string[],
+  symbol: monaco.languages.DocumentSymbol,
+  filterResources: (filter: ResourceFilterType) => void,
+  newDisposables: monaco.IDisposable[]
+) {
+  const label = getSymbolValue(lines, symbol, true);
+  if (label) {
+    const value = label.substring(symbol.name.length + 1).trim();
+
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(`Filter on label [${label}]`, () => {
+      const labels: Record<string, string | null> = {};
+      labels[symbol.name] = value;
+      filterResources({labels, annotations: {}});
+    });
+    newDisposables.push(commandDisposable);
+
+    const hoverDisposable = createHoverProvider(symbol.range, [
+      createMarkdownString('Filter Resources'),
+      commandMarkdownLink,
+    ]);
+    newDisposables.push(hoverDisposable);
+  }
+}
+
+function addAnnotationFilterLink(
+  lines: string[],
+  symbol: monaco.languages.DocumentSymbol,
+  filterResources: (filter: ResourceFilterType) => void,
+  newDisposables: monaco.IDisposable[]
+) {
+  const annotation = getSymbolValue(lines, symbol, true);
+  if (annotation) {
+    const value = annotation.substring(symbol.name.length + 1).trim();
+
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
+      `Filter on annotation [${annotation}]`,
+      () => {
+        const annotations: Record<string, string | null> = {};
+        annotations[symbol.name] = value;
+        filterResources({labels: {}, annotations});
+      }
+    );
+    newDisposables.push(commandDisposable);
+
+    const hoverDisposable = createHoverProvider(symbol.range, [
+      createMarkdownString('Filter Resources'),
+      commandMarkdownLink,
+    ]);
+    newDisposables.push(hoverDisposable);
+  }
+}
+
+function processSymbol(
+  symbol: monaco.languages.DocumentSymbol,
+  parents: monaco.languages.DocumentSymbol[],
+  lines: string[],
+  filterResources: (filter: ResourceFilterType) => void
+) {
+  const newDisposables: monaco.IDisposable[] = [];
+
+  if (symbol.children) {
+    symbol.children.forEach(child => {
+      newDisposables.push(...processSymbol(child, parents.concat(symbol), lines, filterResources));
+    });
+  }
+
+  if (symbol.name === 'namespace') {
+    addNamespaceFilterLink(lines, symbol, filterResources, newDisposables);
+  }
+
+  if (symbol.name === 'kind') {
+    addKindFilterLink(lines, symbol, filterResources, newDisposables);
+  }
+
+  if (parents.length > 0) {
+    const parentName = parents[parents.length - 1].name;
+
+    if (parentName === 'labels' || parentName === 'matchLabels') {
+      addLabelFilterLink(lines, symbol, filterResources, newDisposables);
+    } else if (parentName === 'annotations') {
+      addAnnotationFilterLink(lines, symbol, filterResources, newDisposables);
+    }
+  }
+
+  return newDisposables;
+}
+
+export async function applyForResource(
   resource: K8sResource,
   selectResource: (resourceId: string) => void,
   selectFilePath: (filePath: string) => void,
-  createResource: (outgoingRef: ResourceRef, namespace?: string, targetFolderget?: string) => void,
+  createResource: ((outgoingRef: ResourceRef, namespace?: string, targetFolderget?: string) => void) | undefined,
+  filterResources: (filter: ResourceFilterType) => void,
   resourceMap: ResourceMapType,
-  fileMap: FileMapType
+  fileMap: FileMapType,
+  model: monaco.editor.IModel | null
 ) {
   const refs = resource.refs;
   const newDecorations: monaco.editor.IModelDeltaDecoration[] = [];
   const newDisposables: monaco.IDisposable[] = [];
+
+  if (model) {
+    const symbols: monaco.languages.DocumentSymbol[] = await getSymbols(model);
+    const lines = resource.text.split('\n');
+
+    newDisposables.push(...symbols.map(symbol => processSymbol(symbol, [], lines, filterResources)).flat());
+  }
 
   if (!refs || refs.length === 0) {
     return {newDecorations, newDisposables};
@@ -181,7 +338,7 @@ export function applyForResource(
       }
 
       // add command for creating resource from unsatisfied ref
-      if (isUnsatisfiedRef(outgoingRef.type)) {
+      if (createResource && isUnsatisfiedRef(outgoingRef.type)) {
         if (
           outgoingRef.target.type === 'resource' &&
           !outgoingRef.target.resourceId &&
@@ -244,20 +401,22 @@ export function applyForResource(
     // create default link if there is only one command
     if (outgoingRefs.length === 1) {
       const outgoingRef = outgoingRefs[0];
-      const linkDisposable = createLinkProvider(
-        inlineRange,
-        isUnsatisfiedRef(outgoingRef.type) ? 'Create resource' : 'Open resource',
-        () => {
-          if (isUnsatisfiedRef(outgoingRef.type)) {
-            createResource(outgoingRef, resource.namespace, getResourceFolder(resource));
-          } else if (outgoingRef.target?.type === 'resource' && outgoingRef.target.resourceId) {
-            selectResource(outgoingRef.target.resourceId);
-          } else if (outgoingRef.target?.type === 'file' && outgoingRef.target.filePath) {
-            selectFilePath(outgoingRef.target.filePath);
+      if (createResource || !isUnsatisfiedRef(outgoingRef.type)) {
+        const linkDisposable = createLinkProvider(
+          inlineRange,
+          isUnsatisfiedRef(outgoingRef.type) ? 'Create resource' : 'Open resource',
+          () => {
+            if (isUnsatisfiedRef(outgoingRef.type) && createResource) {
+              createResource(outgoingRef, resource.namespace, getResourceFolder(resource));
+            } else if (outgoingRef.target?.type === 'resource' && outgoingRef.target.resourceId) {
+              selectResource(outgoingRef.target.resourceId);
+            } else if (outgoingRef.target?.type === 'file' && outgoingRef.target.filePath) {
+              selectFilePath(outgoingRef.target.filePath);
+            }
           }
-        }
-      );
-      newDisposables.push(linkDisposable);
+        );
+        newDisposables.push(linkDisposable);
+      }
     }
   });
 

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -187,11 +187,14 @@ function addLabelFilterLink(
   if (label) {
     const value = label.substring(symbol.name.length + 1).trim();
 
-    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(`Filter on label [${label}]`, () => {
-      const labels: Record<string, string | null> = {};
-      labels[symbol.name] = value;
-      filterResources({labels, annotations: {}});
-    });
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
+      `Add label [${label}] to current filter`,
+      () => {
+        const labels: Record<string, string | null> = {};
+        labels[symbol.name] = value;
+        filterResources({labels, annotations: {}});
+      }
+    );
     newDisposables.push(commandDisposable);
 
     const hoverDisposable = createHoverProvider(symbol.range, [
@@ -213,7 +216,7 @@ function addAnnotationFilterLink(
     const value = annotation.substring(symbol.name.length + 1).trim();
 
     const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
-      `Filter on annotation [${annotation}]`,
+      `Add annotation [${annotation}] to current filter`,
       () => {
         const annotations: Record<string, string | null> = {};
         annotations[symbol.name] = value;

--- a/src/components/molecules/Monaco/editorHelpers.ts
+++ b/src/components/molecules/Monaco/editorHelpers.ts
@@ -117,7 +117,7 @@ const isPositionAfterRange = (position: monaco.IPosition, range: monaco.IRange) 
   return position.column > range.startColumn && position.lineNumber >= range.startLineNumber;
 };
 
-const getSymbols = async (model: monaco.editor.IModel) => {
+export const getSymbols = async (model: monaco.editor.IModel) => {
   const symbols = await getDocumentSymbols(model, false, {
     isCancellationRequested: false,
     onCancellationRequested: () => {

--- a/src/components/molecules/Monaco/useCodeIntel.ts
+++ b/src/components/molecules/Monaco/useCodeIntel.ts
@@ -57,7 +57,7 @@ function useCodeIntel(
   const debouncedUpdate = debounce(() => {
     clearCodeIntel();
     applyCodeIntel();
-  }, 200);
+  }, 100);
 
   useEffect(() => {
     debouncedUpdate();

--- a/src/components/molecules/Monaco/useCodeIntel.ts
+++ b/src/components/molecules/Monaco/useCodeIntel.ts
@@ -1,6 +1,8 @@
 import {useEffect, useRef} from 'react';
 import {monaco} from 'react-monaco-editor';
 
+import {debounce} from 'lodash';
+
 import {FileMapType, ResourceFilterType, ResourceMapType} from '@models/appstate';
 import {K8sResource, ResourceRef} from '@models/k8sresource';
 
@@ -52,11 +54,16 @@ function useCodeIntel(
     }
   };
 
-  useEffect(() => {
+  const debouncedUpdate = debounce(() => {
     clearCodeIntel();
     applyCodeIntel();
+  }, 200);
+
+  useEffect(() => {
+    debouncedUpdate();
 
     return () => {
+      debouncedUpdate.cancel();
       clearCodeIntel();
     };
   }, [code, isEditorMounted, selectedResource, resourceMap, editor]);

--- a/src/components/molecules/Monaco/useCodeIntel.ts
+++ b/src/components/molecules/Monaco/useCodeIntel.ts
@@ -1,8 +1,7 @@
 import {useEffect, useRef} from 'react';
 import {monaco} from 'react-monaco-editor';
-import {useDebounce} from 'react-use';
 
-import {FileMapType, ResourceMapType} from '@models/appstate';
+import {FileMapType, ResourceFilterType, ResourceMapType} from '@models/appstate';
 import {K8sResource, ResourceRef} from '@models/k8sresource';
 
 import codeIntel from './codeIntel';
@@ -17,7 +16,8 @@ function useCodeIntel(
   isEditorMounted: boolean,
   selectResource: (resourceId: string) => void,
   selectFilePath: (filePath: string) => void,
-  createResource: (outgoingRef: ResourceRef, namespace?: string, targetFolder?: string) => void
+  createResource: ((outgoingRef: ResourceRef, namespace?: string, targetFolder?: string) => void) | undefined,
+  filterResources: (filter: ResourceFilterType) => void
 ) {
   const idsOfDecorationsRef = useRef<string[]>([]);
   const disposablesRef = useRef<monaco.IDisposable[]>([]);
@@ -34,31 +34,32 @@ function useCodeIntel(
 
   const applyCodeIntel = () => {
     if (editor && selectedResource) {
-      const {newDecorations, newDisposables} = codeIntel.applyForResource(
-        selectedResource,
-        selectResource,
-        selectFilePath,
-        createResource,
-        resourceMap,
-        fileMap
-      );
-      idsOfDecorationsRef.current = setDecorations(editor, newDecorations);
-      disposablesRef.current = newDisposables;
+      codeIntel
+        .applyForResource(
+          selectedResource,
+          selectResource,
+          selectFilePath,
+          createResource,
+          filterResources,
+          resourceMap,
+          fileMap,
+          editor?.getModel()
+        )
+        .then(({newDecorations, newDisposables}) => {
+          idsOfDecorationsRef.current = setDecorations(editor, newDecorations);
+          disposablesRef.current = newDisposables;
+        });
     }
   };
 
-  useDebounce(
-    () => {
-      clearCodeIntel();
-      applyCodeIntel();
+  useEffect(() => {
+    clearCodeIntel();
+    applyCodeIntel();
 
-      return () => {
-        clearCodeIntel();
-      };
-    },
-    200,
-    [code, isEditorMounted, selectedResource, resourceMap, editor]
-  );
+    return () => {
+      clearCodeIntel();
+    };
+  }, [code, isEditorMounted, selectedResource, resourceMap, editor]);
 
   useEffect(() => {
     if (completionDisposableRef.current && completionDisposableRef.current.dispose) {

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -407,6 +407,30 @@ export const mainSlice = createSlice({
     updateResourceFilter: (state: Draft<AppState>, action: PayloadAction<ResourceFilterType>) => {
       state.resourceFilter = action.payload;
     },
+    extendResourceFilter: (state: Draft<AppState>, action: PayloadAction<ResourceFilterType>) => {
+      const filter = action.payload;
+
+      let newFilter: ResourceFilterType = {
+        namespace: filter.namespace || state.resourceFilter.namespace,
+        kind: filter.kind || state.resourceFilter.kind,
+        name: state.resourceFilter.name,
+        labels: filter.labels,
+        annotations: filter.annotations,
+      };
+
+      Object.keys(state.resourceFilter.labels).forEach(key => {
+        if (!newFilter.labels[key]) {
+          newFilter.labels[key] = state.resourceFilter.labels[key];
+        }
+      });
+      Object.keys(state.resourceFilter.annotations).forEach(key => {
+        if (!newFilter.annotations[key]) {
+          newFilter.annotations[key] = state.resourceFilter.annotations[key];
+        }
+      });
+
+      state.resourceFilter = newFilter;
+    },
     setShouldIgnoreOptionalUnsatisfiedRefs: (state: Draft<AppState>, action: PayloadAction<boolean>) => {
       state.resourceRefsProcessingOptions.shouldIgnoreOptionalUnsatisfiedRefs = action.payload;
     },
@@ -862,6 +886,7 @@ export const {
   stopPreviewLoader,
   removeResource,
   updateResourceFilter,
+  extendResourceFilter,
   addNotification,
   setDiffResourceInClusterDiff,
   setClusterDiffRefreshDiffResource,


### PR DESCRIPTION
This PR adds hover actions to editor for extending the current resource filter - see #444 

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
