### PR TITLE
Olelensmar/fix/filter decorations in editor

### DIFF
--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -154,33 +154,18 @@ function addNamespaceFilterLink(
       commandMarkdownLink,
     ]);
     newDisposables.push(hoverDisposable);
-    addLinkDecorations(symbol, newDecorations, 'Add/Remove namespace filter');
+    addLinkDecoration(symbol, newDecorations);
   }
 }
 
-function addLinkDecorations(
+function addLinkDecoration(
   symbol: monaco.languages.DocumentSymbol,
-  newDecorations: monaco.editor.IModelDeltaDecoration[],
-  glyphHoverMessage: string
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
-  // const glyphDecoration: monaco.editor.IModelDeltaDecoration = {
-  //   range: symbol.range,
-  //   options: {
-  //     glyphMarginClassName: 'monokleEditorAddRemoveFilterGlyphClass',
-  //     glyphMarginHoverMessage: {value: glyphHoverMessage},
-  //   },
-  // };
-  //
-  // newDecorations.push(glyphDecoration);
-
   const inlineDecoration: monaco.editor.IModelDeltaDecoration = {
     range: symbol.range,
     options: {
       inlineClassName: 'monokleEditorAddRemoveFilterInlineClass',
-      // overviewRuler: {
-      //   position: monaco.editor.OverviewRulerLane.Left,
-      //   color: 'orange',
-      // },
     },
   };
 
@@ -210,7 +195,7 @@ function addKindFilterLink(
     ]);
     newDisposables.push(hoverDisposable);
 
-    addLinkDecorations(symbol, newDecorations, 'Add/Remove kind filter');
+    addLinkDecoration(symbol, newDecorations);
   }
 }
 
@@ -241,7 +226,7 @@ function addLabelFilterLink(
     ]);
     newDisposables.push(hoverDisposable);
 
-    addLinkDecorations(symbol, newDecorations, 'Add/Remove label to filter');
+    addLinkDecoration(symbol, newDecorations);
   }
 }
 
@@ -272,7 +257,7 @@ function addAnnotationFilterLink(
     ]);
     newDisposables.push(hoverDisposable);
 
-    addLinkDecorations(symbol, newDecorations, 'Add/Remove annotation to filter');
+    addLinkDecoration(symbol, newDecorations);
   }
 }
 

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -136,7 +136,8 @@ function addNamespaceFilterLink(
   lines: string[],
   symbol: monaco.languages.DocumentSymbol,
   filterResources: (filter: ResourceFilterType) => void,
-  newDisposables: monaco.IDisposable[]
+  newDisposables: monaco.IDisposable[],
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
   const namespace = getSymbolValue(lines, symbol);
   if (namespace) {
@@ -153,20 +154,54 @@ function addNamespaceFilterLink(
       commandMarkdownLink,
     ]);
     newDisposables.push(hoverDisposable);
+    addLinkDecorations(symbol, newDecorations, 'Add/Remove namespace filter');
   }
+}
+
+function addLinkDecorations(
+  symbol: monaco.languages.DocumentSymbol,
+  newDecorations: monaco.editor.IModelDeltaDecoration[],
+  glyphHoverMessage: string
+) {
+  // const glyphDecoration: monaco.editor.IModelDeltaDecoration = {
+  //   range: symbol.range,
+  //   options: {
+  //     glyphMarginClassName: 'monokleEditorAddRemoveFilterGlyphClass',
+  //     glyphMarginHoverMessage: {value: glyphHoverMessage},
+  //   },
+  // };
+  //
+  // newDecorations.push(glyphDecoration);
+
+  const inlineDecoration: monaco.editor.IModelDeltaDecoration = {
+    range: symbol.range,
+    options: {
+      inlineClassName: 'monokleEditorAddRemoveFilterInlineClass',
+      // overviewRuler: {
+      //   position: monaco.editor.OverviewRulerLane.Left,
+      //   color: 'orange',
+      // },
+    },
+  };
+
+  newDecorations.push(inlineDecoration);
 }
 
 function addKindFilterLink(
   lines: string[],
   symbol: monaco.languages.DocumentSymbol,
   filterResources: (filter: ResourceFilterType) => void,
-  newDisposables: monaco.IDisposable[]
+  newDisposables: monaco.IDisposable[],
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
   const kind = getSymbolValue(lines, symbol);
   if (kind) {
-    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(`Filter on kind [${kind}]`, () => {
-      filterResources({kind, labels: {}, annotations: {}});
-    });
+    const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
+      `Add/Remove filter on kind [${kind}]`,
+      () => {
+        filterResources({kind, labels: {}, annotations: {}});
+      }
+    );
     newDisposables.push(commandDisposable);
 
     const hoverDisposable = createHoverProvider(symbol.range, [
@@ -174,6 +209,8 @@ function addKindFilterLink(
       commandMarkdownLink,
     ]);
     newDisposables.push(hoverDisposable);
+
+    addLinkDecorations(symbol, newDecorations, 'Add/Remove kind filter');
   }
 }
 
