### PR TITLE
fix: remove unnecessary logic from patch resources

### DIFF
--- a/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
+++ b/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
@@ -3,9 +3,6 @@ import {K8sResource} from '@models/k8sresource';
 import {SectionBlueprint} from '@models/navigator';
 
 import {selectK8sResource} from '@redux/reducers/main';
-import {isUnsavedResource} from '@redux/services/resource';
-
-import {isResourcePassingFilter} from '@utils/resources';
 
 import sectionBlueprintMap from '../sectionBlueprintMap';
 import KustomizePatchPrefix from './KustomizePatchPrefix';
@@ -70,7 +67,7 @@ const KustomizePatchSectionBlueprint: SectionBlueprint<K8sResource, KustomizePat
       return rawItems.length > 0;
     },
     isLoading: scope => {
-      return scope.isPreviewLoading || scope.isFolderLoading;
+      return scope.isFolderLoading;
     },
     isInitialized: (_, rawItems) => {
       return rawItems.length > 0;
@@ -82,12 +79,6 @@ const KustomizePatchSectionBlueprint: SectionBlueprint<K8sResource, KustomizePat
     builder: {
       isSelected: rawItem => rawItem.isSelected,
       isHighlighted: rawItem => rawItem.isHighlighted,
-      isDirty: rawItem => isUnsavedResource(rawItem),
-      isVisible: (rawItem, scope) => {
-        const isPassingFilter = isResourcePassingFilter(rawItem, scope.resourceFilter);
-        return isPassingFilter;
-      },
-      isDisabled: (_, scope) => scope.isInPreviewMode,
     },
     instanceHandler: {
       onClick: (itemInstance, dispatch) => {


### PR DESCRIPTION
This PR...

## Changes

- let patches be enabled in preview mode
- don't apply resource filters to patches
- remove patches loading state while preview loads

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
