### PR TITLE
feat: Preselect namespace when adding a new resource

### DIFF
--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -54,5 +54,5 @@ export const useResetFormOnCloseModal = ({
     if (visible && defaultValues) {
       form.setFieldsValue(defaultValues);
     }
-  }, [visible]);
+  }, [defaultValues, form, visible]);
 };

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -47,19 +47,12 @@ export const useResetFormOnCloseModal = ({
   visible: boolean;
   defaultValues?: any;
 }) => {
-  const prevVisibleRef = useRef<boolean>();
   useEffect(() => {
-    prevVisibleRef.current = visible;
-  }, [visible]);
-  const prevVisible = prevVisibleRef.current;
-
-  useEffect(() => {
-    if (!visible && prevVisible) {
+    if (!visible) {
       form.resetFields();
     }
-    if (visible && !prevVisible && defaultValues) {
+    if (visible && defaultValues) {
       form.setFieldsValue(defaultValues);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 };


### PR DESCRIPTION
## Changes

- Preselect namespace when adding a new resource from the resource filter namespace ( if it exists )

## Fixes

- Show `Add to File` path prefilled only for `File Explorer` -> `Add Resource`


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
