### PR TITLE
refactor: Different icon for folders in file explorer

### DIFF
--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -163,6 +163,15 @@ const FileTreeContainer = styled.div`
     margin-left: 8px;
     background: transparent;
   }
+
+  & .ant-tree-switcher-leaf-line::before {
+    border-right: 1px solid #434343;
+  }
+
+  & .ant-tree-switcher-leaf-line::after {
+    border-bottom: 1px solid #434343;
+  }
+
   & .ant-tree-treenode-selected {
     vertical-align: center;
     margin-left: 0px !important;
@@ -915,8 +924,8 @@ const FileTreePane = () => {
             return node.highlight;
           }}
           disabled={isInPreviewMode || previewLoader.isLoading}
-          showLine
-          showIcon={false}
+          showIcon
+          showLine={{showLeafIcon: false}}
         />
       ) : (
         <NoFilesContainer>


### PR DESCRIPTION
## Fixes

- Show the default folder icon for entities that are folders

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

![image](https://user-images.githubusercontent.com/47887589/146790625-6233d12c-8e0e-4358-8f38-f446c2bdfc8c.png)