@@ -181,14 +218,15 @@ function addLabelFilterLink(
   lines: string[],
   symbol: monaco.languages.DocumentSymbol,
   filterResources: (filter: ResourceFilterType) => void,
-  newDisposables: monaco.IDisposable[]
+  newDisposables: monaco.IDisposable[],
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
   const label = getSymbolValue(lines, symbol, true);
   if (label) {
     const value = label.substring(symbol.name.length + 1).trim();
 
     const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
-      `Add label [${label}] to current filter`,
+      `Add/Remove label [${label}] from/to current filter`,
       () => {
         const labels: Record<string, string | null> = {};
         labels[symbol.name] = value;
@@ -202,6 +240,8 @@ function addLabelFilterLink(
       commandMarkdownLink,
     ]);
     newDisposables.push(hoverDisposable);
+
+    addLinkDecorations(symbol, newDecorations, 'Add/Remove label to filter');
   }
 }
 
@@ -209,14 +249,15 @@ function addAnnotationFilterLink(
   lines: string[],
   symbol: monaco.languages.DocumentSymbol,
   filterResources: (filter: ResourceFilterType) => void,
-  newDisposables: monaco.IDisposable[]
+  newDisposables: monaco.IDisposable[],
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
   const annotation = getSymbolValue(lines, symbol, true);
   if (annotation) {
     const value = annotation.substring(symbol.name.length + 1).trim();
 
     const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
-      `Add annotation [${annotation}] to current filter`,
+      `Add/Remove annotation [${annotation}] to/from current filter`,
       () => {
         const annotations: Record<string, string | null> = {};
         annotations[symbol.name] = value;
@@ -230,6 +271,8 @@ function addAnnotationFilterLink(
       commandMarkdownLink,
     ]);
     newDisposables.push(hoverDisposable);
+
+    addLinkDecorations(symbol, newDecorations, 'Add/Remove annotation to filter');
   }
 }
 
@@ -237,35 +280,33 @@ function processSymbol(
   symbol: monaco.languages.DocumentSymbol,
   parents: monaco.languages.DocumentSymbol[],
   lines: string[],
-  filterResources: (filter: ResourceFilterType) => void
+  filterResources: (filter: ResourceFilterType) => void,
+  newDisposables: monaco.IDisposable[],
+  newDecorations: monaco.editor.IModelDeltaDecoration[]
 ) {
-  const newDisposables: monaco.IDisposable[] = [];
-
   if (symbol.children) {
     symbol.children.forEach(child => {
-      newDisposables.push(...processSymbol(child, parents.concat(symbol), lines, filterResources));
+      processSymbol(child, parents.concat(symbol), lines, filterResources, newDisposables, newDecorations);
     });
   }
 
   if (symbol.name === 'namespace') {
-    addNamespaceFilterLink(lines, symbol, filterResources, newDisposables);
+    addNamespaceFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);
   }
 
   if (symbol.name === 'kind') {
-    addKindFilterLink(lines, symbol, filterResources, newDisposables);
+    addKindFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);
   }
 
   if (parents.length > 0) {
     const parentName = parents[parents.length - 1].name;
 
     if (parentName === 'labels' || parentName === 'matchLabels') {
-      addLabelFilterLink(lines, symbol, filterResources, newDisposables);
+      addLabelFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);
     } else if (parentName === 'annotations') {
-      addAnnotationFilterLink(lines, symbol, filterResources, newDisposables);
+      addAnnotationFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);
     }
   }
