### PR TITLE
feat: added action to reset filters when no resources match

### DIFF
--- a/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
+++ b/src/components/organisms/SettingsDrawer/SettingsDrawer.tsx
@@ -314,6 +314,14 @@ const SettingsDrawer = () => {
         />
       </StyledDiv>
       <StyledDiv>
+        <Checkbox
+          checked={appConfig.settings.hideExcludedFilesInFileExplorer}
+          onChange={onChangeHideExcludedFilesInFileExplorer}
+        >
+          Hide excluded files
+        </Checkbox>
+      </StyledDiv>
+      <StyledDiv>
         <StyledSpan>Helm Preview Mode</StyledSpan>
         <Tooltip title={HelmPreviewModeTooltip}>
           <StyledSelect value={appConfig.settings.helmPreviewMode} onChange={onChangeHelmPreviewMode}>
@@ -338,15 +346,6 @@ const SettingsDrawer = () => {
             Automatically load last folder
           </Checkbox>
         </Tooltip>
-      </StyledDiv>
-      <StyledDiv>
-        <StyledSpan>File Explorer</StyledSpan>
-        <Checkbox
-          checked={appConfig.settings.hideExcludedFilesInFileExplorer}
-          onChange={onChangeHideExcludedFilesInFileExplorer}
-        >
-          Hide excluded files
-        </Checkbox>
       </StyledDiv>
       <StyledDiv>
         <StyledSpan>Maximum folder read recursion depth</StyledSpan>

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
 
-import {useAppSelector} from '@redux/hooks';
+import {ResourceFilterType} from '@models/appstate';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {updateResourceFilter} from '@redux/reducers/main';
 import {activeResourcesSelector} from '@redux/selectors';
 
 function K8sResourceSectionEmptyDisplay() {
   const activeResources = useAppSelector(activeResourcesSelector);
+  const dispatch = useAppDispatch();
+
+  function resetFilters() {
+    const emptyFilter: ResourceFilterType = {annotations: {}, labels: {}};
+    dispatch(updateResourceFilter(emptyFilter));
+  }
 
   return (
     <>
@@ -12,7 +21,9 @@ function K8sResourceSectionEmptyDisplay() {
       {activeResources.length === 0 ? (
         <p>No resources found in the current folder.</p>
       ) : (
-        <p>No resources match the active filters.</p>
+        <p>
+          No resources match the active filters. <a onClick={resetFilters}>[Reset Filters]</a>{' '}
+        </p>
       )}
     </>
   );

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionEmptyDisplay.tsx
@@ -22,7 +22,7 @@ function K8sResourceSectionEmptyDisplay() {
         <p>No resources found in the current folder.</p>
       ) : (
         <p>
-          No resources match the active filters. <a onClick={resetFilters}>[Reset Filters]</a>{' '}
+          No resources match the active filters. <a onClick={resetFilters}>[Reset Filters]</a>
         </p>
       )}
     </>


### PR DESCRIPTION
This PR adds a "Reset filters" link to the "No resources match the active filters" message (cause I'm lazy and don't want to have to open the filters panel to reset..)

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
