### PR TITLE
Improve ESLint and TS configurations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -9,3 +9,8 @@ server.js
 build.js
 init.js
 site
+commitlint.config.js
+craco.config.js
+notarization
+resources
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
         selector: ['variable'],
         types: ['boolean'],
         format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
-        prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'does'],
+        prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'does', 'are', 'was'],
       },
     ],
     '@typescript-eslint/prefer-literal-enum-member': ['warn'],
@@ -90,7 +90,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-filename-extension': [2, {extensions: ['.js', '.jsx', '.ts', '.tsx']}], // Make ESLint happy about JSX inside of tsx files
     'react/destructuring-assignment': ['warn', 'always', {ignoreClassFields: true}],
-    'react/boolean-prop-naming': ['warn', {rule: '^(is|should|has|can|did|will|does)[A-Z]([A-Za-z0-9]?)+'}],
+    'react/boolean-prop-naming': ['warn', {rule: '^(is|should|has|can|did|will|does|are|was)[A-Z]([A-Za-z0-9]?)+'}],
     'react/no-array-index-key': 'warn',
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
     'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,7 +90,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/jsx-filename-extension': [2, {extensions: ['.js', '.jsx', '.ts', '.tsx']}], // Make ESLint happy about JSX inside of tsx files
     'react/destructuring-assignment': ['warn', 'always', {ignoreClassFields: true}],
-    'react/boolean-prop-naming': ['error', {rule: '^(is|has|does|should)[A-Z]([A-Za-z0-9]?)+'}],
+    'react/boolean-prop-naming': ['warn', {rule: '^(is|should|has|can|did|will|does)[A-Z]([A-Za-z0-9]?)+'}],
     'react/no-array-index-key': 'warn',
     'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
     'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,74 +9,103 @@ module.exports = {
     ecmaFeatures: {jsx: true},
     ecmaVersion: 12,
     sourceType: 'module',
+    project: ['./tsconfig.json'],
   },
   plugins: ['react', '@typescript-eslint', 'react-hooks', 'unused-imports', 'prettier'],
   rules: {
-    'no-underscore-dangle': 'off',
-    'react/jsx-uses-react': 'off',
-    'react/react-in-jsx-scope': 'off',
-    'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
-    'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
     'no-console': 'warn',
-    'no-undef': 'off',
-    semi: 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['warn'],
-    'import/no-extraneous-dependencies': 'off',
-    'prefer-destructuring': 'off',
-    'no-param-reassign': 'off',
-    'no-use-before-define': 'off',
-    'comma-dangle': 'off',
     'no-multiple-empty-lines': 1,
+    'no-param-reassign': 'off',
+    'no-undef': 'off',
+    'no-underscore-dangle': 'off',
+    'no-unused-vars': 'off',
+    'no-use-before-define': 'off',
     'no-useless-escape': 'off',
-    'object-curly-newline': 'off',
-    'lines-between-class-members': 'off',
-    'unused-imports/no-unused-imports-ts': 'error',
-    'react/jsx-props-no-spreading': 0,
-    'react/jsx-max-props-per-line': [1, {maximum: 1, when: 'multiline'}],
+    'no-unused-expressions': 'off', // prevents basic use of React exports such as in App.tsx
     // Disabled old no-shadow rule as seems to be communicated by ESLint while working with TS.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-shadow.md
     'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': ['error'],
-    'import/prefer-default-export': 'off', // cannot control what we import from standard libs
-    'import/no-unresolved': 'off', // typescript
-    'require-yield': 'off', // don't micromanage sagas or side effects
-    'import/extensions': 'off', // don't micromanage pretty imports
-    'no-unused-expressions': 'off', // prevents basic use of React exports such as in App.tsx
-    'react/jsx-filename-extension': [2, {extensions: ['.js', '.jsx', '.ts', '.tsx']}], // Make ESLint happy about JSX inside of tsx files
-    // Temporarily, we will ignore these while we introduce linting to our repo *conservatively*.
-    // These are to be re-enabled soon.
-    'arrow-body-style': 'off', // warn
-    'arrow-parens': 'off', // warn
-    'dot-notation': 'off', // required for our env variables currently
-    'prefer-const': 'off',
-    'max-len': 'off',
-    'react/jsx-no-target-blank': 'off', //  target="_blank" without rel="noreferrer" is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener  react/jsx-no-target-blank
-    'react/prop-types': 'off', // TODO re-enable
-    'react/require-default-props': 'off', // TODO re-enable
-    'no-nested-ternary': 'off', // warn
-    'consistent-return': 'off', // warn. Look at api calls closely before enabling this. api.ts.
-    // Accessibility off for now to make speed a priority and avoid restructuring for now
-    'jsx-a11y/click-events-have-key-events': 'off',
-    'jsx-a11y/no-static-element-interactions': 'off',
-    'jsx-a11y/anchor-is-valid': 'off', // TODO warn because, we should really be using buttons.
-    'jsx-a11y/no-noninteractive-element-interactions': 'off',
-    'jsx-a11y/alt-text': 'off',
-    'space-in-brackets': 'off',
-    'jsx-a11y/label-has-associated-control': [
-      'warn',
-      {
-        controlComponents: ['Select'],
-        assert: 'either',
-        depth: 3,
-      },
-    ],
+    'no-nested-ternary': 'off',
     'no-implicit-coercion': [
       'error',
       {
         boolean: true,
         number: true,
         string: true,
+      },
+    ],
+    'arrow-body-style': 'off', // warn
+    'arrow-parens': 'off', // warn
+    'comma-dangle': 'off',
+    'consistent-return': 'off',
+    'dot-notation': 'off', // required for our env variables currently
+    'import/no-extraneous-dependencies': 'off',
+    'import/prefer-default-export': 'off', // cannot control what we import from standard libs
+    'import/no-unresolved': 'off', // typescript
+    'import/extensions': 'off', // don't micromanage pretty imports
+    'lines-between-class-members': 'off',
+    'max-len': 'off',
+    'object-curly-newline': 'off',
+    'prefer-destructuring': 'off',
+    'prefer-const': 'off',
+    'require-yield': 'off',
+    'unused-imports/no-unused-imports-ts': 'error',
+    'space-in-brackets': 'off',
+    semi: 'error',
+    // TypeScript rules
+    '@typescript-eslint/no-unused-vars': ['warn'],
+    '@typescript-eslint/no-shadow': ['error'],
+    '@typescript-eslint/ban-types': ['warn'],
+    '@typescript-eslint/no-empty-function': ['warn'],
+    '@typescript-eslint/no-empty-interface': ['warn'],
+    '@typescript-eslint/no-for-in-array': ['warn'],
+    '@typescript-eslint/no-inferrable-types': ['warn'],
+    '@typescript-eslint/no-misused-new': ['warn'],
+    '@typescript-eslint/no-this-alias': ['warn'],
+    '@typescript-eslint/no-unnecessary-boolean-literal-compare': ['warn'],
+    '@typescript-eslint/no-unnecessary-condition': ['warn'],
+    '@typescript-eslint/no-unnecessary-type-assertion': ['warn'],
+    '@typescript-eslint/no-unnecessary-type-constraint': ['warn'],
+    '@typescript-eslint/no-implied-eval': ['error'],
+    '@typescript-eslint/naming-convention': [
+      'warn',
+      {
+        selector: ['variable'],
+        types: ['boolean'],
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+        prefix: ['is', 'should', 'has', 'can', 'did', 'will', 'does'],
+      },
+    ],
+    '@typescript-eslint/prefer-literal-enum-member': ['warn'],
+    '@typescript-eslint/prefer-optional-chain': ['warn'],
+    '@typescript-eslint/restrict-plus-operands': ['warn'],
+    '@typescript-eslint/restrict-template-expressions': ['warn'],
+    // React rules
+    'react/jsx-no-target-blank': 'warn', // target="_blank" without rel="noreferrer" is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener  react/jsx-no-target-blank
+    'react/prop-types': 'off', // this doesn't allow us to use React.FC<>
+    'react/require-default-props': 'off',
+    'react/jsx-props-no-spreading': 0,
+    'react/jsx-max-props-per-line': [1, {maximum: 1, when: 'multiline'}],
+    'react/jsx-uses-react': 'off',
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-filename-extension': [2, {extensions: ['.js', '.jsx', '.ts', '.tsx']}], // Make ESLint happy about JSX inside of tsx files
+    'react/destructuring-assignment': ['warn', 'always', {ignoreClassFields: true}],
+    'react/boolean-prop-naming': ['error', {rule: '^(is|has|does|should)[A-Z]([A-Za-z0-9]?)+'}],
+    'react/no-array-index-key': 'warn',
+    'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
+    'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
+    // Accessibility off for now to make speed a priority and avoid restructuring for now
+    'jsx-a11y/click-events-have-key-events': 'off',
+    'jsx-a11y/no-static-element-interactions': 'off',
+    'jsx-a11y/anchor-is-valid': 'warn',
+    'jsx-a11y/no-noninteractive-element-interactions': 'off',
+    'jsx-a11y/alt-text': 'off',
+    'jsx-a11y/label-has-associated-control': [
+      'warn',
+      {
+        controlComponents: ['Select'],
+        assert: 'either',
+        depth: 3,
       },
     ],
   },

