### PR TITLE
refactor: show resource filters as a panel

### DIFF
--- a/src/components/atoms/KeyValueInput/KeyValueInput.tsx
+++ b/src/components/atoms/KeyValueInput/KeyValueInput.tsx
@@ -11,7 +11,6 @@ import {v4 as uuidv4} from 'uuid';
 import Colors from '@styles/Colors';
 
 const Container = styled.div`
-  min-width: 600px;
   max-height: 800px;
   overflow-y: auto;
 `;
@@ -24,13 +23,21 @@ const TitleContainer = styled.div`
 const TitleLabel = styled.span``;
 
 const KeyValueContainer = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-gap: 8px;
   align-items: center;
   margin: 10px 0;
 `;
 
+const KeyValueRemoveButtonContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-gap: 8px;
+  align-items: center;
+`;
+
 const StyledRemoveButton = styled(Button)`
-  margin-left: 8px;
   min-width: 24px;
 `;
 
@@ -146,46 +153,38 @@ function KeyValueInput(props: KeyValueInputProps) {
         </Button>
       </TitleContainer>
       {entries.map(entry => (
-        <KeyValueContainer key={entry.id}>
-          <Select
-            value={entry.key}
-            onChange={newKey => updateEntryKey(entry.id, newKey)}
-            style={{width: '100%'}}
-            showSearch
-          >
-            {Object.keys(data)
-              .filter(key => key === entry.key || !entries.some(e => e.key === key))
-              .map(key => (
-                <Select.Option key={key} value={key}>
-                  {key}
-                </Select.Option>
-              ))}
-          </Select>
-          {entry.key && (
-            <Select
-              value={entry.value}
-              onChange={newValue => updateEntryValue(entry.id, newValue)}
-              style={{width: '100%', marginLeft: 8}}
-              showSearch
-            >
-              <Select.Option key={ANY_VALUE} value={ANY_VALUE}>
-                {ANY_VALUE}
-              </Select.Option>
-              {data[entry.key] &&
-                data[entry.key].map((value: string) => (
-                  <Select.Option key={value} value={value}>
-                    {value}
+        <KeyValueRemoveButtonContainer>
+          <KeyValueContainer key={entry.id}>
+            <Select value={entry.key} onChange={newKey => updateEntryKey(entry.id, newKey)} showSearch>
+              {Object.keys(data)
+                .filter(key => key === entry.key || !entries.some(e => e.key === key))
+                .map(key => (
+                  <Select.Option key={key} value={key}>
+                    {key}
                   </Select.Option>
                 ))}
             </Select>
-          )}
+            {entry.key && (
+              <Select value={entry.value} onChange={newValue => updateEntryValue(entry.id, newValue)} showSearch>
+                <Select.Option key={ANY_VALUE} value={ANY_VALUE}>
+                  {ANY_VALUE}
+                </Select.Option>
+                {data[entry.key] &&
+                  data[entry.key].map((value: string) => (
+                    <Select.Option key={value} value={value}>
+                      {value}
+                    </Select.Option>
+                  ))}
+              </Select>
+            )}
+          </KeyValueContainer>
           <StyledRemoveButton
             onClick={() => removeEntry(entry.id)}
             color={Colors.redError}
             size="small"
             icon={<MinusOutlined />}
           />
-        </KeyValueContainer>
+        </KeyValueRemoveButtonContainer>
       ))}
     </Container>
   );

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -21,7 +21,7 @@ import {ResourceKindHandlers} from '@src/kindhandlers';
 const ALL_OPTIONS = '<all>';
 
 const BaseContainer = styled.div`