-
-  return newDisposables;
 }
 
 export async function applyForResource(
@@ -286,7 +327,7 @@ export async function applyForResource(
     const symbols: monaco.languages.DocumentSymbol[] = await getSymbols(model);
     const lines = resource.text.split('\n');
 
-    newDisposables.push(...symbols.map(symbol => processSymbol(symbol, [], lines, filterResources)).flat());
+    symbols.forEach(symbol => processSymbol(symbol, [], lines, filterResources, newDisposables, newDecorations));
   }
 
   if (!refs || refs.length === 0) {
@@ -365,7 +406,7 @@ export async function applyForResource(
           return;
         }
         const {commandMarkdownLink, commandDisposable} = createCommandMarkdownLink(
-          `${outgoingRefResource.kind}: ${outgoingRefResource.name}`,
+          `${outgoingRefResource.kind}: ${outgoingRefResource.name} in ${outgoingRefResource.filePath}`,
           () => {
             // @ts-ignore
             selectResource(outgoingRef.target?.resourceId);

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,22 @@ code {
   text-decoration: underline;
 }
 
+.monokleEditorAddRemoveFilterInlineClass {
+  text-decoration-color: orange !important;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.monokleEditorAddRemoveFilterGlyphClass {
+  background-color: orange !important;
+  border-radius: 50%;
+  max-height: 10px;
+  max-width: 10px;
+  margin-top: 5px;
+  margin-left: 15px;
+}
+
+
 .ant-menu-submenu-popup {
   max-height: 250px !important;
   overflow-y: scroll !important;

--- a/src/index.css
+++ b/src/index.css
@@ -40,20 +40,10 @@ code {
 }
 
 .monokleEditorAddRemoveFilterInlineClass {
-  text-decoration-color: orange !important;
+  text-decoration-color: #006d75 !important;
   text-decoration: underline;
   text-decoration-style: dotted;
 }
-
-.monokleEditorAddRemoveFilterGlyphClass {
-  background-color: orange !important;
-  border-radius: 50%;
-  max-height: 10px;
-  max-width: 10px;
-  margin-top: 5px;
-  margin-left: 15px;
-}
-
 
 .ant-menu-submenu-popup {
   max-height: 250px !important;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -411,25 +411,37 @@ export const mainSlice = createSlice({
     extendResourceFilter: (state: Draft<AppState>, action: PayloadAction<ResourceFilterType>) => {
       const filter = action.payload;
 
+      // construct new filter
       let newFilter: ResourceFilterType = {
-        namespace: filter.namespace || state.resourceFilter.namespace,
-        kind: filter.kind || state.resourceFilter.kind,
+        namespace: filter.namespace
+          ? filter.namespace === state.resourceFilter.namespace
+            ? undefined
+            : filter.namespace
+          : state.resourceFilter.namespace,
+        kind: filter.kind
+          ? filter.kind === state.resourceFilter.kind
+            ? undefined
+            : filter.kind
+          : state.resourceFilter.kind,
         name: state.resourceFilter.name,
-        labels: filter.labels,
-        annotations: filter.annotations,
+        labels: state.resourceFilter.labels,
+        annotations: state.resourceFilter.annotations,
       };
 
-      Object.keys(state.resourceFilter.labels).forEach(key => {
-        if (!newFilter.labels[key]) {
-          newFilter.labels[key] = state.resourceFilter.labels[key];
+      Object.keys(filter.labels).forEach(key => {
+        if (newFilter.labels[key] === filter.labels[key]) {
+          delete newFilter.labels[key];
+        } else {
+          newFilter.labels[key] = filter.labels[key];
         }
       });
-      Object.keys(state.resourceFilter.annotations).forEach(key => {
-        if (!newFilter.annotations[key]) {
-          newFilter.annotations[key] = state.resourceFilter.annotations[key];
+      Object.keys(filter.annotations).forEach(key => {
+        if (newFilter.annotations[key] === filter.annotations[key]) {
+          delete newFilter.annotations[key];
+        } else {
+          newFilter.annotations[key] = filter.annotations[key];
         }
       });
-
       state.resourceFilter = newFilter;
     },
     setShouldIgnoreOptionalUnsatisfiedRefs: (state: Draft<AppState>, action: PayloadAction<boolean>) => {


### PR DESCRIPTION
This PR adds underline decorations to all filter links in the editor - and updates filter logic to add/remove the selected filter

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
