### PR TITLE
feat: Actions menu for checkable resources

### DIFF
--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 import {Menu} from 'antd';
 
+import {CloseOutlined} from '@ant-design/icons';
+
 import styled from 'styled-components';
 
-import {useAppDispatch} from '@redux/hooks';
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {uncheckAllResourceIds} from '@redux/reducers/main';
 
 import Colors from '@styles/Colors';
@@ -16,19 +18,43 @@ const StyledMenu = styled(Menu)`
   line-height: 1.57;
   display: flex;
   align-items: center;
+
+  & .ant-menu-item {
+    padding: 0 12px !important;
+  }
+
+  & .ant-menu-item::after {
+    left: 12px;
+    right: 12px;
+  }
+
+  & li:first-child {
+    color: ${Colors.grey7};
+    cursor: default;
+  }
 `;
 
 const CheckedResourcesActionsMenu: React.FC = () => {
   const dispatch = useAppDispatch();
 
+  const checkedResourceIds = useAppSelector(state => state.main.checkedResourceIds);
+
+  const deselectHandler = () => {
+    dispatch(uncheckAllResourceIds());
+  };
+
   return (
     <StyledMenu mode="horizontal">
+      <Menu.Item disabled key="resources-selected">
+        {checkedResourceIds.length} Selected
+      </Menu.Item>
       <Menu.Item style={{color: Colors.red7}} key="delete">
         Delete
       </Menu.Item>
+      <Menu.Item key="deploy">Deploy</Menu.Item>
 
-      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={() => dispatch(uncheckAllResourceIds())}>
-        Deselect
+      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={deselectHandler}>
+        <CloseOutlined />
       </Menu.Item>
     </StyledMenu>
   );

--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -8,6 +8,8 @@ import styled from 'styled-components';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {uncheckAllResourceIds} from '@redux/reducers/main';
+import {isInClusterModeSelector} from '@redux/selectors';
+import {applyCheckedResources} from '@redux/thunks/applyCheckedResources';
 
 import Colors from '@styles/Colors';
 
@@ -38,6 +40,12 @@ const CheckedResourcesActionsMenu: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const checkedResourceIds = useAppSelector(state => state.main.checkedResourceIds);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
+  console.log(isInClusterMode);
+
+  const deployHandler = () => {
+    dispatch(applyCheckedResources());
+  };
 
   const deselectHandler = () => {
     dispatch(uncheckAllResourceIds());
@@ -51,7 +59,11 @@ const CheckedResourcesActionsMenu: React.FC = () => {
       <Menu.Item style={{color: Colors.red7}} key="delete">
         Delete
       </Menu.Item>
-      <Menu.Item key="deploy">Deploy</Menu.Item>
+      {!isInClusterMode && (
+        <Menu.Item key="deploy" onClick={deployHandler}>
+          Deploy
+        </Menu.Item>
+      )}
 
       <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={deselectHandler}>
         <CloseOutlined />

--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -12,6 +12,10 @@ import Colors from '@styles/Colors';
 const StyledMenu = styled(Menu)`
   background: linear-gradient(90deg, #112a45 0%, #111d2c 100%);
   color: ${Colors.blue6};
+  height: 40px;
+  line-height: 1.57;
+  display: flex;
+  align-items: center;
 `;
 
 const CheckedResourcesActionsMenu: React.FC = () => {

--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -84,7 +84,7 @@ const CheckedResourcesActionsMenu: React.FC = () => {
     applyCheckedResourcesWithConfirm(checkedResourceIds.length, currentContext, dispatch);
   };
 
-  const onClickDeselectChecked = () => {
+  const onClickUncheckAll = () => {
     dispatch(uncheckAllResourceIds());
   };
 
@@ -105,7 +105,7 @@ const CheckedResourcesActionsMenu: React.FC = () => {
         </Menu.Item>
       )}
 
-      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={onClickDeselectChecked}>
+      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={onClickUncheckAll}>
         <CloseOutlined />
       </Menu.Item>
     </StyledMenu>

--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {uncheckAllResourceIds} from '@redux/reducers/main';
 import {isInClusterModeSelector} from '@redux/selectors';
-import {applyCheckedResources} from '@redux/thunks/applyCheckedResources';
+import applyCheckedResourcesWithConfirm from '@redux/services/applyCheckedResourcesWithConfirm';
 
 import Colors from '@styles/Colors';
 
@@ -40,14 +40,18 @@ const CheckedResourcesActionsMenu: React.FC = () => {
   const dispatch = useAppDispatch();
 
   const checkedResourceIds = useAppSelector(state => state.main.checkedResourceIds);
+  const currentContext = useAppSelector(state => state.config.kubeConfig.currentContext);
   const isInClusterMode = useAppSelector(isInClusterModeSelector);
-  console.log(isInClusterMode);
 
-  const deployHandler = () => {
-    dispatch(applyCheckedResources());
+  const onClickDeployChecked = () => {
+    if (!currentContext) {
+      return;
+    }
+
+    applyCheckedResourcesWithConfirm(checkedResourceIds.length, currentContext, dispatch);
   };
 
-  const deselectHandler = () => {
+  const onClickDeselectChecked = () => {
     dispatch(uncheckAllResourceIds());
   };
 
@@ -60,12 +64,12 @@ const CheckedResourcesActionsMenu: React.FC = () => {
         Delete
       </Menu.Item>
       {!isInClusterMode && (
-        <Menu.Item key="deploy" onClick={deployHandler}>
+        <Menu.Item key="deploy" onClick={onClickDeployChecked}>
           Deploy
         </Menu.Item>
       )}
 
-      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={deselectHandler}>
+      <Menu.Item style={{marginLeft: 'auto'}} key="deselect" onClick={onClickDeselectChecked}>
         <CloseOutlined />
       </Menu.Item>
     </StyledMenu>

--- a/src/components/molecules/ClusterDiff/ClusterDiff.tsx
+++ b/src/components/molecules/ClusterDiff/ClusterDiff.tsx
@@ -4,13 +4,11 @@ import {Divider} from 'antd';
 
 import styled from 'styled-components';
 
-import {ClusterToLocalResourcesMatch} from '@models/appstate';
-
 import {ResourceFilterIconWithPopover, SectionRenderer} from '@components/molecules';
 
 import {GlobalScrollbarStyle} from '@utils/scrollbar';
 
-import ClusterDiffSectionBlueprint, {ClusterDiffScopeType} from '@src/navsections/ClusterDiffSectionBlueprint';
+import ClusterDiffSectionBlueprint from '@src/navsections/ClusterDiffSectionBlueprint';
 
 import * as S from './ClusterDiff.styled';
 import ClusterDiffNamespaceFilter from './ClusterDiffNamespaceFilter';
@@ -49,11 +47,7 @@ function ClusterDiff() {
         <Divider style={{margin: '8px 0'}} />
         <ListContainer>
           <S.List>
-            <SectionRenderer<ClusterToLocalResourcesMatch, ClusterDiffScopeType>
-              sectionBlueprint={ClusterDiffSectionBlueprint}
-              level={0}
-              isLastSection={false}
-            />
+            <SectionRenderer sectionBlueprint={ClusterDiffSectionBlueprint} level={0} isLastSection={false} />
           </S.List>
         </ListContainer>
       </LeftPane>

--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -13,14 +13,14 @@ import {useSectionCustomization} from './useSectionCustomization';
 
 import * as S from './styled';
 
-type SectionRendererProps<ItemType, ScopeType> = {
-  sectionBlueprint: SectionBlueprint<ItemType, ScopeType>;
+type SectionRendererProps = {
+  sectionBlueprint: SectionBlueprint<any>;
   level: number;
   isLastSection: boolean;
   itemRendererOptions?: ItemRendererOptions;
 };
 
-function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemType, ScopeType>) {
+function SectionRenderer(props: SectionRendererProps) {
   const {sectionBlueprint, level, isLastSection, itemRendererOptions} = props;
 
   const {itemBlueprint, name: sectionName, id: sectionId} = sectionBlueprint;
@@ -185,7 +185,7 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
         itemBlueprint &&
         sectionInstance.groups.length === 0 &&
         sectionInstance.visibleItemIds.map(itemId => (
-          <ItemRenderer<ItemType, ScopeType>
+          <ItemRenderer
             key={itemId}
             itemId={itemId}
             blueprint={itemBlueprint}
@@ -210,7 +210,7 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
                 </S.Name>
               </S.NameContainer>
               {group.visibleItemIds.map(itemId => (
-                <ItemRenderer<ItemType, ScopeType>
+                <ItemRenderer
                   key={itemId}
                   itemId={itemId}
                   blueprint={itemBlueprint}
@@ -227,7 +227,7 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
         sectionBlueprint.childSectionIds
           .map(childSectionId => navSectionMap.getById(childSectionId))
           .map(child => (
-            <SectionRenderer<ItemType, ScopeType>
+            <SectionRenderer
               key={child.name}
               sectionBlueprint={child}
               level={level + 1}
@@ -238,4 +238,4 @@ function SectionRenderer<ItemType, ScopeType>(props: SectionRendererProps<ItemTy
   );
 }
 
-export default SectionRenderer;
+export default React.memo(SectionRenderer);

--- a/src/components/organisms/HelmPane/HelmPane.tsx
+++ b/src/components/organisms/HelmPane/HelmPane.tsx
@@ -2,13 +2,11 @@ import React, {useContext} from 'react';
 
 import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
 
-import {HelmValuesFile} from '@models/helm';
-
 import {MonoPaneTitle} from '@components/atoms';
 import {SectionRenderer} from '@components/molecules';
 
 import AppContext from '@src/AppContext';
-import HelmChartSectionBlueprint, {HelmChartScopeType} from '@src/navsections/HelmChartSectionBlueprint';
+import HelmChartSectionBlueprint from '@src/navsections/HelmChartSectionBlueprint';
 
 import * as S from './styled';
 
@@ -23,11 +21,7 @@ const HelmPane: React.FC = () => {
         <MonoPaneTitle>Helm</MonoPaneTitle>
       </S.TitleBar>
       <S.List height={navigatorHeight}>
-        <SectionRenderer<HelmValuesFile, HelmChartScopeType>
-          sectionBlueprint={HelmChartSectionBlueprint}
-          level={0}
-          isLastSection={false}
-        />
+        <SectionRenderer sectionBlueprint={HelmChartSectionBlueprint} level={0} isLastSection={false} />
       </S.List>
     </>
   );

--- a/src/components/organisms/KustomizePane/KustomizePane.tsx
+++ b/src/components/organisms/KustomizePane/KustomizePane.tsx
@@ -2,14 +2,12 @@ import React, {useContext} from 'react';
 
 import {NAVIGATOR_HEIGHT_OFFSET} from '@constants/constants';
 
-import {K8sResource} from '@models/k8sresource';
-
 import {MonoPaneTitle} from '@components/atoms';
 import {SectionRenderer} from '@components/molecules';
 
 import AppContext from '@src/AppContext';
-import KustomizationSectionBlueprint, {KustomizationScopeType} from '@src/navsections/KustomizationSectionBlueprint';
-import KustomizePatchSectionBlueprint, {KustomizePatchScopeType} from '@src/navsections/KustomizePatchSectionBlueprint';
+import KustomizationSectionBlueprint from '@src/navsections/KustomizationSectionBlueprint';
+import KustomizePatchSectionBlueprint from '@src/navsections/KustomizePatchSectionBlueprint';
 
 import * as S from './styled';
 
@@ -24,16 +22,8 @@ const HelmPane: React.FC = () => {
         <MonoPaneTitle>Kustomize</MonoPaneTitle>
       </S.TitleBar>
       <S.List height={navigatorHeight}>
-        <SectionRenderer<K8sResource, KustomizationScopeType>
-          sectionBlueprint={KustomizationSectionBlueprint}
-          level={0}
-          isLastSection={false}
-        />
-        <SectionRenderer<K8sResource, KustomizePatchScopeType>
-          sectionBlueprint={KustomizePatchSectionBlueprint}
-          level={0}
-          isLastSection={false}
-        />
+        <SectionRenderer sectionBlueprint={KustomizationSectionBlueprint} level={0} isLastSection={false} />
+        <SectionRenderer sectionBlueprint={KustomizePatchSectionBlueprint} level={0} isLastSection={false} />
       </S.List>
     </>
   );

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -67,11 +67,12 @@ const NavPane: React.FC = () => {
 
   const [filtersContainerRef, {height, width}] = useMeasure<HTMLDivElement>();
 
-  const fileMap = useAppSelector(state => state.main.fileMap);
   const resourceFilters: ResourceFilterType = useAppSelector(state => state.main.resourceFilter);
-  const activeResources = useAppSelector(activeResourcesSelector);
 
+  const activeResources = useAppSelector(activeResourcesSelector);
   const checkedResourceIds = useAppSelector(state => state.main.checkedResourceIds);
+  const fileMap = useAppSelector(state => state.main.fileMap);
+  const isPreviewLoading = useAppSelector(state => state.main.previewLoader.isLoading);
   const isResourceFiltersOpen = useAppSelector(state => state.ui.isResourceFiltersOpen);
 
   const isInClusterMode = useSelector(isInClusterModeSelector);
@@ -99,7 +100,7 @@ const NavPane: React.FC = () => {
 
   return (
     <>
-      {checkedResourceIds.length ? (
+      {checkedResourceIds.length && !isPreviewLoading ? (
         <CheckedResourcesActionsMenu />
       ) : (
         <S.TitleBar>

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -62,8 +62,6 @@ const FiltersContainer = styled.div`
 const NavPane: React.FC = () => {
   const dispatch = useAppDispatch();
   const {windowSize} = useContext(AppContext);
-  const windowHeight = windowSize.height;
-  const navigatorHeight = windowHeight - NAVIGATOR_HEIGHT_OFFSET;
 
   const [filtersContainerRef, {height, width}] = useMeasure<HTMLDivElement>();
 
@@ -78,6 +76,9 @@ const NavPane: React.FC = () => {
   const isInClusterMode = useSelector(isInClusterModeSelector);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
 
+  const windowHeight = windowSize.height;
+  const navigatorHeight = windowHeight - NAVIGATOR_HEIGHT_OFFSET;
+
   const appliedFilters = useMemo(() => {
     return Object.entries(resourceFilters)
       .map(([key, value]) => {
@@ -89,6 +90,14 @@ const NavPane: React.FC = () => {
   const isFolderOpen = useMemo(() => {
     return Boolean(fileMap[ROOT_FILE_ENTRY]);
   }, [fileMap]);
+
+  const sectionListHeight = useMemo(() => {
+    if (isResourceFiltersOpen && height) {
+      return navigatorHeight - (height + 24);
+    }
+
+    return navigatorHeight;
+  }, [height, isResourceFiltersOpen, navigatorHeight]);
 
   const onClickNewResource = () => {
     dispatch(openNewResourceWizard());
@@ -147,8 +156,7 @@ const NavPane: React.FC = () => {
         </>
       )}
 
-      {/* 15 - Divider height */}
-      <S.List height={navigatorHeight - (isResourceFiltersOpen && height ? height + 15 : 0)}>
+      <S.List height={sectionListHeight}>
         <SectionRenderer<K8sResource, K8sResourceScopeType>
           sectionBlueprint={K8sResourceSectionBlueprint}
           level={0}

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -99,30 +99,34 @@ const NavPane: React.FC = () => {
 
   return (
     <>
-      <S.TitleBar>
-        <MonoPaneTitle>
-          Navigator <WarningsAndErrorsDisplay />
-        </MonoPaneTitle>
-        <S.TitleBarRightButtons>
-          <S.PlusButton
-            disabled={!isFolderOpen || isInClusterMode || isInPreviewMode}
-            onClick={onClickNewResource}
-            type="link"
-            size="small"
-            icon={<PlusOutlined />}
-          />
-          <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
-            <Button
-              disabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
+      {checkedResourceIds.length ? (
+        <CheckedResourcesActionsMenu />
+      ) : (
+        <S.TitleBar>
+          <MonoPaneTitle>
+            Navigator <WarningsAndErrorsDisplay />
+          </MonoPaneTitle>
+          <S.TitleBarRightButtons>
+            <S.PlusButton
+              disabled={!isFolderOpen || isInClusterMode || isInPreviewMode}
+              onClick={onClickNewResource}
               type="link"
               size="small"
-              icon={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
-              onClick={resourceFilterButtonHandler}
+              icon={<PlusOutlined />}
             />
-          </Badge>
-          <ClusterCompareButton />
-        </S.TitleBarRightButtons>
-      </S.TitleBar>
+            <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
+              <Button
+                disabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
+                type="link"
+                size="small"
+                icon={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
+                onClick={resourceFilterButtonHandler}
+              />
+            </Badge>
+            <ClusterCompareButton />
+          </S.TitleBarRightButtons>
+        </S.TitleBar>
+      )}
 
       {isResourceFiltersOpen && (
         <>
@@ -141,8 +145,6 @@ const NavPane: React.FC = () => {
           </FiltersContainer>
         </>
       )}
-
-      {checkedResourceIds.length ? <CheckedResourcesActionsMenu /> : null}
 
       {/* 20 - FiltersContainer padding & 15 - Divider height */}
       <S.List height={navigatorHeight - (isResourceFiltersOpen && height ? height + 20 + 15 : 0)}>

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -38,11 +38,11 @@ import WarningsAndErrorsDisplay from './WarningsAndErrorsDisplay';
 
 const FiltersContainer = styled.div`
   position: relative;
-  padding: 0px 16px;
+  padding: 6px 0 3px 0;
   margin-bottom: 10px;
 
   & .react-resizable {
-    padding: 10px 16px;
+    padding: 8px 16px;
     overflow-y: auto;
 
     ${GlobalScrollbarStyle}
@@ -146,8 +146,8 @@ const NavPane: React.FC = () => {
         </>
       )}
 
-      {/* 20 - FiltersContainer padding & 15 - Divider height */}
-      <S.List height={navigatorHeight - (isResourceFiltersOpen && height ? height + 20 + 15 : 0)}>
+      {/* 15 - Divider height */}
+      <S.List height={navigatorHeight - (isResourceFiltersOpen && height ? height + 15 : 0)}>
         <SectionRenderer<K8sResource, K8sResourceScopeType>
           sectionBlueprint={K8sResourceSectionBlueprint}
           level={0}

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -12,7 +12,6 @@ import styled from 'styled-components';
 import {NAVIGATOR_HEIGHT_OFFSET, ROOT_FILE_ENTRY} from '@constants/constants';
 
 import {ResourceFilterType} from '@models/appstate';
-import {K8sResource} from '@models/k8sresource';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {openNewResourceWizard, toggleResourceFilters} from '@redux/reducers/ui';
@@ -27,10 +26,8 @@ import {GlobalScrollbarStyle} from '@utils/scrollbar';
 import Colors from '@styles/Colors';
 
 import AppContext from '@src/AppContext';
-import K8sResourceSectionBlueprint, {K8sResourceScopeType} from '@src/navsections/K8sResourceSectionBlueprint';
-import UnknownResourceSectionBlueprint, {
-  UnknownResourceScopeType,
-} from '@src/navsections/UnknownResourceSectionBlueprint';
+import K8sResourceSectionBlueprint from '@src/navsections/K8sResourceSectionBlueprint';
+import UnknownResourceSectionBlueprint from '@src/navsections/UnknownResourceSectionBlueprint';
 
 import ClusterCompareButton from './ClusterCompareButton';
 import * as S from './NavigatorPane.styled';
@@ -157,16 +154,8 @@ const NavPane: React.FC = () => {
       )}
 
       <S.List height={sectionListHeight}>
-        <SectionRenderer<K8sResource, K8sResourceScopeType>
-          sectionBlueprint={K8sResourceSectionBlueprint}
-          level={0}
-          isLastSection={false}
-        />
-        <SectionRenderer<K8sResource, UnknownResourceScopeType>
-          sectionBlueprint={UnknownResourceSectionBlueprint}
-          level={0}
-          isLastSection={false}
-        />
+        <SectionRenderer sectionBlueprint={K8sResourceSectionBlueprint} level={0} isLastSection={false} />
+        <SectionRenderer sectionBlueprint={UnknownResourceSectionBlueprint} level={0} isLastSection={false} />
       </S.List>
     </>
   );

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -612,6 +612,7 @@ export const mainSlice = createSlice({
         state.selectedPath = undefined;
         state.selectedValuesFileId = undefined;
         state.clusterDiff.shouldReload = true;
+        state.checkedResourceIds = [];
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
@@ -627,6 +628,7 @@ export const mainSlice = createSlice({
         state.currentSelectionHistoryIndex = undefined;
         resetSelectionHistory(state);
         state.selectedResourceId = undefined;
+        state.checkedResourceIds = [];
         if (action.payload.previewResourceId && state.helmValuesMap[action.payload.previewResourceId]) {
           selectFilePath(state.helmValuesMap[action.payload.previewResourceId].filePath, state);
         }
@@ -647,6 +649,7 @@ export const mainSlice = createSlice({
         state.selectedResourceId = undefined;
         state.selectedPath = undefined;
         state.selectedValuesFileId = undefined;
+        state.checkedResourceIds = [];
         Object.values(state.resourceMap).forEach(resource => {
           resource.isSelected = false;
           resource.isHighlighted = false;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -696,6 +696,7 @@ export const mainSlice = createSlice({
         isLoading: false,
         targetResourceId: undefined,
       };
+      state.checkedResourceIds = [];
       state.diffResourceId = undefined;
       state.diffContent = undefined;
       state.isSelectingFile = false;

--- a/src/redux/services/applyCheckedResourcesWithConfirm.tsx
+++ b/src/redux/services/applyCheckedResourcesWithConfirm.tsx
@@ -1,0 +1,30 @@
+import {Modal} from 'antd';
+
+import {ExclamationCircleOutlined} from '@ant-design/icons';
+
+import {ThunkDispatch} from 'redux-thunk';
+
+import {applyCheckedResources} from '@redux/thunks/applyCheckedResources';
+
+const applyCheckedResourcesWithConfirm = (
+  checkedResourcesLength: number,
+  context: string,
+  dispatch: ThunkDispatch<any, any, any>
+) => {
+  const title = `Deploy selected resources (${checkedResourcesLength}) to cluster [${context}]?`;
+
+  Modal.confirm({
+    title,
+    icon: <ExclamationCircleOutlined />,
+    centered: true,
+    onOk() {
+      return new Promise(resolve => {
+        dispatch(applyCheckedResources());
+        resolve({});
+      });
+    },
+    onCancel() {},
+  });
+};
+
+export default applyCheckedResourcesWithConfirm;

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -1,4 +1,5 @@
 import log from 'loglevel';
+import {ThunkDispatch} from 'redux-thunk';
 
 import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
@@ -7,7 +8,6 @@ import {AppConfig} from '@models/appconfig';
 import {K8sResource} from '@models/k8sresource';
 
 import {setAlert} from '@redux/reducers/alert';
-import {AppDispatch} from '@redux/store';
 import {applyYamlToCluster} from '@redux/thunks/applyYaml';
 
 import {doesTextStartWithYamlDocumentDelimiter} from './resource';
@@ -15,7 +15,7 @@ import {doesTextStartWithYamlDocumentDelimiter} from './resource';
 const applyMultipleResources = (
   stateConfig: AppConfig,
   resourcesToApply: K8sResource[],
-  dispatch: AppDispatch,
+  dispatch: ThunkDispatch<any, any, any>,
   onSuccessCallback?: () => void
 ) => {
   const kubeconfigPath = stateConfig.kubeconfigPath;

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -13,13 +13,13 @@ import {applyYamlToCluster} from '@redux/thunks/applyYaml';
 import {doesTextStartWithYamlDocumentDelimiter} from './resource';
 
 const applyMultipleResources = (
-  stateConfig: AppConfig,
+  config: AppConfig,
   resourcesToApply: K8sResource[],
   dispatch: AppDispatch,
   onSuccessCallback?: () => void
 ) => {
-  const kubeconfigPath = stateConfig.kubeconfigPath;
-  const context = stateConfig.kubeConfig.currentContext;
+  const kubeconfigPath = config.kubeconfigPath;
+  const context = config.kubeConfig.currentContext;
 
   if (!kubeconfigPath || !context || !resourcesToApply.length) {
     return;

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -1,5 +1,4 @@
 import log from 'loglevel';
-import {ThunkDispatch} from 'redux-thunk';
 
 import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
@@ -8,6 +7,7 @@ import {AppConfig} from '@models/appconfig';
 import {K8sResource} from '@models/k8sresource';
 
 import {setAlert} from '@redux/reducers/alert';
+import {AppDispatch} from '@redux/store';
 import {applyYamlToCluster} from '@redux/thunks/applyYaml';
 
 import {doesTextStartWithYamlDocumentDelimiter} from './resource';
@@ -15,7 +15,7 @@ import {doesTextStartWithYamlDocumentDelimiter} from './resource';
 const applyMultipleResources = (
   stateConfig: AppConfig,
   resourcesToApply: K8sResource[],
-  dispatch: ThunkDispatch<any, any, any>,
+  dispatch: AppDispatch,
   onSuccessCallback?: () => void
 ) => {
   const kubeconfigPath = stateConfig.kubeconfigPath;

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -1,0 +1,77 @@
+import log from 'loglevel';
+
+import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
+
+import {AlertEnum, AlertType} from '@models/alert';
+import {AppConfig} from '@models/appconfig';
+import {K8sResource} from '@models/k8sresource';
+
+import {setAlert} from '@redux/reducers/alert';
+import {AppDispatch} from '@redux/store';
+import {applyYamlToCluster} from '@redux/thunks/applyYaml';
+
+import {doesTextStartWithYamlDocumentDelimiter} from './resource';
+
+const applyMultipleResources = (
+  stateConfig: AppConfig,
+  resourcesToApply: K8sResource[],
+  dispatch: AppDispatch,
+  onSuccessCallback?: () => void
+) => {
+  const kubeconfigPath = stateConfig.kubeconfigPath;
+  const context = stateConfig.kubeConfig.currentContext;
+
+  if (!kubeconfigPath || !context || !resourcesToApply.length) {
+    return;
+  }
+
+  const yamlToApply = resourcesToApply
+    .map(r => r.text)
+    .reduce<string>((fullYaml, currentText) => {
+      if (doesTextStartWithYamlDocumentDelimiter(currentText)) {
+        return `${fullYaml}\n${currentText}`;
+      }
+      return `${fullYaml}\n${YAML_DOCUMENT_DELIMITER_NEW_LINE}${currentText}`;
+    }, '');
+
+  try {
+    const child = applyYamlToCluster(yamlToApply, kubeconfigPath, context);
+    child.on('exit', (code, signal) => {
+      log.info(`kubectl exited with code ${code} and signal ${signal}`);
+    });
+
+    let alertMessage: string = '';
+
+    child.stdout.on('data', data => {
+      alertMessage += `\n${data.toString()}`;
+    });
+
+    child.stdout.on('end', () => {
+      const alert: AlertType = {
+        type: AlertEnum.Success,
+        title: `Applied selected resources to cluster ${context} successfully`,
+        message: alertMessage,
+      };
+
+      if (onSuccessCallback) {
+        onSuccessCallback();
+      }
+
+      dispatch(setAlert(alert));
+    });
+
+    child.stderr.on('data', data => {
+      const alert: AlertType = {
+        type: AlertEnum.Error,
+        title: `Applying selected resources to cluster ${context} failed`,
+        message: data.toString(),
+      };
+      dispatch(setAlert(alert));
+    });
+  } catch (e) {
+    log.error('Failed to apply selected resources');
+    log.error(e);
+  }
+};
+
+export default applyMultipleResources;

--- a/src/redux/thunks/applyCheckedResources.ts
+++ b/src/redux/thunks/applyCheckedResources.ts
@@ -1,0 +1,22 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+
+import {K8sResource} from '@models/k8sresource';
+
+import applyMultipleResources from '@redux/services/applyMultipleResources';
+import {AppDispatch, RootState} from '@redux/store';
+
+export const applyCheckedResources = createAsyncThunk<void, undefined, {dispatch: AppDispatch; state: RootState}>(
+  'main/applyCheckedResources',
+  async (_, thunkAPI) => {
+    const state = thunkAPI.getState();
+
+    const checkedResources = state.main.checkedResourceIds;
+    const resourceMap = state.main.resourceMap;
+
+    const resourcesToApply = checkedResources
+      .map(resource => resourceMap[resource])
+      .filter((r): r is K8sResource => r !== undefined);
+
+    applyMultipleResources(state.config, resourcesToApply, thunkAPI.dispatch);
+  }
+);

--- a/src/redux/thunks/applySelectedResourceMatches.ts
+++ b/src/redux/thunks/applySelectedResourceMatches.ts
@@ -1,18 +1,10 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 
-import log from 'loglevel';
-
-import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
-
-import {AlertEnum, AlertType} from '@models/alert';
 import {K8sResource} from '@models/k8sresource';
 
-import {setAlert} from '@redux/reducers/alert';
 import {reloadClusterDiff} from '@redux/reducers/main';
-import {doesTextStartWithYamlDocumentDelimiter} from '@redux/services/resource';
+import applyMultipleResources from '@redux/services/applyMultipleResources';
 import {AppDispatch, RootState} from '@redux/store';
-
-import {applyYamlToCluster} from './applyYaml';
 
 export const applySelectedResourceMatches = createAsyncThunk<
   void,
@@ -24,15 +16,9 @@ export const applySelectedResourceMatches = createAsyncThunk<
 >('main/applySelectedResourceMatches', async (_, thunkAPI) => {
   const state = thunkAPI.getState();
 
-  const kubeconfigPath = state.config.kubeconfigPath;
-  const context = state.config.kubeConfig.currentContext;
   const matches = state.main.clusterDiff.clusterToLocalResourcesMatches;
   const resourceMap = state.main.resourceMap;
   const selectedMatches = state.main.clusterDiff.selectedMatches;
-
-  if (!kubeconfigPath || !context || selectedMatches.length === 0) {
-    return;
-  }
 
   const resourcesToApply = matches
     .filter(match => selectedMatches.includes(match.id))
@@ -41,47 +27,7 @@ export const applySelectedResourceMatches = createAsyncThunk<
     )
     .filter((r): r is K8sResource => r !== undefined);
 
-  const yamlToApply = resourcesToApply
-    .map(r => r.text)
-    .reduce<string>((fullYaml, currentText) => {
-      if (doesTextStartWithYamlDocumentDelimiter(currentText)) {
-        return `${fullYaml}\n${currentText}`;
-      }
-      return `${fullYaml}\n${YAML_DOCUMENT_DELIMITER_NEW_LINE}${currentText}`;
-    }, '');
-
-  try {
-    const child = applyYamlToCluster(yamlToApply, kubeconfigPath, context);
-    child.on('exit', (code, signal) => {
-      log.info(`kubectl exited with code ${code} and signal ${signal}`);
-    });
-
-    let alertMessage: string = '';
-
-    child.stdout.on('data', data => {
-      alertMessage += `\n${data.toString()}`;
-    });
-
-    child.stdout.on('end', () => {
-      const alert: AlertType = {
-        type: AlertEnum.Success,
-        title: `Applied selected resources to cluster ${context} successfully`,
-        message: alertMessage,
-      };
-      thunkAPI.dispatch(reloadClusterDiff());
-      thunkAPI.dispatch(setAlert(alert));
-    });
-
-    child.stderr.on('data', data => {
-      const alert: AlertType = {
-        type: AlertEnum.Error,
-        title: `Applying selected resources to cluster ${context} failed`,
-        message: data.toString(),
-      };
-      thunkAPI.dispatch(setAlert(alert));
-    });
-  } catch (e) {
-    log.error('Failed to apply selected resources');
-    log.error(e);
-  }
+  applyMultipleResources(state.config, resourcesToApply, thunkAPI.dispatch, () => {
+    thunkAPI.dispatch(reloadClusterDiff());
+  });
 });


### PR DESCRIPTION
## Changes

- Show actions menu instead of the title bar ( with warnings, buttons etc. )
- Show the number of selected resources
- Deploy resources functionality with modal confirmation
- Delete modal confirmation (without logic to delete the resources)

## Fixes

- Minor styling updates
- Do not show `Delete` when in preview mode
- Do not show `Deploy` when in cluster mode

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