--- a/src/components/atoms/KeyValueInput/KeyValueInput.tsx
+++ b/src/components/atoms/KeyValueInput/KeyValueInput.tsx
@@ -5,6 +5,7 @@ import {Button, Select} from 'antd';
 import {MinusOutlined, PlusOutlined} from '@ant-design/icons';
 
 import isDeepEqual from 'fast-deep-equal/es6/react';
+import _ from 'lodash';
 import styled from 'styled-components';
 import {v4 as uuidv4} from 'uuid';
 
@@ -137,10 +138,13 @@ function KeyValueInput(props: KeyValueInputProps) {
   const updateEntryValue = (entryId: string, value: string) => {
     const newEntries = Array.from(entries);
     const entryIndex = newEntries.findIndex(e => e.id === entryId);
-    newEntries[entryIndex] = {
-      ...newEntries[entryIndex],
-      value,
-    };
+    const currentEntry = newEntries[entryIndex];
+    if (currentEntry) {
+      newEntries[entryIndex] = {
+        ...currentEntry,
+        value,
+      };
+    }
     setEntries(newEntries);
     updateKeyValue(newEntries);
   };
@@ -181,12 +185,11 @@ function KeyValueInput(props: KeyValueInputProps) {
                 <Select.Option key={ANY_VALUE} value={ANY_VALUE}>
                   {ANY_VALUE}
                 </Select.Option>
-                {data[entry.key] &&
-                  data[entry.key].map((value: string) => (
-                    <Select.Option key={value} value={value}>
-                      {value}
-                    </Select.Option>
-                  ))}
+                {_.get(data, entry.key, []).map((value: string) => (
+                  <Select.Option key={value} value={value}>
+                    {value}
+                  </Select.Option>
+                ))}
               </Select>
             )}
           </KeyValueContainer>

--- a/src/components/atoms/SplitView/SplitView.tsx
+++ b/src/components/atoms/SplitView/SplitView.tsx
@@ -222,7 +222,11 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const onTouchStartLeftNav = (evt: TouchEvent<HTMLElement>): any => {
-    setSeparatorLeftNavXPosition(evt.touches[0].clientX);
+    let clientX = evt.touches[0]?.clientX;
+    if (!clientX) {
+      return;
+    }
+    setSeparatorLeftNavXPosition(clientX);
     setDraggingLeftNav(true);
   };
 
@@ -232,7 +236,11 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const onTouchStartNavEdit = (evt: TouchEvent<HTMLElement>): any => {
-    setSeparatorNavEditXPosition(evt.touches[0].clientX);
+    let clientX = evt.touches[0]?.clientX;
+    if (!clientX) {
+      return;
+    }
+    setSeparatorNavEditXPosition(clientX);
     setDraggingNavEdit(true);
   };
 
@@ -242,7 +250,11 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const onTouchStartEditRight = (evt: TouchEvent<HTMLElement>): any => {
-    setSeparatorEditRightXPosition(evt.touches[0].clientX);
+    let clientX = evt.touches[0]?.clientX;
+    if (!clientX) {
+      return;
+    }
+    setSeparatorEditRightXPosition(clientX);
     setDraggingEditRight(true);
   };
 
