### PR TITLE
fix: guard against no cluster configured

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -61,6 +61,9 @@ import featureFlags from '@src/feature-flags.json';
 import {getResourceKindHandler} from '@src/kindhandlers';
 import {getFormSchema, getUiSchema} from '@src/kindhandlers/common/formLoader';
 
+import { setAlert } from '@redux/reducers/alert';
+import { AlertEnum, AlertType } from '@models/alert';
+
 import * as S from './ActionsPane.styled';
 import ActionsPaneFooter from './ActionsPaneFooter';
 
@@ -259,10 +262,21 @@ const ActionsPane = (props: {contentHeight: string}) => {
   }, [monacoEditor]);
 
   const diffSelectedResource = useCallback(() => {
+    if (!kubeconfigContext || kubeconfigContext === '') {
+      const alert: AlertType = {
+        type: AlertEnum.Error,
+        title: 'Diff failed',
+        message: 'No Cluster Configured',
+      };
+
+      dispatch(setAlert(alert));
+      return;
+    }
+
     if (selectedResourceId) {
       dispatch(openResourceDiffModal(selectedResourceId));
     }
-  }, [dispatch, selectedResourceId]);
+  }, [dispatch, selectedResourceId,kubeconfigContext]);
 
   const onPerformResourceDiff = useCallback(
     (_: any, resourceId: string) => {

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -265,7 +265,7 @@ const ActionsPane = (props: {contentHeight: string}) => {
     if (!kubeconfigContext || kubeconfigContext === '') {
       const alert: AlertType = {
         type: AlertEnum.Error,
-        title: 'Diff failed',
+        title: 'Diff not available',
         message: 'No Cluster Configured',
       };
 

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -276,7 +276,7 @@ const ActionsPane = (props: {contentHeight: string}) => {
     if (selectedResourceId) {
       dispatch(openResourceDiffModal(selectedResourceId));
     }
-  }, [dispatch, selectedResourceId,kubeconfigContext]);
+  }, [dispatch, selectedResourceId, kubeconfigContext]);
 
   const onPerformResourceDiff = useCallback(
     (_: any, resourceId: string) => {


### PR DESCRIPTION
This PR...

## Changes

- Added a guard check if there is no kube context before open the DiffModal and show an alert 

## Fixes

- Crashing if there is no configured cluster 

<img width="1058" alt="Screen Shot 2022-01-12 at 10 15 41 AM" src="https://user-images.githubusercontent.com/20525304/149135982-960697af-a25c-4bc4-b636-e91dcf45e6a4.png">


## How to test it

- remove the kube config from ~/.kube/config or shutdown the cluster 
- open a project folder
- select a resource 
- diff against the cluster 
- should show cluster is not configured error popup message  

## Screenshots
<img width="1433" alt="Screen Shot 2022-01-12 at 1 49 34 PM" src="https://user-images.githubusercontent.com/20525304/149135759-6b0f481d-b450-4a23-b945-23ec0d480b6f.png">


## Checklist

- [x] tested locally 
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
