### PR TITLE
feat: hotkey for resetting resource filters

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,7 +6,7 @@ Monokle is layed out like many other desktop applications:
 
 Left to right:
 
-- The vertical toolbar to the far left  allows you to switch between File and Cluster mode.
+- The vertical toolbar to the far left allows you to switch between File and Cluster mode.
 - The File Explorer (shown in screenshot) shows the contents of the currently selected folder.
 - The Navigator in the center shows all resources found in the current folder or cluster. By default it shows all possible
   Resource sections and subsections - when selecting a folder or cluster only those sections that actually contain
@@ -19,7 +19,7 @@ The top right contains the following buttons
 - GitHub -> opens the Monokle GitHub repo in your system browser.
 - Help -> opens the Monokle documentation in your system browser
 
-## Settings 
+## Settings
 
 Clicking the Settings icon on the top right opens the settings:
 
@@ -29,10 +29,10 @@ Clicking the Settings icon on the top right opens the settings:
 - **Files: Include**: which files to parse for kubernetes resources when scanning folders
 - **Files: Exclude**: which files/folders to exclude when scanning folders for resources
 - **Helm Preview Mode**: which Helm command to use for generating previews (see [Working with Helm Charts](helm.md))
-    - Template: uses [Helm Template](https://helm.sh/docs/helm/helm_template/)
-    - Install: uses [Helm Install](https://helm.sh/docs/helm/helm_install/)
-- **On Startup**: 
-    - Automatically load last folder: will do just that on startup!
+  - Template: uses [Helm Template](https://helm.sh/docs/helm/helm_template/)
+  - Install: uses [Helm Install](https://helm.sh/docs/helm/helm_install/)
+- **On Startup**:
+  - Automatically load last folder: will do just that on startup!
 - **Maximum folder-read recursion depth**: configures how "deep" Monokle will parse a specified folder (to avoid going too deep)
 
 ## System Menu
@@ -43,13 +43,13 @@ Mac System Menu:
 
 ![MacOS Monokle System Menu](img/mac-system-menu.png)
 
-Windows System Menu: 
+Windows System Menu:
 
 ![Windows Monokle System Menu](img/windows-system-menu.png)
 
 ## Multiple Windows
 
-You can launch multiple project windows using the New Monokle Windows option. It allows you to work on multiple folders or clusters simultaneously. Thus visual navigation for the recently used pages becomes simpler and faster.   
+You can launch multiple project windows using the New Monokle Windows option. It allows you to work on multiple folders or clusters simultaneously. Thus visual navigation for the recently used pages becomes simpler and faster.
 
 **Action:** File > New Monokle Window
 
@@ -72,6 +72,7 @@ Monokle current supports the following keyboard shortcuts:
 - Open New Resource Wizard: Ctrl/Cmd N
 - Apply Resource or File to cluster: Ctrl/Cmd ALT S
 - Diff Resource: Ctrl/Cmd ALT D
+- Reset Resource Filters: Ctrl/Cmd ALT R
 
 ## Auto-update
 

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -7,7 +7,7 @@ import hotkeys from '@constants/hotkeys';
 import {makeApplyKustomizationText, makeApplyResourceText} from '@constants/makeApplyText';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {openResourceDiffModal} from '@redux/reducers/main';
+import {openResourceDiffModal, updateResourceFilter} from '@redux/reducers/main';
 import {
   openNewResourceWizard,
   setLeftMenuSelection,
@@ -240,6 +240,10 @@ const HotKeysHandler = () => {
 
   useHotkeys(hotkeys.OPEN_HELM_TAB, () => {
     dispatch(setLeftMenuSelection('helm-pane'));
+  });
+
+  useHotkeys(hotkeys.RESET_RESOURCE_FILTERS, () => {
+    dispatch(updateResourceFilter({name: '', namespace: undefined, kind: undefined, labels: {}, annotations: {}}));
   });
 
   return (

--- a/src/constants/hotkeys.ts
+++ b/src/constants/hotkeys.ts
@@ -16,6 +16,7 @@ const hotkeys = {
   OPEN_EXPLORER_TAB: 'ctrl+shift+e, command+shift+e',
   OPEN_KUSTOMIZATION_TAB: 'ctrl+shift+k, command+shift+k',
   OPEN_HELM_TAB: 'ctrl+shift+h, command+shift+h',
+  RESET_RESOURCE_FILTERS: 'ctrl+alt+r, command+alt+r',
 };
 
 export default hotkeys;


### PR DESCRIPTION
## Changes

- Added `Ctrl/Cmd ALT R` hotkey for resetting the resource filters


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
