### PR TITLE
feat: show namespace tag next to resources in navigator + styling changes

### DIFF
--- a/src/components/molecules/ResourceRefsIconPopover/ResourceRefsIconPopover.tsx
+++ b/src/components/molecules/ResourceRefsIconPopover/ResourceRefsIconPopover.tsx
@@ -57,7 +57,7 @@ const ResourceRefsIconPopover = (props: {
   }, [type]);
 
   if (!resourceRefs || resourceRefs.length === 0) {
-    return null;
+    return <span style={{minWidth: '20px'}} />;
   }
 
   if (isDisabled) {

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -49,7 +49,7 @@ export const ItemContainer = styled.span<ItemContainerProps>`
       return `background: ${Colors.blackPearl};`;
     }
   }};
-
+  ${props => !props.isHovered && 'padding-right: 46px;'}
 `;
 
 type ItemNameProps = {

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -89,7 +89,7 @@ export const ItemName = styled.span<ItemNameProps>`
 `;
 
 export const PrefixContainer = styled.span`
-  width: 20px;
+  min-width: 20px;
 `;
 
 export const SuffixContainer = styled.span`

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -20,6 +20,9 @@ export const ItemContainer = styled.span<ItemContainerProps>`
   align-items: center;
   width: 100%;
   user-select: none;
+  padding-left: ${props => (props.$isSectionCheckable ? '32px;' : '26px;')}
+  padding-right: 8px;
+  margin-bottom: 2px;
   ${props => props.hasOnClick && `cursor: pointer;`}
   ${props => {
     if (props.isLastItem) {
@@ -46,7 +49,7 @@ export const ItemContainer = styled.span<ItemContainerProps>`
       return `background: ${Colors.blackPearl};`;
     }
   }};
-  padding-left: ${props => `${(props.level + 1) * 8 + 1 + (props.$isSectionCheckable ? 24 : 0)}px;`};
+
 `;
 
 type ItemNameProps = {
@@ -63,6 +66,7 @@ export const ItemName = styled.span<ItemNameProps>`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
   ${props => {
     if (props.isSelected) {
       return `font-weight: 700;`;
@@ -111,5 +115,5 @@ export const BlankSpace = styled.span`
 `;
 
 export const Checkbox = styled(RawCheckbox)<{$level: number}>`
-  ${props => props.$level && `margin-left: -${props.$level * 8 + 24}px;`}
+  margin-left: -24px;
 `;

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -4,7 +4,7 @@ import {MinusSquareOutlined, PlusSquareOutlined} from '@ant-design/icons';
 
 import {SectionBlueprint, SectionInstance} from '@models/navigator';
 
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {useAppDispatch} from '@redux/hooks';
 
 import Colors from '@styles/Colors';
 
@@ -41,10 +41,6 @@ function SectionHeader(props: SectionHeaderProps) {
 
   const {NameDisplay, NameSuffix} = useSectionCustomization(sectionBlueprint.customization);
 
-  const itemInstances = useAppSelector(state =>
-    sectionInstance.itemIds.map(itemId => state.navigator.itemInstanceMap[itemId])
-  );
-
   const toggleCollapse = useCallback(() => {
     if (isCollapsed) {
       expandSection();
@@ -79,6 +75,8 @@ function SectionHeader(props: SectionHeaderProps) {
       isHighlighted={Boolean(sectionInstance.isHighlighted && isCollapsed)}
       isInitialized={Boolean(sectionInstance.isInitialized)}
       isVisible={Boolean(sectionInstance.isVisible)}
+      isSectionCheckable={Boolean(sectionBlueprint.builder?.makeCheckable)}
+      hasCustomNameDisplay={Boolean(NameDisplay.Component)}
       isLastSection={isLastSection}
       isCollapsed={isCollapsed}
       onMouseEnter={() => setIsHovered(true)}

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -14,6 +14,8 @@ type NameContainerProps = {
   isVisible?: boolean;
   isInitialized?: boolean;
   disableHoverStyle?: boolean;
+  isSectionCheckable?: boolean;
+  hasCustomNameDisplay?: boolean;
 };
 
 export const NameContainer = styled.li<NameContainerProps>`
@@ -23,6 +25,8 @@ export const NameContainer = styled.li<NameContainerProps>`
   flex-wrap: wrap;
   width: 100%;
   user-select: none;
+  ${props =>
+    (!props.isSectionCheckable && !props.hasCustomNameDisplay) || !props.isInitialized ? 'padding-left: 16px;' : ''}
   ${props => {
     if (props.isVisible === false) {
       return 'visibility: hidden; height: 0;';
@@ -31,7 +35,7 @@ export const NameContainer = styled.li<NameContainerProps>`
   }}
   ${props => {
     if (props.isLastSection && (props.isCollapsed || !props.isInitialized) && !props.hasChildSections) {
-      return `margin-bottom: 12px;`;
+      return `margin-bottom: 16px;`;
     }
   }}
     ${props => {
@@ -64,15 +68,13 @@ type NameProps = {
 };
 
 export const Name = styled.span<NameProps>`
-  padding: 2px 16px;
+  padding: 2px 8px;
   padding-right: 0px;
   margin-right: 4px;
   ${props => {
     return `font-size: ${24 - 4 * props.$level}px;`;
   }}
-  ${props => {
-    return `margin-left: ${8 * props.$level - (props.$isCheckable ? 10 : 0)}px;`;
-  }}
+
   ${props => {
     if (props.$isSelected) {
       return `font-weight: 700;`;
@@ -106,16 +108,12 @@ export const ItemsLength = styled.span<{selected: boolean}>`
 `;
 
 export const EmptyDisplayContainer = styled.div<{level: number}>`
-  margin-left: ${props => {
-    return `${16 + 8 * props.level}px`;
-  }};
+  margin-left: 16px;
 `;
 
 export const BeforeInitializationContainer = styled.div<{level: number}>`
   padding-top: 16px;
-  margin-left: ${props => {
-    return `${16 + 8 * props.level}px`;
-  }};
+  margin-left: 16px;
 `;
 
 export const BlankSpace = styled.span<{level?: number}>`

--- a/src/index.css
+++ b/src/index.css
@@ -82,3 +82,7 @@ code {
     transform: scale(1.3);
   }
 }
+
+.resource-prefix-popover-overlay .ant-popover-inner-content {
+  padding: 0 16px;
+}

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
@@ -27,7 +27,6 @@ import Colors from '@styles/Colors';
 
 const StyledActionsMenuIconContainer = styled.span<{isSelected: boolean}>`
   cursor: pointer;
-  margin-right: 8px;
   padding: 8px;
   display: flex;
   align-items: center;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
@@ -1,22 +1,71 @@
+import {useCallback} from 'react';
+
+import {Button, Popover, Tag} from 'antd';
+
+import styled from 'styled-components';
+
 import {ItemCustomComponentProps} from '@models/navigator';
 
-import {useAppSelector} from '@redux/hooks';
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {extendResourceFilter} from '@redux/reducers/main';
 
 import ResourceRefsIconPopover from '@components/molecules/ResourceRefsIconPopover';
 
+import Colors from '@styles/Colors';
+
+const Container = styled.span`
+  display: flex;
+  align-items: center;
+  & .ant-popover-inner-content {
+    padding: 0 !important;
+  }
+`;
+
 const Prefix = (props: ItemCustomComponentProps) => {
   const {itemInstance} = props;
+  const dispatch = useAppDispatch();
   const resource = useAppSelector(state => state.main.resourceMap[itemInstance.id]);
+  const filterNamespace = useAppSelector(state => state.main.resourceFilter.namespace);
+
+  const applyNamespaceFilter = useCallback(() => {
+    dispatch(extendResourceFilter({namespace: resource.namespace, labels: {}, annotations: {}}));
+  }, [resource, dispatch]);
+
   if (!resource) {
     return null;
   }
+
   return (
-    <ResourceRefsIconPopover
-      isSelected={itemInstance.isSelected}
-      isDisabled={itemInstance.isDisabled}
-      resource={resource}
-      type="incoming"
-    />
+    <Container>
+      <ResourceRefsIconPopover
+        isSelected={itemInstance.isSelected}
+        isDisabled={itemInstance.isDisabled}
+        resource={resource}
+        type="incoming"
+      />
+      {resource.namespace && !filterNamespace && (
+        <Popover
+          title="Filter"
+          overlayClassName="resource-prefix-popover-overlay"
+          content={
+            <Button type="link" onClick={applyNamespaceFilter} style={{padding: 0}}>
+              Set namespace filter to {resource.namespace}
+            </Button>
+          }
+        >
+          <Tag
+            style={{
+              marginLeft: 4,
+              color: itemInstance.isSelected ? Colors.blackPure : Colors.whitePure,
+              fontWeight: itemInstance.isSelected ? 600 : undefined,
+            }}
+            color="default"
+          >
+            {resource.namespace}
+          </Tag>
+        </Popover>
+      )}
+    </Container>
   );
 };
 

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
@@ -21,6 +21,17 @@ const Container = styled.span`
   }
 `;
 
+const StyledTag = styled(Tag)<{$isSelected: boolean}>`
+  margin-left: 4;
+  color: ${props => (props.$isSelected ? Colors.blackPure : Colors.whitePure)};
+  font-weight: ${props => (props.$isSelected ? 700 : undefined)};
+  font-size: '12px';
+  padding: '0 5px';
+  overflow: 'hidden';
+  text-overflow: 'ellipsis';
+  white-space: 'nowrap';
+`;
+
 const Prefix = (props: ItemCustomComponentProps) => {
   const {itemInstance} = props;
   const dispatch = useAppDispatch();
@@ -53,16 +64,9 @@ const Prefix = (props: ItemCustomComponentProps) => {
             </Button>
           }
         >
-          <Tag
-            style={{
-              marginLeft: 4,
-              color: itemInstance.isSelected ? Colors.blackPure : Colors.whitePure,
-              fontWeight: itemInstance.isSelected ? 600 : undefined,
-            }}
-            color="default"
-          >
+          <StyledTag $isSelected={itemInstance.isSelected} color="default">
             {resource.namespace}
-          </Tag>
+          </StyledTag>
         </Popover>
       )}
     </Container>

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
@@ -22,14 +22,14 @@ const Container = styled.span`
 `;
 
 const StyledTag = styled(Tag)<{$isSelected: boolean}>`
-  margin-left: 4;
+  margin-left: 4px;
   color: ${props => (props.$isSelected ? Colors.blackPure : Colors.whitePure)};
   font-weight: ${props => (props.$isSelected ? 700 : undefined)};
-  font-size: '12px';
-  padding: '0 5px';
-  overflow: 'hidden';
-  text-overflow: 'ellipsis';
-  white-space: 'nowrap';
+  font-size: 12px;
+  padding: 0 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const Prefix = (props: ItemCustomComponentProps) => {

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
@@ -58,7 +58,18 @@ export function makeResourceKindNavSection(
       getRawItems: scope => {
         return scope.activeResources
           .filter(r => r.kind === kindHandler.kind)
-          .sort((a, b) => a.name.localeCompare(b.name));
+          .sort((a, b) => {
+            if (a.namespace && !b.namespace) {
+              return -1;
+            }
+            if (!a.namespace && b.namespace) {
+              return 1;
+            }
+            if (a.namespace && b.namespace) {
+              return a.namespace.localeCompare(b.namespace);
+            }
+            return a.name.localeCompare(b.name);
+          });
       },
       getMeta: () => {
         return {resourceKind: kindHandler.kind};


### PR DESCRIPTION
This PR...

## Changes

- added namespace tag next to resources with Popover to apply filter to that namespace
- namespace tag is hidden if there is a filter on the namespace
- aligned sections and items (removed the indentation based on nesting levels)

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/147068619-82a50547-2bc4-4e96-8877-9170828824ca.png)
![image](https://user-images.githubusercontent.com/20538711/147068663-ac24b5de-06c6-4ced-8548-cbb541475fe7.png)
![image](https://user-images.githubusercontent.com/20538711/147068922-187b7cb1-c34d-4021-98d3-5f6db2cef1d2.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
