### PR TITLE
fix: scroll into view logic of section blueprints

### DIFF
--- a/src/components/molecules/ClusterDiff/ClusterDiff.tsx
+++ b/src/components/molecules/ClusterDiff/ClusterDiff.tsx
@@ -46,7 +46,7 @@ function ClusterDiff() {
         </S.TitleBar>
         <Divider style={{margin: '8px 0'}} />
         <ListContainer>
-          <S.List>
+          <S.List id="cluster-diff-sections-container">
             <SectionRenderer sectionBlueprint={ClusterDiffSectionBlueprint} level={0} isLastSection={false} />
           </S.List>
         </ListContainer>

--- a/src/components/organisms/HelmPane/HelmPane.tsx
+++ b/src/components/organisms/HelmPane/HelmPane.tsx
@@ -20,7 +20,7 @@ const HelmPane: React.FC = () => {
       <S.TitleBar>
         <MonoPaneTitle>Helm</MonoPaneTitle>
       </S.TitleBar>
-      <S.List height={navigatorHeight}>
+      <S.List id="helm-sections-container" height={navigatorHeight}>
         <SectionRenderer sectionBlueprint={HelmChartSectionBlueprint} level={0} isLastSection={false} />
       </S.List>
     </>

--- a/src/components/organisms/KustomizePane/KustomizePane.tsx
+++ b/src/components/organisms/KustomizePane/KustomizePane.tsx
@@ -21,7 +21,7 @@ const HelmPane: React.FC = () => {
       <S.TitleBar>
         <MonoPaneTitle>Kustomize</MonoPaneTitle>
       </S.TitleBar>
-      <S.List height={navigatorHeight}>
+      <S.List id="kustomize-sections-container" height={navigatorHeight}>
         <SectionRenderer sectionBlueprint={KustomizationSectionBlueprint} level={0} isLastSection={false} />
         <SectionRenderer sectionBlueprint={KustomizePatchSectionBlueprint} level={0} isLastSection={false} />
       </S.List>

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -136,24 +136,22 @@ const NavPane: React.FC = () => {
       )}
 
       {isResourceFiltersOpen && (
-        <>
-          <FiltersContainer ref={filtersContainerRef}>
-            <ResizableBox
-              width={width}
-              height={height || 350}
-              axis="y"
-              resizeHandles={['s']}
-              minConstraints={[100, 200]}
-              maxConstraints={[width, navigatorHeight - 200]}
-              handle={(h: number, ref: LegacyRef<HTMLSpanElement>) => <span className="custom-handle" ref={ref} />}
-            >
-              <ResourceFilter />
-            </ResizableBox>
-          </FiltersContainer>
-        </>
+        <FiltersContainer ref={filtersContainerRef}>
+          <ResizableBox
+            width={width}
+            height={height || 350}
+            axis="y"
+            resizeHandles={['s']}
+            minConstraints={[100, 200]}
+            maxConstraints={[width, navigatorHeight - 200]}
+            handle={(h: number, ref: LegacyRef<HTMLSpanElement>) => <span className="custom-handle" ref={ref} />}
+          >
+            <ResourceFilter />
+          </ResizableBox>
+        </FiltersContainer>
       )}
 
-      <S.List height={sectionListHeight}>
+      <S.List id="navigator-sections-container" height={sectionListHeight}>
         <SectionRenderer sectionBlueprint={K8sResourceSectionBlueprint} level={0} isLastSection={false} />
         <SectionRenderer sectionBlueprint={UnknownResourceSectionBlueprint} level={0} isLastSection={false} />
       </S.List>

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -94,8 +94,8 @@ export interface SectionBlueprint<RawItemType, ScopeType = any> {
   name: string;
   id: string;
   getScope: (state: RootState) => ScopeType;
+  containerElementId: string;
   rootSectionId: string;
-  parentSectionId?: string;
   childSectionIds?: string[];
   builder?: {
     getRawItems?: (scope: ScopeType) => RawItemType[];

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
@@ -22,6 +22,7 @@ export const CLUSTER_DIFF_SECTION_NAME = 'K8s Resources Diff' as const;
 const ClusterDiffSectionBlueprint: SectionBlueprint<ClusterToLocalResourcesMatch, ClusterDiffScopeType> = {
   name: CLUSTER_DIFF_SECTION_NAME,
   id: CLUSTER_DIFF_SECTION_NAME,
+  containerElementId: 'cluster-diff-sections-container',
   rootSectionId: CLUSTER_DIFF_SECTION_NAME,
   getScope(state) {
     return {

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -26,6 +26,7 @@ export const HELM_CHART_SECTION_NAME = 'Helm Charts' as const;
 const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, HelmChartScopeType> = {
   name: HELM_CHART_SECTION_NAME,
   id: HELM_CHART_SECTION_NAME,
+  containerElementId: 'helm-sections-container',
   rootSectionId: HELM_CHART_SECTION_NAME,
   getScope: state => {
     return {

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
@@ -43,6 +43,7 @@ const childSections = childSectionNames.map(childSectionName => {
   const subsection: SectionBlueprint<K8sResource, {activeResourcesLength: number; checkedResourceIds: string[]}> = {
     name: childSectionName,
     id: childSectionName,
+    containerElementId: 'navigator-sections-container',
     rootSectionId: navSectionNames.K8S_RESOURCES,
     childSectionIds: kindHandlerSections.map(k => k.name),
     getScope: state => {
@@ -89,6 +90,7 @@ export const K8S_RESOURCE_SECTION_NAME = navSectionNames.K8S_RESOURCES;
 const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScopeType> = {
   name: navSectionNames.K8S_RESOURCES,
   id: navSectionNames.K8S_RESOURCES,
+  containerElementId: 'navigator-sections-container',
   rootSectionId: navSectionNames.K8S_RESOURCES,
   childSectionIds: childSectionNames,
   getScope: state => {

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
@@ -37,6 +37,7 @@ export function makeResourceKindNavSection(
   const sectionBlueprint: SectionBlueprint<K8sResource, ResourceKindScopeType> = {
     name: kindSectionName,
     id: kindSectionName,
+    containerElementId: 'navigator-sections-container',
     rootSectionId: navSectionNames.K8S_RESOURCES,
     getScope: state => {
       return {

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
@@ -31,6 +31,7 @@ const KustomizationSectionBlueprint: SectionBlueprint<K8sResource, Kustomization
   name: KUSTOMIZATION_SECTION_NAME,
   id: KUSTOMIZATION_SECTION_NAME,
   rootSectionId: KUSTOMIZE_PATCH_SECTION_NAME,
+  containerElementId: 'kustomize-sections-container',
   getScope: state => {
     return {
       resourceMap: state.main.resourceMap,

--- a/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
+++ b/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
@@ -27,6 +27,7 @@ const KustomizePatchSectionBlueprint: SectionBlueprint<K8sResource, KustomizePat
   name: KUSTOMIZE_PATCH_SECTION_NAME,
   id: KUSTOMIZE_PATCH_SECTION_NAME,
   rootSectionId: KUSTOMIZE_PATCH_SECTION_NAME,
+  containerElementId: 'kustomize-sections-container',
   getScope: state => {
     return {
       resourceMap: state.main.resourceMap,

--- a/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
+++ b/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
@@ -32,6 +32,7 @@ export const UNKNOWN_RESOURCE_SECTION_NAME = 'Unknown Resources' as const;
 const UnknownResourceSectionBlueprint: SectionBlueprint<K8sResource, UnknownResourceScopeType> = {
   name: UNKNOWN_RESOURCE_SECTION_NAME,
   id: UNKNOWN_RESOURCE_SECTION_NAME,
+  containerElementId: 'navigator-sections-container',
   rootSectionId: UNKNOWN_RESOURCE_SECTION_NAME,
   getScope: state => {
     return {


### PR DESCRIPTION
This PR...

## Changes

- added `containerElementId` to all section blueprints in order to "observe" the height changes of those elements using ResizeObserver

## Fixes

- wrong compute of sectionInstanceRoots

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
