### PR TITLE
fix: Disable create resource button on preview mode + small fixes

### DIFF
--- a/src/components/molecules/ResourceRefsIconPopover/RefLink.tsx
+++ b/src/components/molecules/ResourceRefsIconPopover/RefLink.tsx
@@ -10,7 +10,7 @@ import {isIncomingRef, isOutgoingRef, isUnsatisfiedRef} from '@redux/services/re
 
 import {Icon} from '@atoms';
 
-import {FontColors} from '@styles/Colors';
+import Colors, {FontColors} from '@styles/Colors';
 
 const StyledRefText = styled.span<{isUnsatisfied: boolean; isDisabled: boolean}>`
   ${props => {
@@ -58,7 +58,7 @@ const RefIcon = React.memo((props: {resourceRef: ResourceRef; style: React.CSSPr
     return <Icon name="incomingRefs" style={style} />;
   }
   if (isUnsatisfiedRef(resourceRef.type)) {
-    return <Icon name="warning" style={style} />;
+    return <Icon name="warning" style={style} color={Colors.yellowWarning} />;
   }
   return null;
 });

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -85,6 +85,7 @@ function SectionHeader(props: SectionHeaderProps) {
       onMouseLeave={() => setIsHovered(false)}
     >
       {sectionInstance.checkable &&
+        sectionInstance.isInitialized &&
         (sectionBlueprint.customization?.isCheckVisibleOnHover
           ? sectionInstance.checkable.value === 'partial' || sectionInstance.checkable.value === 'checked' || isHovered
           : true) && (
@@ -98,6 +99,7 @@ function SectionHeader(props: SectionHeaderProps) {
           </span>
         )}
       {sectionInstance.checkable &&
+        sectionInstance.isInitialized &&
         sectionBlueprint.customization?.isCheckVisibleOnHover &&
         sectionInstance.checkable.value === 'unchecked' &&
         !isHovered && <S.CheckboxPlaceholder $level={level} />}

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -416,7 +416,6 @@ const ActionsPane = (props: {contentHeight: string}) => {
                   <S.ExtraRightButton
                     onClick={() => openExternalResourceKindDocumentation(resourceKindHandler?.helpLink)}
                     type="link"
-                    ghost
                     ref={extraButton}
                   >
                     {isButtonShrinked ? '' : `See ${selectedResource?.kind} documentation`} <BookOutlined />

--- a/src/components/organisms/DiffModal/DiffModal.tsx
+++ b/src/components/organisms/DiffModal/DiffModal.tsx
@@ -238,49 +238,51 @@ const DiffModal = () => {
           <span className={`custom-modal-handle custom-modal-handle-${h}`} ref={ref} />
         )}
       >
-        <MonacoDiffContainer width="100%" height="calc(100% - 140px)" ref={containerRef}>
-          <MonacoDiffEditor
-            width={containerWidth}
-            height={containerHeight}
-            language="yaml"
-            original={resourceContent}
-            value={cleanDiffContent}
-            options={options}
-            theme={KUBESHOP_MONACO_THEME}
-          />
-        </MonacoDiffContainer>
+        <>
+          <MonacoDiffContainer width="100%" height="calc(100% - 140px)" ref={containerRef}>
+            <MonacoDiffEditor
+              width={containerWidth}
+              height={containerHeight}
+              language="yaml"
+              original={resourceContent}
+              value={cleanDiffContent}
+              options={options}
+              theme={KUBESHOP_MONACO_THEME}
+            />
+          </MonacoDiffContainer>
 
-        <TagsContainer>
-          <StyledTag>Local</StyledTag>
-          <Button
-            type="primary"
-            ghost
-            onClick={handleApply}
-            icon={<Icon name="kubernetes" />}
-            disabled={!areResourcesDifferent}
-          >
-            Deploy local resource to cluster <ArrowRightOutlined />
-          </Button>
-          <Button
-            type="primary"
-            ghost
-            onClick={handleReplace}
-            disabled={!shouldDiffIgnorePaths || !areResourcesDifferent}
-          >
-            <ArrowLeftOutlined /> Replace local resource with cluster resource
-          </Button>
-          <StyledTag>Cluster</StyledTag>
-        </TagsContainer>
-        <SwitchContainer onClick={() => setShouldDiffIgnorePaths(!shouldDiffIgnorePaths)}>
-          <Switch checked={shouldDiffIgnorePaths} />
-          <StyledSwitchLabel>Hide ignored fields</StyledSwitchLabel>
-        </SwitchContainer>
-        <ButtonContainer>
-          <Button onClick={handleRefresh}>Refresh</Button>
-          <Button onClick={handleOk} style={{marginLeft: 12}}>
-            Close
-          </Button>
-        </ButtonContainer>
+          <TagsContainer>
+            <StyledTag>Local</StyledTag>
+            <Button
+              type="primary"
+              ghost
+              onClick={handleApply}
+              icon={<Icon name="kubernetes" />}
+              disabled={!areResourcesDifferent}
+            >
+              Deploy local resource to cluster <ArrowRightOutlined />
+            </Button>
+            <Button
+              type="primary"
+              ghost
+              onClick={handleReplace}
+              disabled={!shouldDiffIgnorePaths || !areResourcesDifferent}
+            >
+              <ArrowLeftOutlined /> Replace local resource with cluster resource
+            </Button>
+            <StyledTag>Cluster</StyledTag>
+          </TagsContainer>
+          <SwitchContainer onClick={() => setShouldDiffIgnorePaths(!shouldDiffIgnorePaths)}>
+            <Switch checked={shouldDiffIgnorePaths} />
+            <StyledSwitchLabel>Hide ignored fields</StyledSwitchLabel>
+          </SwitchContainer>
+          <ButtonContainer>
+            <Button onClick={handleRefresh}>Refresh</Button>
+            <Button onClick={handleOk} style={{marginLeft: 12}}>
+              Close
+            </Button>
+          </ButtonContainer>
+        </>
       </ResizableBox>
     </StyledModal>
   );

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -851,7 +851,6 @@ const FileTreePane = () => {
                     onClick={refreshFolder}
                     icon={<ReloadOutlined />}
                     type="link"
-                    ghost
                     disabled={isButtonDisabled}
                   />
                 </Tooltip>
@@ -860,7 +859,6 @@ const FileTreePane = () => {
                     icon={<Icon name="collapse" />}
                     onClick={onToggleTree}
                     type="link"
-                    ghost
                     size="small"
                     disabled={isButtonDisabled}
                   />

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -412,7 +412,6 @@ const PageHeader = () => {
                         Boolean(previewType === 'cluster' && previewLoader.isLoading) || isClusterActionDisabled
                       }
                       type="link"
-                      ghost
                       onClick={handleLoadCluster}
                     >
                       {createClusterObjectsLabel()}

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameSuffix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameSuffix.tsx
@@ -13,6 +13,7 @@ import {NewResourceWizardInput} from '@models/ui';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {openNewResourceWizard} from '@redux/reducers/ui';
+import {isInPreviewModeSelector} from '@redux/selectors';
 
 import {ResourceKindHandlers, getResourceKindHandler} from '@src/kindhandlers';
 
@@ -38,6 +39,7 @@ const ResourceKindSectionSuffix: React.FC<SectionCustomComponentProps> = props =
   const dispatch = useAppDispatch();
 
   const isFolderOpen = useAppSelector(state => Boolean(state.main.fileMap[ROOT_FILE_ENTRY]));
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
 
   const resourceKind = useMemo(() => {
     return sectionInstance.meta?.resourceKind;
@@ -61,7 +63,7 @@ const ResourceKindSectionSuffix: React.FC<SectionCustomComponentProps> = props =
   return (
     <SuffixContainer>
       <ButtonContainer>
-        <Button icon={<PlusOutlined />} type="link" onClick={createResource} size="small" />
+        <Button icon={<PlusOutlined />} type="link" onClick={createResource} size="small" disabled={isInPreviewMode} />
       </ButtonContainer>
     </SuffixContainer>
   );


### PR DESCRIPTION
## Fixes

- Disable create resource button on preview mode
- Show corresponding color for icon
- Hide checkboxes before the sections are initialized
- Fix console warnings

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
