### PR TITLE
fix: disable actions for excluded/unsupported files

### DIFF
--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -65,6 +65,7 @@ interface TreeNode {
   isLeaf?: boolean;
   icon?: React.ReactNode;
   isExcluded?: boolean;
+  isSupported?: boolean;
 }
 
 const StyledNumberOfResources = styled(Typography.Text)`
@@ -121,6 +122,7 @@ const createNode = (
     children: [],
     highlight: false,
     isExcluded: fileEntry.isExcluded,
+    isSupported: fileEntry.isSupported,
   };
 
   if (fileEntry.children) {
@@ -364,7 +366,8 @@ interface TreeItemProps {
   onCreateResource: (params: {targetFolder?: string; targetFile?: string}) => void;
   onFilterByFileOrFolder: (relativePath: string | undefined) => void;
   onPreview: (relativePath: string) => void;
-  isExcluded?: Boolean;
+  isExcluded?: boolean;
+  isSupported?: boolean;
   isFolder?: Boolean;
 }
 
@@ -384,12 +387,9 @@ function deleteEntityWizard(entityInfo: {entityAbsolutePath: string}, onOk: () =
 }
 
 const TreeItem: React.FC<TreeItemProps> = props => {
+  const {isExcluded, isFolder, isSupported, processingEntity, title, treeKey} = props;
   const {
-    title,
-    treeKey,
-    isExcluded,
     setProcessingEntity,
-    processingEntity,
     onDelete,
     onRename,
     onExcludeFromProcessing,
@@ -398,7 +398,6 @@ const TreeItem: React.FC<TreeItemProps> = props => {
     onCreateResource,
     onFilterByFileOrFolder,
     onPreview,
-    isFolder,
   } = props;
 
   const [isTitleHovered, setTitleHoverState] = useState(false);
@@ -474,7 +473,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
       ) : null}
 
       <Menu.Item
-        disabled={isInPreviewMode}
+        disabled={isInPreviewMode || (!isFolder && (isExcluded || !isSupported))}
         onClick={e => {
           e.domEvent.stopPropagation();
           onCreateResource(isFolder ? {targetFolder: target} : {targetFile: target});
@@ -486,7 +485,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
       <ContextMenuDivider />
       <Menu.Item
         key={`filter_on_this_${isFolder ? 'folder' : 'file'}`}
-        disabled={isInPreviewMode}
+        disabled={isInPreviewMode || (!isFolder && (isExcluded || !isSupported))}
         onClick={e => {
           e.domEvent.stopPropagation();
 
@@ -504,7 +503,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
       {fileMap[ROOT_FILE_ENTRY].filePath !== treeKey ? (
         <>
           <Menu.Item
-            disabled={isInPreviewMode}
+            disabled={isInPreviewMode || (!isFolder && !isSupported && !isExcluded)}
             onClick={e => {
               e.domEvent.stopPropagation();
               if (isExcluded) {
@@ -926,7 +925,7 @@ const FileTreePane = () => {
         }
       }
     },
-    [resourceMap, fileMap, helmValuesMap]
+    [dispatch, fileMap, helmValuesMap, resourceMap]
   );
 
   const onCreateResource = ({targetFolder, targetFile}: {targetFolder?: string; targetFile?: string}) => {


### PR DESCRIPTION
## Fixes

- Disabled `Add resource` for **Excluded** and **Unsupported** files
- Disabled `Filter on this file/folder` for **Excluded** and **Unsupported** files
- Disabled `Remove from/Add to Files: Exclude` for **Unsupported** files

##

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test