### PR TITLE
refactor: remove zoom action for non macos systems

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -278,17 +278,19 @@ const viewMenu = (state: RootState, dispatch: MainDispatch): MenuItemConstructor
 };
 
 const windowMenu = (): MenuItemConstructorOptions => {
-  return {
-    label: 'Window',
-    submenu: [
-      {role: 'minimize'},
-      {role: 'zoom'},
-      {type: 'separator'},
-      {role: 'front'},
-      {type: 'separator'},
-      {role: 'window'},
-    ],
-  };
+  const submenu: MenuItemConstructorOptions[] = [
+    {role: 'minimize'},
+    {type: 'separator'},
+    {role: 'front'},
+    {type: 'separator'},
+    {role: 'window'},
+  ];
+
+  if (isMac) {
+    submenu.splice(1, 0, {role: 'zoom'});
+  }
+
+  return {label: 'Window', submenu};
 };
 
 const helpMenu = (


### PR DESCRIPTION
This PR removes the `Zoom` action for non-macOS systems.

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