-  min-width: 400px;
+  min-width: 250px;
 `;
 
 const FieldContainer = styled.div`

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -33,7 +33,7 @@ import WarningsAndErrorsDisplay from './WarningsAndErrorsDisplay';
 
 const FiltersContainer = styled.div`
   padding: 10px 16px;
-  max-height: 500px;
+  max-height: 30vh;
   overflow-y: auto;
   ::-webkit-scrollbar {
     width: 0;

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -1,9 +1,11 @@
 import {useContext, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import {Badge} from 'antd';
+import {Badge, Button, Divider} from 'antd';
 
 import {FilterOutlined, PlusOutlined} from '@ant-design/icons';
+
+import styled from 'styled-components';
 
 import {NAVIGATOR_HEIGHT_OFFSET, ROOT_FILE_ENTRY} from '@constants/constants';
 
@@ -11,12 +13,11 @@ import {ResourceFilterType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {openNewResourceWizard} from '@redux/reducers/ui';
+import {openNewResourceWizard, toggleResourceFilters} from '@redux/reducers/ui';
 import {activeResourcesSelector, isInClusterModeSelector, isInPreviewModeSelector} from '@redux/selectors';
 
 import {MonoPaneTitle} from '@components/atoms';
 import {ResourceFilter, SectionRenderer} from '@components/molecules';
-import IconWithPopover from '@components/molecules/IconWithPopover';
 
 import Colors from '@styles/Colors';
 
@@ -30,6 +31,16 @@ import ClusterCompareButton from './ClusterCompareButton';
 import * as S from './NavigatorPane.styled';
 import WarningsAndErrorsDisplay from './WarningsAndErrorsDisplay';
 
+const FiltersContainer = styled.div`
+  padding: 10px 16px;
+  max-height: 500px;
+  overflow-y: auto;
+  ::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
+  }
+`;
+
 const NavPane: React.FC = () => {
   const dispatch = useAppDispatch();
   const {windowSize} = useContext(AppContext);
@@ -39,6 +50,8 @@ const NavPane: React.FC = () => {
   const fileMap = useAppSelector(state => state.main.fileMap);
   const resourceFilters: ResourceFilterType = useAppSelector(state => state.main.resourceFilter);
   const activeResources = useAppSelector(activeResourcesSelector);
+
+  const isResourceFiltersOpen = useAppSelector(state => state.ui.isResourceFiltersOpen);
 
   const isInClusterMode = useSelector(isInClusterModeSelector);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
@@ -59,6 +72,10 @@ const NavPane: React.FC = () => {
     dispatch(openNewResourceWizard());
   };
 
+  const resourceFilterButtonHandler = () => {
+    dispatch(toggleResourceFilters());
+  };
+
   return (
     <>
       <S.TitleBar>
@@ -74,17 +91,27 @@ const NavPane: React.FC = () => {
             icon={<PlusOutlined />}
           />
           <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
-            <IconWithPopover
-              popoverContent={<ResourceFilter />}
-              popoverTrigger="click"
-              iconComponent={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
-              isDisabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
+            <Button
+              disabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
+              type="link"
+              size="small"
+              icon={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
+              onClick={resourceFilterButtonHandler}
             />
           </Badge>
           <ClusterCompareButton />
         </S.TitleBarRightButtons>
       </S.TitleBar>
       <S.List height={navigatorHeight}>
+        {isResourceFiltersOpen && (
+          <>
+            <FiltersContainer>
+              <ResourceFilter />
+            </FiltersContainer>
+            <Divider style={{margin: 0, marginBottom: 12}} />
+          </>
+        )}
+
         <SectionRenderer<K8sResource, K8sResourceScopeType>
           sectionBlueprint={K8sResourceSectionBlueprint}
           level={0}

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -50,6 +50,7 @@ export type LeftMenuSelection =
   | 'templates-pane';
 
 export type UiState = {
+  isResourceFiltersOpen: boolean;
   isSettingsOpen: boolean;
   isClusterDiffVisible: boolean;
   isNotificationsOpen: boolean;

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -86,6 +86,7 @@ const initialLogsState: LogsState = {
 const uiLeftMenuSelection = electronStore.get('ui.leftMenu.selection');
 
 const initialUiState: UiState = {
+  isResourceFiltersOpen: false,
   isSettingsOpen: electronStore.get('ui.isSettingsOpen'),
   isClusterDiffVisible: false,
   isNotificationsOpen: electronStore.get('ui.isNotificationsOpen'),

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -16,6 +16,9 @@ export const uiSlice = createSlice({
   name: 'ui',
   initialState: initialState.ui,
   reducers: {
+    toggleResourceFilters: (state: Draft<UiState>) => {
+      state.isResourceFiltersOpen = !state.isResourceFiltersOpen;
+    },
     toggleSettings: (state: Draft<UiState>) => {
       state.isSettingsOpen = !state.isSettingsOpen;
       electronStore.set('ui.isSettingsOpen', state.isSettingsOpen);
@@ -208,6 +211,7 @@ export const uiSlice = createSlice({
 });
 
 export const {
+  toggleResourceFilters,
   toggleSettings,
   openClusterDiff,
   closeClusterDiff,


### PR DESCRIPTION
## Changes

- Show resource filters as a panel instead of a popup

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