@@ -252,7 +264,11 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const onTouchMove = (evt: TouchEvent<HTMLElement>): any => {
-    onMove(evt.touches[0].clientX);
+    let clientX = evt.touches[0]?.clientX;
+    if (!clientX) {
+      return;
+    }
+    onMove(clientX);
   };
 
   const onMouseUp = () => {

--- a/src/components/molecules/FilePatternList/FilePatternList.tsx
+++ b/src/components/molecules/FilePatternList/FilePatternList.tsx
@@ -39,12 +39,12 @@ const FilePatternList = (props: FilePatternListProps) => {
 
   const dispatch = useAppDispatch();
 
-  const [isAddingPattern, setIsAddingPattern] = useState<Boolean>(false);
+  const [isAddingPattern, setIsAddingPattern] = useState<boolean>(false);
   const [patternInput, setPatternInput] = useState<string>('');
   const [inputRef, focusInput] = useFocus<Input>();
   const filePatternInputRef = useRef<any>();
   const appConfig = useAppSelector(state => state.config);
-  const fileMap = useAppSelector(state => state.main.fileMap);
+  const rootFileEntry = useAppSelector(state => state.main.fileMap[ROOT_FILE_ENTRY]);
 
   useOnClickOutside(filePatternInputRef, () => {
     setIsAddingPattern(false);
@@ -93,6 +93,10 @@ const FilePatternList = (props: FilePatternListProps) => {
     }
   }, [isSettingsOpened]);
 
+  if (!rootFileEntry) {
+    return null;
+  }
+
   return (
     <div>
       <StyledUl>
@@ -128,7 +132,7 @@ const FilePatternList = (props: FilePatternListProps) => {
             <Button
               onClick={() => {
                 dispatch(setScanExcludesStatus('applied'));
-                dispatch(setRootFolder(fileMap[ROOT_FILE_ENTRY].filePath));
+                dispatch(setRootFolder(rootFileEntry.filePath));
               }}
             >
               Apply changes

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -77,6 +77,7 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
   const previewType = useAppSelector(state => state.main.previewType);
   const shouldEditorReloadSelectedPath = useAppSelector(state => state.main.shouldEditorReloadSelectedPath);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
+  const rootFileEntry = useAppSelector(state => state.main.fileMap[ROOT_FILE_ENTRY]);
 
   const [containerRef, {width: containerWidth, height: containerHeight}] = useMeasure<HTMLDivElement>();
 
@@ -198,10 +199,10 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
         newCode = resource.text;
         editor?.setModel(monaco.editor.createModel(newCode, 'yaml'));
       }
-    } else if (selectedPath && selectedPath !== fileMap[ROOT_FILE_ENTRY].filePath) {
-      const filePath = path.join(fileMap[ROOT_FILE_ENTRY].filePath, selectedPath);
+    } else if (selectedPath && rootFileEntry && selectedPath !== rootFileEntry.filePath) {
+      const filePath = path.join(rootFileEntry.filePath, selectedPath);
       const fileStats = getFileStats(filePath);
-      if (fileStats && fileStats.isFile()) {
+      if (fileStats?.isFile()) {
         newCode = fs.readFileSync(filePath, 'utf8');
       }
     }
@@ -214,13 +215,13 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
   }, [selectedPath, selectedResourceId]);
 
   useEffect(() => {
-    if (!selectedPath || !shouldEditorReloadSelectedPath) {
+    if (!selectedPath || !shouldEditorReloadSelectedPath || !rootFileEntry) {
       return;
     }
     log.info('[Monaco]: selected file was updated outside Monokle - reading file...');
-    const filePath = path.join(fileMap[ROOT_FILE_ENTRY].filePath, selectedPath);
+    const filePath = path.join(rootFileEntry.filePath, selectedPath);
     const fileStats = getFileStats(filePath);
-    if (fileStats && fileStats.isFile()) {
+    if (fileStats?.isFile()) {
       const newCode = fs.readFileSync(filePath, 'utf8');
       setCode(newCode);
       setOrgCode(newCode);

--- a/src/components/molecules/Monaco/codeIntel.ts
+++ b/src/components/molecules/Monaco/codeIntel.ts
@@ -49,16 +49,15 @@ const SymbolsToResourceKindMatchers = ResourceKindHandlers.map(resourceKindHandl
 }).flat();
 
 const getResourceKindFromSymbols = (symbols: monaco.languages.DocumentSymbol[]) => {
-  for (let i = 0; i < SymbolsToResourceKindMatchers.length; i += 1) {
-    const matcher = SymbolsToResourceKindMatchers[i];
-    if (matcher.symbolsPaths && matcher.symbolsPaths.length > 0) {
+  SymbolsToResourceKindMatchers.forEach(matcher => {
+    if (matcher.symbolsPaths.length) {
       const isMatch = matcher.symbolsPaths.some(symbolsPath => {
-        const sliceIndex = matcher.symbolsPaths ? -symbolsPath.length : 0;
+        const sliceIndex = matcher.symbolsPaths.length ? -symbolsPath.length : 0;
         const slicedSymbols = symbols.slice(sliceIndex);
         if (symbolsPath.length === slicedSymbols.length) {
           let areEqual = true;
           symbolsPath.forEach((symbol, index) => {
-            if (symbol !== slicedSymbols[index].name) {
+            if (symbol !== slicedSymbols[index]?.name) {
               areEqual = false;
             }
           });
@@ -70,7 +69,8 @@ const getResourceKindFromSymbols = (symbols: monaco.languages.DocumentSymbol[]) 
         return matcher.resourceKind;
       }
     }
-  }
+  });
+
   return null;
 };
 
@@ -155,7 +155,7 @@ export async function applyForResource(
           outgoingRefs: [ref],
         });
       } else {
-        listOfOutgoingRefsByEqualPos[refsByEqualPosIndex].outgoingRefs.push(ref);
+        listOfOutgoingRefsByEqualPos[refsByEqualPosIndex]?.outgoingRefs.push(ref);
       }
     }
   });
@@ -258,7 +258,7 @@ export async function applyForResource(
     // create default link if there is only one command
     if (outgoingRefs.length === 1) {
       const outgoingRef = outgoingRefs[0];
-      if (createResource || !isUnsatisfiedRef(outgoingRef.type)) {
+      if (outgoingRef && (createResource || !isUnsatisfiedRef(outgoingRef.type))) {
         const linkDisposable = createLinkProvider(
           inlineRange,
           isUnsatisfiedRef(outgoingRef.type) ? 'Create resource' : 'Open resource',

--- a/src/components/molecules/Monaco/symbolProcessing.ts
+++ b/src/components/molecules/Monaco/symbolProcessing.ts
@@ -211,7 +211,11 @@ function processSymbol(
   }
 
   if (parents.length > 0) {
-    const parentName = parents[parents.length - 1].name;
+    const lastParent = parents[parents.length - 1];
+    if (!lastParent) {
+      return;
+    }
+    const parentName = lastParent.name;
 
     if (parentName === 'labels' || parentName === 'matchLabels') {
       addLabelFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);

--- a/src/components/molecules/PreviewDropdown/PreviewDropdown.tsx
+++ b/src/components/molecules/PreviewDropdown/PreviewDropdown.tsx
@@ -10,6 +10,8 @@ import styled from 'styled-components';
 
 import {KUSTOMIZATION_KIND} from '@constants/constants';
 
+import {HelmValuesFile} from '@models/helm';
+
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectHelmValuesFile, selectK8sResource} from '@redux/reducers/main';
 import {startPreview} from '@redux/services/preview';
@@ -87,7 +89,9 @@ const PreviewDropdown = (props: {btnStyle?: React.CSSProperties}) => {
   const helmCharts: HelmChartMenuItem[] = useAppSelector(state => {
     const helmValuesMap = state.main.helmValuesMap;
     return Object.values(state.main.helmChartMap).map(helmChart => {
-      const valuesFiles = helmChart.valueFileIds.map(valuesFileId => helmValuesMap[valuesFileId]);
+      const valuesFiles = helmChart.valueFileIds
+        .map(valuesFileId => helmValuesMap[valuesFileId])
+        .filter((v): v is HelmValuesFile => Boolean(v));
       return {
         id: helmChart.id,
         name: helmChart.name,
@@ -152,6 +156,10 @@ const PreviewDropdown = (props: {btnStyle?: React.CSSProperties}) => {
 
   const onMenuItemClick = ({key}: {key: string}) => {
     const [type, id] = key.split('__');
+
+    if (!id) {
+      return;
+    }
 
     if (type === 'kustomization') {
       selectAndPreviewKustomization(id);

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -61,9 +61,10 @@ const makeKeyValuesFromObjectList = (objectList: any[], getNestedObject: (curren
         if (typeof value !== 'string') {
           return;
         }
-        if (keyValues[key]) {
-          if (!keyValues[key].includes(value)) {
-            keyValues[key].push(value);
+        const currentKeyValues = keyValues[key];
+        if (currentKeyValues) {
+          if (!currentKeyValues.includes(value)) {
+            currentKeyValues.push(value);
           }
         } else {
           keyValues[key] = [value];

--- a/src/components/molecules/ResourceRefsIconPopover/RefLink.tsx
+++ b/src/components/molecules/ResourceRefsIconPopover/RefLink.tsx
@@ -38,9 +38,10 @@ const StyledPositionText = styled.span`
 `;
 
 const getRefTargetName = (ref: ResourceRef, resourceMap: ResourceMapType) => {
-  if (ref.target?.type === 'resource') {
-    if (ref.target.resourceId && resourceMap[ref.target.resourceId]) {
-      return resourceMap[ref.target.resourceId].name;
+  if (ref.target?.type === 'resource' && ref.target.resourceId) {
+    const targetResource = resourceMap[ref.target.resourceId];
+    if (ref.target.resourceId && targetResource) {
+      return targetResource.name;
     }
   }
   if (ref.target?.type === 'file') {
@@ -80,7 +81,7 @@ const ResourceRefLink = (props: {
     if (resourceRef.target.resourceKind) {
       linkText = `${resourceRef.target.resourceKind}: ${targetName}`;
     } else if (resourceRef.target.resourceId) {
-      const resourceKind = resourceMap[resourceRef.target.resourceId].kind;
+      const resourceKind = resourceMap[resourceRef.target.resourceId]?.kind;
       linkText = `${resourceKind}: ${targetName}`;
     }
   }

--- a/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
@@ -40,23 +40,27 @@ function ItemRenderer<ItemType, ScopeType>(props: ItemRendererProps<ItemType, Sc
   const scrollContainer = useRef<ScrollContainerRef>(null);
 
   useEffect(() => {
-    if (!itemInstance.shouldScrollIntoView) {
+    if (!itemInstance?.shouldScrollIntoView) {
       return;
     }
     scrollContainer.current?.scrollIntoView();
-  }, [itemInstance.shouldScrollIntoView]);
+  }, [itemInstance?.shouldScrollIntoView]);
 
   const onClick = useCallback(() => {
-    if (instanceHandler && instanceHandler.onClick && !itemInstance.isDisabled) {
+    if (instanceHandler?.onClick && itemInstance?.isDisabled === false) {
       instanceHandler.onClick(itemInstance, dispatch);
     }
   }, [instanceHandler, itemInstance, dispatch]);
 
   const onCheck = useCallback(() => {
-    if (instanceHandler && instanceHandler.onCheck && !itemInstance.isDisabled) {
+    if (instanceHandler?.onCheck && itemInstance?.isDisabled === false) {
       instanceHandler.onCheck(itemInstance, dispatch);
     }
   }, [instanceHandler, itemInstance, dispatch]);
+
+  if (!itemInstance) {
+    return null;
+  }
 
   return (
     <ScrollIntoView id={itemInstance.id} ref={scrollContainer}>
@@ -71,6 +75,7 @@ function ItemRenderer<ItemType, ScopeType>(props: ItemRendererProps<ItemType, Sc
         isLastItem={isLastItem}
         hasOnClick={Boolean(instanceHandler?.onClick)}
         $isSectionCheckable={isSectionCheckable}
+        $hasContextMenu={Boolean(ContextMenu.Component)}
       >
         {itemInstance.isCheckable &&
           (blueprint.customization?.isCheckVisibleOnHover ? itemInstance.isChecked || isHovered : true) && (

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -13,6 +13,7 @@ type ItemContainerProps = {
   isLastItem: boolean;
   hasOnClick: boolean;
   $isSectionCheckable: boolean;
+  $hasContextMenu: boolean;
 };
 
 export const ItemContainer = styled.span<ItemContainerProps>`
@@ -49,7 +50,7 @@ export const ItemContainer = styled.span<ItemContainerProps>`
       return `background: ${Colors.blackPearl};`;
     }
   }};
-  ${props => !props.isHovered && 'padding-right: 46px;'}
+  ${props => props.$hasContextMenu && !props.isHovered && 'padding-right: 46px;'}
 `;
 
 type ItemNameProps = {

--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -94,12 +94,14 @@ function SectionRenderer(props: SectionRendererProps) {
   }, [sectionInstance?.shouldExpand, expandSection]);
 
   const groupInstanceById: Record<string, ItemGroupInstance> = useMemo(() => {
-    return sectionInstance?.groups
-      .map<[string, ItemGroupInstance]>(g => [g.id, g])
-      .reduce<Record<string, ItemGroupInstance>>((acc, [k, v]) => {
-        acc[k] = v;
-        return acc;
-      }, {});
+    return (
+      sectionInstance?.groups
+        .map<[string, ItemGroupInstance]>(g => [g.id, g])
+        .reduce<Record<string, ItemGroupInstance>>((acc, [k, v]) => {
+          acc[k] = v;
+          return acc;
+        }, {}) || {}
+    );
   }, [sectionInstance?.groups]);
 
   const lastVisibleChildSectionId = useMemo(() => {
@@ -146,12 +148,12 @@ function SectionRenderer(props: SectionRendererProps) {
     return null;
   }
 
-  if (sectionInstance?.isLoading) {
+  if (sectionInstance.isLoading) {
     return <S.Skeleton />;
   }
 
-  if (sectionInstance?.isEmpty) {
-    if (EmptyDisplay && EmptyDisplay.Component) {
+  if (sectionInstance.isEmpty) {
+    if (EmptyDisplay.Component) {
       return (
         <S.EmptyDisplayContainer level={level}>
           <EmptyDisplay.Component sectionInstance={sectionInstance} />
@@ -179,9 +181,7 @@ function SectionRenderer(props: SectionRendererProps) {
         expandSection={expandSection}
         collapseSection={collapseSection}
       />
-      {sectionInstance &&
-        sectionInstance.isVisible &&
-        !isCollapsed &&
+      {!isCollapsed &&
         itemBlueprint &&
         sectionInstance.groups.length === 0 &&
         sectionInstance.visibleItemIds.map(itemId => (
@@ -195,12 +195,13 @@ function SectionRenderer(props: SectionRendererProps) {
             options={itemRendererOptions}
           />
         ))}
-      {sectionInstance?.isVisible &&
-        !isCollapsed &&
+      {!isCollapsed &&
         itemBlueprint &&
-        groupInstanceById &&
         sectionInstance.visibleGroupIds.map(groupId => {
           const group = groupInstanceById[groupId];
+          if (!group) {
+            return null;
+          }
           return (
             <React.Fragment key={group.id}>
               <S.NameContainer style={{color: 'red'}}>
@@ -223,17 +224,16 @@ function SectionRenderer(props: SectionRendererProps) {
             </React.Fragment>
           );
         })}
-      {sectionBlueprint.childSectionIds &&
-        sectionBlueprint.childSectionIds
-          .map(childSectionId => navSectionMap.getById(childSectionId))
-          .map(child => (
-            <SectionRenderer
-              key={child.name}
-              sectionBlueprint={child}
-              level={level + 1}
-              isLastSection={child.id === lastVisibleChildSectionId}
-            />
-          ))}
+      {sectionBlueprint.childSectionIds
+        ?.map(childSectionId => navSectionMap.getById(childSectionId))
+        .map(child => (
+          <SectionRenderer
+            key={child.name}
+            sectionBlueprint={child}
+            level={level + 1}
+            isLastSection={child.id === lastVisibleChildSectionId}
+          />
+        ))}
     </>
   );
 }

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -112,7 +112,11 @@ const ActionsPane = (props: {contentHeight: string}) => {
   const extraButton = useRef<any>();
 
   const getDistanceBetweenTwoComponents = useCallback(() => {
-    const tabsListEl = tabsList[0].getBoundingClientRect();
+    const firstTab = tabsList[0];
+    if (!firstTab) {
+      return;
+    }
+    const tabsListEl = firstTab.getBoundingClientRect();
     const extraButtonEl = extraButton.current.getBoundingClientRect();
 
     const distance = extraButtonEl.left - tabsListEl.right;
@@ -325,9 +329,16 @@ const ActionsPane = (props: {contentHeight: string}) => {
       }
 
       const helmValuesFile = helmValuesMap[selectedValuesFileId];
+      if (!helmValuesFile) {
+        return;
+      }
+      const helmChart = helmChartMap[helmValuesFile.helmChartId];
+      if (!helmChart) {
+        return;
+      }
       applyHelmChart(
         helmValuesFile,
-        helmChartMap[helmValuesFile.helmChartId],
+        helmChart,
         fileMap,
         dispatch,
         kubeconfig,
@@ -354,12 +365,15 @@ const ActionsPane = (props: {contentHeight: string}) => {
     if (!selectedValuesFileId) {
       return '';
     }
-
     const helmValuesFile = helmValuesMap[selectedValuesFileId];
-
-    return `Install the ${helmChartMap[helmValuesFile.helmChartId].name} Chart using ${
-      helmValuesFile.name
-    } in cluster [${kubeconfigContext || ''}]?`;
+    if (!helmValuesFile) {
+      return '';
+    }
+    const helmChart = helmChartMap[helmValuesFile.helmChartId];
+    if (!helmChart) {
+      return '';
+    }
+    return `Install the ${helmChart.name} Chart using ${helmValuesFile.name} in cluster [${kubeconfigContext || ''}]?`;
   }, [helmChartMap, helmValuesMap, kubeconfigContext, selectedValuesFileId]);
 
   // called from main thread because thunks cannot be dispatched by main
@@ -381,7 +395,7 @@ const ActionsPane = (props: {contentHeight: string}) => {
   useEffect(() => {
     if (
       (activeTabKey === 'metadataForm' || activeTabKey === 'form') &&
-      (!selectedResourceId || !(resourceKindHandler && resourceKindHandler.formEditorOptions))
+      (!selectedResourceId || !resourceKindHandler?.formEditorOptions)
     ) {
       setActiveTabKey('source');
     }

--- a/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
+++ b/src/components/organisms/ClusterDiffModal/ClusterDiffModal.tsx
@@ -143,11 +143,13 @@ function ClusterDiffModal() {
     () =>
       matches
         .filter(match => selectedMatches.includes(match.id))
-        .map(match =>
-          match.localResourceIds && match.localResourceIds.length > 0
-            ? resourceMap[match.localResourceIds[0]]
-            : undefined
-        )
+        .map(match => {
+          const firstLocalResourceId = match.localResourceIds?.[0];
+          if (!firstLocalResourceId) {
+            return undefined;
+          }
+          return resourceMap[firstLocalResourceId];
+        })
         .filter((r): r is K8sResource => r !== undefined),
     [matches, selectedMatches, resourceMap]
   );

--- a/src/components/organisms/DiffModal/DiffModal.tsx
+++ b/src/components/organisms/DiffModal/DiffModal.tsx
@@ -7,6 +7,7 @@ import {Button, Modal, Switch, Tag} from 'antd';
 
 import {ArrowLeftOutlined, ArrowRightOutlined} from '@ant-design/icons';
 
+import _ from 'lodash';
 import styled from 'styled-components';
 import {parse, stringify} from 'yaml';
 
@@ -153,10 +154,12 @@ const DiffModal = () => {
 
   const confirmModalTitle = useMemo(() => {
     const resource = resourceMap[diffResourceId || ''];
-
+    if (!resource) {
+      return '';
+    }
     return isKustomizationResource(resource)
-      ? makeApplyKustomizationText(resource?.name, kubeconfigContext)
-      : makeApplyResourceText(resource?.name, kubeconfigContext);
+      ? makeApplyKustomizationText(resource.name, kubeconfigContext)
+      : makeApplyResourceText(resource.name, kubeconfigContext);
   }, [diffResourceId, kubeconfigContext, resourceMap]);
 
   useEffect(() => {
@@ -307,7 +310,9 @@ const DiffModal = () => {
           {isApplyModalVisible && (
             <ModalConfirmWithNamespaceSelect
               isVisible={isApplyModalVisible}
-              resources={diffResourceId && resourceMap[diffResourceId] ? [resourceMap[diffResourceId]] : []}
+              resources={
+                diffResourceId && _.has(resourceMap, diffResourceId) ? [_.get(resourceMap, diffResourceId)] : []
+              }
               title={confirmModalTitle}
               onOk={selectedNamespace => onClickApplyResource(selectedNamespace)}
               onCancel={() => setIsApplyModalVisible(false)}

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -59,8 +59,9 @@ const HotKeysHandler = () => {
   useHotkeys(
     hotkeys.REFRESH_FOLDER,
     () => {
-      if (mainState.fileMap && mainState.fileMap[ROOT_FILE_ENTRY] && mainState.fileMap[ROOT_FILE_ENTRY].filePath) {
-        dispatch(setRootFolder(mainState.fileMap[ROOT_FILE_ENTRY].filePath));
+      const rootFileEntry = mainState.fileMap[ROOT_FILE_ENTRY];
+      if (rootFileEntry) {
+        dispatch(setRootFolder(rootFileEntry.filePath));
       }
     },
     [mainState]

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -6,6 +6,7 @@ import {Form, Input, Modal, Select} from 'antd';
 
 import {InfoCircleOutlined} from '@ant-design/icons';
 
+import log from 'loglevel';
 import path from 'path/posix';
 
 import {ROOT_FILE_ENTRY} from '@constants/constants';
@@ -190,17 +191,22 @@ const NewResourceWizard = () => {
 
     if (savingDestination !== 'doNotSave') {
       let absolutePath;
+      const rootFileEntry = fileMap[ROOT_FILE_ENTRY];
+      if (!rootFileEntry) {
+        log.warn('rootFileEntry is undefined');
+        return;
+      }
 
       const fullFileName = getFullFileName(formValues.name);
       if (savingDestination === 'saveToFolder' && selectedFolder) {
         absolutePath =
           selectedFolder === ROOT_FILE_ENTRY
-            ? path.join(fileMap[ROOT_FILE_ENTRY].filePath, path.sep, fullFileName)
-            : path.join(fileMap[ROOT_FILE_ENTRY].filePath, selectedFolder, path.sep, fullFileName);
+            ? path.join(rootFileEntry.filePath, path.sep, fullFileName)
+            : path.join(rootFileEntry.filePath, selectedFolder, path.sep, fullFileName);
       } else if (savingDestination === 'saveToFile' && selectedFile) {
-        absolutePath = path.join(fileMap[ROOT_FILE_ENTRY].filePath, selectedFile);
+        absolutePath = path.join(rootFileEntry.filePath, selectedFile);
       } else {
-        absolutePath = path.join(fileMap[ROOT_FILE_ENTRY].filePath, path.sep, fullFileName);
+        absolutePath = path.join(rootFileEntry.filePath, path.sep, fullFileName);
       }
 
       dispatch(saveUnsavedResource({resource: newResource, absolutePath}));

--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -240,10 +240,11 @@ const PageHeader = () => {
       setPreviewResource(undefined);
     }
 
-    if (previewValuesFileId && helmValuesMap[previewValuesFileId]) {
-      const valuesFile = helmValuesMap[previewValuesFileId];
+    const valuesFile = previewValuesFileId ? helmValuesMap[previewValuesFileId] : undefined;
+    const chart = valuesFile ? helmChartMap[valuesFile.helmChartId] : undefined;
+    if (valuesFile && chart) {
       setPreviewValuesFile(valuesFile);
-      setHelmChart(helmChartMap[valuesFile.helmChartId]);
+      setHelmChart(chart);
     } else {
       setPreviewValuesFile(undefined);
       setHelmChart(undefined);

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionBlueprint.ts
@@ -43,7 +43,7 @@ const ClusterDiffSectionBlueprint: SectionBlueprint<ClusterToLocalResourcesMatch
         Record<string, ClusterToLocalResourcesMatch[]>
       >((acc, match) => {
         if (acc[match.resourceKind]) {
-          acc[match.resourceKind].push(match);
+          acc[match.resourceKind]?.push(match);
         } else {
           acc[match.resourceKind] = [match];
         }
@@ -110,10 +110,8 @@ const ClusterDiffSectionBlueprint: SectionBlueprint<ClusterToLocalResourcesMatch
       },
       isVisible(rawItem, scope) {
         const clusterResource = rawItem.clusterResourceId ? scope.resourceMap[rawItem.clusterResourceId] : undefined;
-        const firstLocalResource =
-          rawItem.localResourceIds && rawItem.localResourceIds.length > 0
-            ? scope.resourceMap[rawItem.localResourceIds[0]]
-            : undefined;
+        const firstLocalResourceId = rawItem.localResourceIds?.[0];
+        const firstLocalResource = firstLocalResourceId ? scope.resourceMap[firstLocalResourceId] : undefined;
         if (clusterResource && isResourcePassingFilter(clusterResource, scope.resourceFilter)) {
           return true;
         }

--- a/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionNameDisplay.tsx
+++ b/src/navsections/ClusterDiffSectionBlueprint/ClusterDiffSectionNameDisplay.tsx
@@ -83,8 +83,8 @@ function ResourceDiffSectionNameDisplay() {
   );
   const selectedMatchesLength = useAppSelector(state => state.main.clusterDiff.selectedMatches.length);
   const areAllMatchesSelected = useMemo(
-    () => selectedMatchesLength === clusterDiffSectionInstance.visibleItemIds.length,
-    [selectedMatchesLength, clusterDiffSectionInstance.visibleItemIds.length]
+    () => selectedMatchesLength === clusterDiffSectionInstance?.visibleItemIds.length,
+    [selectedMatchesLength, clusterDiffSectionInstance?.visibleItemIds.length]
   );
 
   const onClickReload = () => {
@@ -99,7 +99,7 @@ function ResourceDiffSectionNameDisplay() {
     if (areAllMatchesSelected) {
       dispatch(unselectAllClusterDiffMatches());
     } else {
-      dispatch(selectMultipleClusterDiffMatches(clusterDiffSectionInstance.visibleItemIds));
+      dispatch(selectMultipleClusterDiffMatches(clusterDiffSectionInstance?.visibleItemIds || []));
     }
   };
 

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -50,7 +50,8 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, HelmChartScope
       return Object.values(scope.helmChartMap)
         .map(helmChart => {
           const helmValuesFiles = helmChart.valueFileIds
-            .map(valuesFile => scope.helmValuesMap[valuesFile])
+            .map(valuesFileId => scope.helmValuesMap[valuesFileId])
+            .filter((valuesFile): valuesFile is HelmValuesFile => Boolean(valuesFile))
             .sort((a, b) => a.name.localeCompare(b.name));
           return {id: helmChart.id, name: helmChart.name, itemIds: helmValuesFiles.map(vf => vf.id)};
         })

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
@@ -22,7 +22,7 @@ const childSectionNames = navSectionNames.representation[navSectionNames.K8S_RES
 const kindHandlersBySubsectionName: Record<string, ResourceKindHandler[]> = {};
 ResourceKindHandlers.forEach(kindHandler => {
   const navSectionName = kindHandler.navigatorPath[0];
-  if (navSectionName !== navSectionNames.K8S_RESOURCES) {
+  if (navSectionName !== navSectionNames.K8S_RESOURCES || !childSectionNames) {
     return;
   }
   const subsectionName = kindHandler.navigatorPath[1];
@@ -31,13 +31,13 @@ ResourceKindHandlers.forEach(kindHandler => {
   }
 
   if (kindHandlersBySubsectionName[subsectionName]) {
-    kindHandlersBySubsectionName[subsectionName].push(kindHandler);
+    kindHandlersBySubsectionName[subsectionName]!.push(kindHandler);
   } else {
     kindHandlersBySubsectionName[subsectionName] = [kindHandler];
   }
 });
 
-const childSections = childSectionNames.map(childSectionName => {
+const childSections = childSectionNames?.map(childSectionName => {
   const kindHandlerSections = (kindHandlersBySubsectionName[childSectionName] || []).map(kindHandler =>
     makeResourceKindNavSection(kindHandler)
   );
@@ -78,7 +78,7 @@ const childSections = childSectionNames.map(childSectionName => {
   return subsection;
 });
 
-childSections.forEach(s => sectionBlueprintMap.register(s));
+childSections?.forEach(s => sectionBlueprintMap.register(s));
 
 export type K8sResourceScopeType = {
   isFolderLoading: boolean;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
@@ -39,6 +39,9 @@ const Prefix = (props: ItemCustomComponentProps) => {
   const filterNamespace = useAppSelector(state => state.main.resourceFilter.namespace);
 
   const applyNamespaceFilter = useCallback(() => {
+    if (!resource) {
+      return;
+    }
     dispatch(extendResourceFilter({namespace: resource.namespace, labels: {}, annotations: {}}));
   }, [resource, dispatch]);
 

--- a/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
+++ b/src/navsections/KustomizePatchSectionBlueprint/KustomizePatchSectionBlueprint.ts
@@ -45,7 +45,7 @@ const KustomizePatchSectionBlueprint: SectionBlueprint<K8sResource, KustomizePat
       const patcheResourcesByKind: Record<string, K8sResource[]> = patchResources.reduce<Record<string, K8sResource[]>>(
         (acc, resource) => {
           if (acc[resource.kind]) {
-            acc[resource.kind].push(resource);
+            acc[resource.kind]!.push(resource);
           } else {
             acc[resource.kind] = [resource];
           }

--- a/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
+++ b/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
@@ -64,7 +64,7 @@ const UnknownResourceSectionBlueprint: SectionBlueprint<K8sResource, UnknownReso
         Record<string, K8sResource[]>
       >((acc, resource) => {
         if (acc[resource.kind]) {
-          acc[resource.kind].push(resource);
+          acc[resource.kind]!.push(resource);
         } else {
           acc[resource.kind] = [resource];
         }

--- a/src/redux/services/applyFileWithConfirm.tsx
+++ b/src/redux/services/applyFileWithConfirm.tsx
@@ -15,7 +15,11 @@ export function applyFileWithConfirm(
   kubeconfig: string,
   context: string
 ) {
-  const title = `Deploy ${fileMap[selectedPath].name} to cluster [${context}]?`;
+  const fileEntry = fileMap[selectedPath];
+  if (!fileEntry) {
+    return;
+  }
+  const title = `Deploy ${fileEntry.name} to cluster [${context}]?`;
 
   Modal.confirm({
     title,

--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -38,7 +38,7 @@ function linkParentKustomization(
  */
 
 export function isKustomizationResource(r: K8sResource | undefined) {
-  return r && r.kind === KUSTOMIZATION_KIND;
+  return Boolean(r && r.kind === KUSTOMIZATION_KIND);
 }
 
 /**
@@ -79,7 +79,7 @@ function processKustomizationResourceRef(
       // resource is folder -> find contained kustomizations and link...
       fileEntry.children
         .map(child => fileMap[path.join(fileEntry.filePath, child)])
-        .filter(childFileEntry => childFileEntry)
+        .filter((childFileEntry): childFileEntry is FileEntry => Boolean(childFileEntry))
         .filter(childFileEntry => isKustomizationFile(childFileEntry, resourceMap))
         .forEach(childFileEntry => {
           linkParentKustomization(childFileEntry, kustomization, resourceMap, refNode);

--- a/src/redux/services/resourceRefs.ts
+++ b/src/redux/services/resourceRefs.ts
@@ -57,7 +57,7 @@ const joinPathParts = (pathParts: string[]) => {
 
 const addRefNodeAtPath = (refNode: RefNode, path: string, refNodesByPath: Record<string, RefNode[]>) => {
   if (refNodesByPath[path]) {
-    refNodesByPath[path].push(refNode);
+    refNodesByPath[path]!.push(refNode);
   } else {
     refNodesByPath[path] = [refNode];
   }
@@ -594,12 +594,12 @@ export function processRefs(
   // select which resources to process based on optional filter
   const resources: K8sResource[] = [];
 
-  if (filter && filter.resourceIds) {
-    resources.push(...filter.resourceIds.map(id => resourceMap[id]));
+  if (filter?.resourceIds) {
+    resources.push(...filter.resourceIds.map(id => resourceMap[id]).filter((r): r is K8sResource => Boolean(r)));
   }
 
-  if (filter && filter.resourceKinds) {
-    resources.push(...Object.values(resourceMap).filter(resource => filter?.resourceKinds?.includes(resource.kind)));
+  if (filter?.resourceKinds) {
+    resources.push(...Object.values(resourceMap).filter(resource => filter.resourceKinds?.includes(resource.kind)));
   }
 
   if (!filter?.resourceIds && !filter?.resourceKinds) {

--- a/src/redux/services/selection.ts
+++ b/src/redux/services/selection.ts
@@ -28,7 +28,7 @@ export function clearResourceSelections(resourceMap: ResourceMapType, excludeIte
 export function highlightChildrenResources(fileEntry: FileEntry, resourceMap: ResourceMapType, fileMap: FileMapType) {
   fileEntry.children
     ?.map(e => fileMap[getChildFilePath(e, fileEntry, fileMap)])
-    .filter(child => child)
+    .filter((child): child is FileEntry => Boolean(child))
     .forEach(child => {
       getResourcesForPath(child.filePath, resourceMap).forEach(e => {
         e.isHighlighted = true;

--- a/src/redux/thunks/applySelectedResourceMatches.ts
+++ b/src/redux/thunks/applySelectedResourceMatches.ts
@@ -23,7 +23,7 @@ export const applySelectedResourceMatches = createAsyncThunk<
   const resourcesToApply = matches
     .filter(match => selectedMatches.includes(match.id))
     .map(match =>
-      match.localResourceIds && match.localResourceIds.length > 0 ? resourceMap[match.localResourceIds[0]] : undefined
+      match.localResourceIds && match.localResourceIds.length > 0 ? resourceMap[match.localResourceIds[0]!] : undefined
     )
     .filter((r): r is K8sResource => r !== undefined);
 

--- a/src/redux/thunks/previewHelmValuesFile.ts
+++ b/src/redux/thunks/previewHelmValuesFile.ts
@@ -30,10 +30,20 @@ export const previewHelmValuesFile = createAsyncThunk<
   const kubeconfigContext = thunkAPI.getState().config.kubeConfig.currentContext;
   const valuesFile = state.helmValuesMap[valuesFileId];
 
-  if (valuesFile && valuesFile.filePath) {
-    const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;
+  if (!kubeconfigContext) {
+    return createRejectionWithAlert(thunkAPI, 'Helm Error', 'Missing Kubeconfig context');
+  }
+
+  if (valuesFile?.filePath) {
+    const rootFolder = state.fileMap[ROOT_FILE_ENTRY]?.filePath;
+    if (!rootFolder) {
+      return createRejectionWithAlert(thunkAPI, 'Helm Error', 'Missing root folder');
+    }
     const folder = path.join(rootFolder, valuesFile.filePath.substr(0, valuesFile.filePath.lastIndexOf(path.sep)));
     const chart = state.helmChartMap[valuesFile.helmChartId];
+    if (!chart) {
+      return createRejectionWithAlert(thunkAPI, 'Helm Error', 'Missing Helm Chart');
+    }
 
     // sanity check
     if (fs.existsSync(folder) && fs.existsSync(path.join(folder, valuesFile.name))) {

--- a/src/redux/thunks/previewKustomization.ts
+++ b/src/redux/thunks/previewKustomization.ts
@@ -28,8 +28,11 @@ export const previewKustomization = createAsyncThunk<
   const state = thunkAPI.getState().main;
   const appConfig = thunkAPI.getState().config;
   const resource = state.resourceMap[resourceId];
-  if (resource && resource.filePath) {
-    const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;
+  if (resource?.filePath) {
+    const rootFolder = state.fileMap[ROOT_FILE_ENTRY]?.filePath;
+    if (!rootFolder) {
+      return createRejectionWithAlert(thunkAPI, 'Kustomize Error', 'Missing root folder');
+    }
     const folder = path.join(rootFolder, resource.filePath.substr(0, resource.filePath.lastIndexOf(path.sep)));
 
     log.info(`previewing ${resource.id} in folder ${folder}`);

--- a/src/redux/thunks/replaceSelectedResourceMatches.ts
+++ b/src/redux/thunks/replaceSelectedResourceMatches.ts
@@ -30,11 +30,14 @@ export const replaceSelectedResourceMatches = createAsyncThunk<
       const updateManyResourcesPayload: UpdateManyResourcesPayload = selectedMatches
         .map(matchId => {
           const currentMatch = clusterToLocalResourcesMatches.find(m => m.id === matchId);
-          if (!currentMatch?.localResourceIds?.length || !currentMatch?.clusterResourceId) {
+          if (!currentMatch?.localResourceIds?.length || !currentMatch.clusterResourceId) {
             return undefined;
           }
 
           const clusterResource = resourceMap[currentMatch.clusterResourceId];
+          if (!clusterResource) {
+            return undefined;
+          }
 
           const originalClusterResourceContent = parse(clusterResource.text);
           const cleanClusterResourceContent = removeIgnoredPathsFromResourceContent(originalClusterResourceContent);
@@ -46,7 +49,7 @@ export const replaceSelectedResourceMatches = createAsyncThunk<
             content: cleanClusterResourceText,
           };
         })
-        .filter((id): id is {resourceId: string; content: string} => Boolean(id) === true);
+        .filter((id): id is {resourceId: string; content: string} => Boolean(id));
 
       thunkAPI.dispatch(updateManyResources(updateManyResourcesPayload));
       thunkAPI.dispatch(reloadClusterDiff());

--- a/src/redux/thunks/saveUnsavedResource.ts
+++ b/src/redux/thunks/saveUnsavedResource.ts
@@ -91,13 +91,13 @@ export const saveUnsavedResource = createAsyncThunk<
       }
 
       const fileContent = await readFilePromise(absolutePath, 'utf-8');
-      const relativeFilePath = absolutePath.substr(mainState.fileMap[ROOT_FILE_ENTRY].filePath.length);
+      const relativeFilePath = absolutePath.substr(rootFileEntry.filePath.length);
       const resourcesFromFile = getResourcesForPath(relativeFilePath, mainState.resourceMap);
 
       if (resourcesFromFile.length === 1) {
         thunkAPI.dispatch(
           addResource({
-            ...resourcesFromFile[0],
+            ...resourcesFromFile[0]!,
             range: {
               start: 0,
               length: fileContent.length,

--- a/src/redux/thunks/selectionHistory.ts
+++ b/src/redux/thunks/selectionHistory.ts
@@ -74,10 +74,10 @@ export const selectFromHistory = async (
   }
 
   const selectionHistoryEntry = newSelectionHistory[nextSelectionHistoryIndex];
-  if (selectionHistoryEntry.type === 'resource') {
+  if (selectionHistoryEntry?.type === 'resource') {
     dispatch(selectK8sResource({resourceId: selectionHistoryEntry.selectedResourceId, isVirtualSelection: true}));
   }
-  if (selectionHistoryEntry.type === 'path') {
+  if (selectionHistoryEntry?.type === 'path') {
     dispatch(selectFile({filePath: selectionHistoryEntry.selectedPath, isVirtualSelection: true}));
   }
 

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -108,18 +108,13 @@ export function getDefaultNamespaceForApply(resources: K8sResource[]): {
   defaultOption?: string;
 } {
   let namespace = 'default';
-
   for (let i = 0; i < resources.length; i += 1) {
-    const resourceNamespace = resources[i].namespace;
-
-    if (resourceNamespace) {
-      if (resources[i].namespace !== namespace) {
-        if (namespace !== 'default') {
-          return {defaultNamespace: 'default', defaultOption: 'none'};
-        }
-
-        namespace = resourceNamespace;
+    const resourceNamespace = resources[i]?.namespace;
+    if (resourceNamespace && resourceNamespace !== namespace) {
+      if (namespace !== 'default') {
+        return {defaultNamespace: 'default', defaultOption: 'none'};
       }
+      namespace = resourceNamespace;
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,14 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "strictBindCallApply": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -21,8 +19,6 @@
     "baseUrl": "./",
     "outDir": "./build"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "extends": "./paths.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
@@ -19,6 +23,8 @@
     "baseUrl": "./",
     "outDir": "./build"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "./paths.json"
 }


### PR DESCRIPTION
This PR...

## Changes

- better ordering/organization of rules in estlintrc
- added multiple typescript lint rules, set all of them to "warn" to begin with
- set `noUncheckedIndexedAccess` to true in tsconfig, read more: https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-beta/#no-unchecked-indexed-access

## Fixes

- fixed all errors introduced by `noUncheckedIndexedAccess`

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
