### PR TITLE
fix: removed all referring refs when deleting a resource

### DIFF
--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -69,6 +69,7 @@ type RefTargetResource = {
   type: 'resource';
   resourceId?: string;
   resourceKind?: string;
+  isOptional?: boolean; // set true for satisfied refs that were optional
 };
 type RefTargetFile = {
   type: 'file';

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -25,7 +25,7 @@ import {
 } from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 
-import {findResourcesToReprocess} from '@redux/services/resourceRefs';
+import {findResourcesToReprocess, removeReferringRefs} from '@redux/services/resourceRefs';
 import {resetSelectionHistory} from '@redux/services/selectionHistory';
 import {performResourceDiff} from '@redux/thunks/diffResource';
 import {loadClusterDiff} from '@redux/thunks/loadClusterDiff';
@@ -357,6 +357,9 @@ export const mainSlice = createSlice({
       if (!resource) {
         return;
       }
+
+      removeReferringRefs(resource, state.resourceMap);
+
       if (state.selectedResourceId === resourceId) {
         clearResourceSelections(state.resourceMap);
         state.selectedResourceId = undefined;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -25,7 +25,7 @@ import {
 } from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 
-import {findResourcesToReprocess, removeReferringRefs} from '@redux/services/resourceRefs';
+import {findResourcesToReprocess, updateReferringRefsOnDelete} from '@redux/services/resourceRefs';
 import {resetSelectionHistory} from '@redux/services/selectionHistory';
 import {performResourceDiff} from '@redux/thunks/diffResource';
 import {loadClusterDiff} from '@redux/thunks/loadClusterDiff';
@@ -358,7 +358,7 @@ export const mainSlice = createSlice({
         return;
       }
 
-      removeReferringRefs(resource, state.resourceMap);
+      updateReferringRefsOnDelete(resource, state.resourceMap);
 
       if (state.selectedResourceId === resourceId) {
         clearResourceSelections(state.resourceMap);

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -12,6 +12,7 @@ import {FileEntry} from '@models/fileentry';
 import {HelmChart, HelmValuesFile} from '@models/helm';
 import {K8sResource} from '@models/k8sresource';
 
+import {removeReferringRefs} from '@redux/services/resourceRefs';
 import {
   clearResourceSelections,
   highlightChildrenResources,
@@ -20,7 +21,7 @@ import {
 
 import {getFileStats, getFileTimestamp} from '@utils/files';
 
-import {extractK8sResources, isPreviewResource, reprocessResources} from './resource';
+import {extractK8sResources, reprocessResources} from './resource';
 
 type PathRemovalSideEffect = {
   removedResources: K8sResource[];
@@ -530,17 +531,8 @@ export function removePath(absolutePath: string, state: AppState, fileEntry: Fil
     }
   }
 
-  reprocessResources(
-    Object.values(state.resourceMap)
-      .filter(r => !isPreviewResource(r))
-      .map(r => r.id),
-    state.resourceMap,
-    state.fileMap,
-    state.resourceRefsProcessingOptions,
-    {
-      resourceKinds: removalSideEffect.removedResources.map(r => r.kind),
-    }
-  );
+  // clear refs
+  removalSideEffect.removedResources.forEach(r => removeReferringRefs(r, state.resourceMap));
 }
 
 /**

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -12,7 +12,7 @@ import {FileEntry} from '@models/fileentry';
 import {HelmChart, HelmValuesFile} from '@models/helm';
 import {K8sResource} from '@models/k8sresource';
 
-import {removeReferringRefs} from '@redux/services/resourceRefs';
+import {updateReferringRefsOnDelete} from '@redux/services/resourceRefs';
 import {
   clearResourceSelections,
   highlightChildrenResources,
@@ -532,7 +532,7 @@ export function removePath(absolutePath: string, state: AppState, fileEntry: Fil
   }
 
   // clear refs
-  removalSideEffect.removedResources.forEach(r => removeReferringRefs(r, state.resourceMap));
+  removalSideEffect.removedResources.forEach(r => updateReferringRefsOnDelete(r, state.resourceMap));
 }
 
 /**

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -181,7 +181,8 @@ export function createResourceRef(
   refType: ResourceRefType,
   refNode?: NodeWrapper,
   targetResourceId?: string,
-  targetResourceKind?: string
+  targetResourceKind?: string,
+  isOptional?: boolean
 ) {
   if (refNode || targetResourceId) {
     resource.refs = resource.refs || [];
@@ -206,6 +207,7 @@ export function createResourceRef(
           type: 'resource',
           resourceId: targetResourceId,
           resourceKind: targetResourceKind,
+          isOptional,
         },
       });
     }
@@ -222,10 +224,11 @@ export function linkResources(
   source: K8sResource,
   target: K8sResource,
   sourceRef: NodeWrapper,
-  targetRef?: NodeWrapper
+  targetRef?: NodeWrapper,
+  isOptional?: boolean
 ) {
-  createResourceRef(source, ResourceRefType.Outgoing, sourceRef, target.id, target.kind);
-  createResourceRef(target, ResourceRefType.Incoming, targetRef, source.id, source.kind);
+  createResourceRef(source, ResourceRefType.Outgoing, sourceRef, target.id, target.kind, isOptional);
+  createResourceRef(target, ResourceRefType.Incoming, targetRef, source.id, source.kind, isOptional);
 }
 
 /**

--- a/src/redux/services/resourceRefs.ts
+++ b/src/redux/services/resourceRefs.ts
@@ -216,6 +216,27 @@ function cleanResourceRefs(resources: K8sResource[]) {
 }
 
 /**
+ * Removes all refs to the specified resource from other resources
+ */
+
+export function removeReferringRefs(resource: K8sResource, resourceMap: ResourceMapType) {
+  // find all resources with outgoing refs to this resource and remove that ref
+  resource.refs
+    // find outgoing refs that point to a valid resource
+    ?.filter(ref => ref.target?.type === 'resource' && ref.target.resourceId && resourceMap[ref.target.resourceId])
+    // get the target resource for each of those refs
+    // @ts-ignore
+    .map(ref => resourceMap[ref.target.resourceId])
+    // make sure it has refs (it should)
+    .filter(r => r.refs)
+    // remove incoming refs pointing to the removed resource
+    .forEach(r => {
+      // @ts-ignore
+      r.refs = r.refs.filter(ref => ref.target?.type !== 'resource' || ref.target.resourceId !== resource.id);
+    });
+}
+
+/**
  * Creates resource refs from a specified resource to target resources using the specified refMapper
  */
 

--- a/src/redux/services/resourceRefs.ts
+++ b/src/redux/services/resourceRefs.ts
@@ -216,7 +216,8 @@ function cleanResourceRefs(resources: K8sResource[]) {
 }
 
 /**
- * Removes all refs to the specified resource from other resources
+ * Updates all refs to the specified deleted resource from other resources - outgoing links to the
+ * deleted resource are either made unsatisifed or removed (if they were optional)
  */
 
 export function updateReferringRefsOnDelete(resource: K8sResource, resourceMap: ResourceMapType) {


### PR DESCRIPTION
A side-benefit of this is that we now have an isOptional flag on refs - which we could use in the ref popups (and anywhere else) to indicate that a ref is optional (goes for both satisfied and unsatisfied refs)

## Changes

-

## Fixes

- #852 

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
