### PR TITLE
feat : filter resource by file/folder

### DIFF
--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -20,6 +20,7 @@ import Colors from '@styles/Colors';
 import {ResourceKindHandlers} from '@src/kindhandlers';
 
 const ALL_OPTIONS = '<all>';
+const ROOT_OPTIONS = '<root>';
 
 const BaseContainer = styled.div`
   min-width: 250px;
@@ -180,14 +181,16 @@ const ResourceFilter = () => {
       if (!wasLocalUpdate) {
         return;
       }
+
       const updatedFilter = {
         name,
         kind: kind === ALL_OPTIONS ? undefined : kind,
         namespace: namespace === ALL_OPTIONS ? undefined : namespace,
         labels,
         annotations,
-        fileOrFolderContainedIn: fileOrFolderContainedIn === ALL_OPTIONS ? undefined : fileOrFolderContainedIn,
+        fileOrFolderContainedIn: fileOrFolderContainedIn === ROOT_OPTIONS ? undefined : fileOrFolderContainedIn,
       };
+
       dispatch(updateResourceFilter(updatedFilter));
     },
     DEFAULT_EDITOR_DEBOUNCE,
@@ -277,16 +280,13 @@ const ResourceFilter = () => {
       <FieldContainer>
         <FieldLabel>Contained in:</FieldLabel>
         <Select
-          defaultValue={ALL_OPTIONS}
+          defaultValue={ROOT_OPTIONS}
           disabled={areFiltersDisabled}
           showSearch
           style={{width: '100%'}}
-          value={fileOrFolderContainedIn || ALL_OPTIONS}
+          value={fileOrFolderContainedIn || ROOT_OPTIONS}
           onChange={updateFileOrFolderContainedIn}
         >
-          <Option key={ALL_OPTIONS} value={ALL_OPTIONS}>
-            {ALL_OPTIONS}
-          </Option>
           {fileOrFolderContainedInOptions}
         </Select>
       </FieldContainer>

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -131,6 +131,7 @@ const ResourceFilter = () => {
     setNamespace(ALL_OPTIONS);
     setLabels({});
     setAnnotations({});
+    setFileOrFolderContainedIn(ALL_OPTIONS);
   };
 
   const updateName = (newName: string) => {
@@ -185,11 +186,12 @@ const ResourceFilter = () => {
         namespace: namespace === ALL_OPTIONS ? undefined : namespace,
         labels,
         annotations,
+        fileOrFolderContainedIn: fileOrFolderContainedIn === ALL_OPTIONS ? undefined : fileOrFolderContainedIn,
       };
       dispatch(updateResourceFilter(updatedFilter));
     },
     DEFAULT_EDITOR_DEBOUNCE,
-    [name, kind, namespace, labels, annotations]
+    [name, kind, namespace, labels, annotations, fileOrFolderContainedIn]
   );
 
   useEffect(() => {
@@ -199,6 +201,7 @@ const ResourceFilter = () => {
       setNamespace(filtersMap.namespace);
       setLabels(filtersMap.labels);
       setAnnotations(filtersMap.annotations);
+      setFileOrFolderContainedIn(filtersMap.fileOrFolderContainedIn);
     }
   }, [wasLocalUpdate, filtersMap]);
 
@@ -281,6 +284,9 @@ const ResourceFilter = () => {
           value={fileOrFolderContainedIn || ALL_OPTIONS}
           onChange={updateFileOrFolderContainedIn}
         >
+          <Option key={ALL_OPTIONS} value={ALL_OPTIONS}>
+            {ALL_OPTIONS}
+          </Option>
           {fileOrFolderContainedInOptions}
         </Select>
       </FieldContainer>

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -132,7 +132,7 @@ const ResourceFilter = () => {
     setNamespace(ALL_OPTIONS);
     setLabels({});
     setAnnotations({});
-    setFileOrFolderContainedIn(ALL_OPTIONS);
+    setFileOrFolderContainedIn(ROOT_OPTIONS);
   };
 
   const updateName = (newName: string) => {

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -3,7 +3,6 @@ import {useDebounce} from 'react-use';
 
 import {Button, Input, Select} from 'antd';
 
-import path from 'path';
 import styled from 'styled-components';
 
 import {DEFAULT_EDITOR_DEBOUNCE} from '@constants/constants';
@@ -116,13 +115,11 @@ const ResourceFilter = () => {
   }, [resourceMap]);
 
   const fileOrFolderContainedInOptions = useMemo(() => {
-    return Object.keys(fileMap)
-      .map(key => key.replace(path.sep, ''))
-      .map(option => (
-        <Option key={option} value={option}>
-          {option}
-        </Option>
-      ));
+    return Object.keys(fileMap).map(option => (
+      <Option key={option} value={option}>
+        {option}
+      </Option>
+    ));
   }, [fileMap]);
 
   const resetFilters = () => {
@@ -278,7 +275,27 @@ const ResourceFilter = () => {
       </FieldContainer>
 
       <FieldContainer>
-        <FieldLabel>Contained in:</FieldLabel>
+        <KeyValueInput
+          label="Labels:"
+          data={allLabels}
+          value={labels}
+          onChange={updateLabels}
+          disabled={areFiltersDisabled}
+        />
+      </FieldContainer>
+
+      <FieldContainer>
+        <KeyValueInput
+          disabled={areFiltersDisabled}
+          label="Annotations:"
+          data={allAnnotations}
+          value={annotations}
+          onChange={updateAnnotations}
+        />
+      </FieldContainer>
+
+      <FieldContainer>
+        <FieldLabel>Contained in file/folder:</FieldLabel>
         <Select
           defaultValue={ROOT_OPTIONS}
           disabled={areFiltersDisabled}
@@ -289,25 +306,6 @@ const ResourceFilter = () => {
         >
           {fileOrFolderContainedInOptions}
         </Select>
-      </FieldContainer>
-
-      <FieldContainer>
-        <KeyValueInput
-          label="Labels:"
-          data={allLabels}
-          value={labels}
-          onChange={updateLabels}
-          disabled={areFiltersDisabled}
-        />
-      </FieldContainer>
-      <FieldContainer>
-        <KeyValueInput
-          disabled={areFiltersDisabled}
-          label="Annotations:"
-          data={allAnnotations}
-          value={annotations}
-          onChange={updateAnnotations}
-        />
       </FieldContainer>
     </BaseContainer>
   );

--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -3,7 +3,7 @@ import {useDebounce} from 'react-use';
 
 import {Button, Input, Select} from 'antd';
 
-import path from 'path/posix';
+import path from 'path';
 import styled from 'styled-components';
 
 import {DEFAULT_EDITOR_DEBOUNCE} from '@constants/constants';

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -356,7 +356,7 @@ interface TreeItemProps {
   onIncludeToProcessing: (relativePath: string) => void;
   onCreateFolder: (absolutePath: string) => void;
   onCreateResource: (params: {targetFolder?: string; targetFile?: string}) => void;
-  onFilterByFileOrFolder: (relativePath: string) => void;
+  onFilterByFileOrFolder: (relativePath: string | undefined) => void;
   isExcluded?: Boolean;
   isFolder?: Boolean;
 }
@@ -462,7 +462,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
         onClick={e => {
           e.domEvent.stopPropagation();
 
-          onFilterByFileOrFolder(relativePath);
+          onFilterByFileOrFolder(isRoot ? undefined : relativePath);
         }}
       >
         Filter on this {isFolder ? 'folder' : 'file'}
@@ -867,8 +867,8 @@ const FileTreePane = () => {
     }
   };
 
-  const onFilterByFileOrFolder = (relativePath: string) => {
-    dispatch(updateResourceFilter({...resourceFilter, fileOrFolderContainedIn: relativePath || '<root>'}));
+  const onFilterByFileOrFolder = (relativePath: string | undefined) => {
+    dispatch(updateResourceFilter({...resourceFilter, fileOrFolderContainedIn: relativePath}));
   };
 
   return (

--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -399,6 +399,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
 
   const [isTitleHovered, setTitleHoverState] = useState(false);
 
+  const fileOrFolderContainedInFilter = useAppSelector(state => state.main.resourceFilter.fileOrFolderContainedIn);
   const fileMap = useAppSelector(state => state.main.fileMap);
   const osPlatform = useAppSelector(state => state.config.osPlatform);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
@@ -466,10 +467,16 @@ const TreeItem: React.FC<TreeItemProps> = props => {
         onClick={e => {
           e.domEvent.stopPropagation();
 
-          onFilterByFileOrFolder(isRoot ? undefined : relativePath);
+          if (isRoot || (fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter)) {
+            onFilterByFileOrFolder(undefined);
+          } else {
+            onFilterByFileOrFolder(relativePath);
+          }
         }}
       >
-        Filter on this {isFolder ? 'folder' : 'file'}
+        {fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter
+          ? 'Remove from filter'
+          : `Filter on this ${isFolder ? 'folder' : 'file'}`}
       </Menu.Item>
       <ContextMenuDivider />
       <Menu.Item

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -243,16 +243,7 @@ const HotKeysHandler = () => {
   });
 
   useHotkeys(hotkeys.RESET_RESOURCE_FILTERS, () => {
-    dispatch(
-      updateResourceFilter({
-        name: '',
-        namespace: undefined,
-        kind: undefined,
-        labels: {},
-        annotations: {},
-        fileOrFolderContainedIn: undefined,
-      })
-    );
+    dispatch(updateResourceFilter({labels: {}, annotations: {}}));
   });
 
   return (

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -243,7 +243,16 @@ const HotKeysHandler = () => {
   });
 
   useHotkeys(hotkeys.RESET_RESOURCE_FILTERS, () => {
-    dispatch(updateResourceFilter({name: '', namespace: undefined, kind: undefined, labels: {}, annotations: {}}));
+    dispatch(
+      updateResourceFilter({
+        name: '',
+        namespace: undefined,
+        kind: undefined,
+        labels: {},
+        annotations: {},
+        fileOrFolderContainedIn: undefined,
+      })
+    );
   });
 
   return (

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -6,7 +6,7 @@ import {Form, Input, Modal, Select} from 'antd';
 
 import {InfoCircleOutlined} from '@ant-design/icons';
 
-import path from 'path/posix';
+import path from 'path';
 
 import {ROOT_FILE_ENTRY} from '@constants/constants';
 import hotkeys from '@constants/hotkeys';

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -62,6 +62,7 @@ type ResourceFilterType = {
   namespace?: string;
   labels: Record<string, string | null>;
   annotations: Record<string, string | null>;
+  fileOrFolderContainedIn?: string;
 };
 
 type ResourceRefsProcessingOptions = {

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -499,6 +499,11 @@ export const mainSlice = createSlice({
             ? undefined
             : filter.kind
           : state.resourceFilter.kind,
+        fileOrFolderContainedIn: filter.fileOrFolderContainedIn
+          ? filter.fileOrFolderContainedIn === state.resourceFilter.fileOrFolderContainedIn
+            ? undefined
+            : filter.fileOrFolderContainedIn
+          : state.resourceFilter.fileOrFolderContainedIn,
         name: state.resourceFilter.name,
         labels: state.resourceFilter.labels,
         annotations: state.resourceFilter.annotations,

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -36,6 +36,9 @@ export function isResourcePassingFilter(resource: K8sResource, filters: Resource
       return false;
     }
   }
+  if (filters.fileOrFolderContainedIn && !resource.filePath.startsWith(filters.fileOrFolderContainedIn)) {
+    return false;
+  }
   if (filters.labels && Object.keys(filters.labels).length > 0) {
     const resourceLabels = resource.content?.metadata?.labels;
     if (!resourceLabels) {


### PR DESCRIPTION
This PR implements the functionality to filter resources by file/folder.

## Changes

- Add new filter `Contained in` in resource filters which filters resources by file/folder
- Add option to apply filtering on file/folder in `FileTreePane ContextMenu`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
