### PR TITLE
feat: add name context to section header

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -39,7 +39,7 @@ function SectionHeader(props: SectionHeaderProps) {
   const dispatch = useAppDispatch();
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
-  const {NameDisplay, NameSuffix} = useSectionCustomization(sectionBlueprint.customization);
+  const {NameDisplay, NameSuffix, NameContext} = useSectionCustomization(sectionBlueprint.customization);
 
   const toggleCollapse = useCallback(() => {
     if (isCollapsed) {
@@ -52,23 +52,6 @@ function SectionHeader(props: SectionHeaderProps) {
   const itemsLength = useMemo(() => {
     return sectionInstance?.visibleDescendantItemIds?.length || 0;
   }, [sectionInstance.visibleDescendantItemIds]);
-
-  const {shouldDisplayPlus, shouldDisplayContext} = useMemo(() => {
-    let _shouldDisplayPlus = false;
-    let _shouldDisplayContext = false;
-    if (NameSuffix.Component) {
-      if (NameSuffix.options?.isVisibleOnHover === undefined) {
-        _shouldDisplayContext = true;
-      } else {
-        _shouldDisplayPlus = NameSuffix.options?.isVisibleOnHover && isHovered;
-      }
-    }
-
-    return {
-      shouldDisplayPlus: _shouldDisplayPlus,
-      shouldDisplayContext: _shouldDisplayContext,
-    };
-  }, [NameSuffix.Component, NameSuffix.options, isHovered]);
 
   const onCheck = useCallback(() => {
     if (!sectionInstance.checkable || !sectionInstance.visibleDescendantItemIds) {
@@ -132,7 +115,9 @@ function SectionHeader(props: SectionHeaderProps) {
             {itemsLength > 0 && (
               <S.ItemsLength selected={sectionInstance.isSelected && isCollapsed}>{itemsLength}</S.ItemsLength>
             )}
-            {shouldDisplayPlus && NameSuffix.Component && <NameSuffix.Component sectionInstance={sectionInstance} />}
+            {NameSuffix.Component && NameSuffix.options?.isVisibleOnHover && isHovered && (
+              <NameSuffix.Component sectionInstance={sectionInstance} />
+            )}
             <S.BlankSpace level={level} onClick={toggleCollapse} />
             {isHovered && sectionInstance.isInitialized && (
               <S.Collapsible>
@@ -151,8 +136,8 @@ function SectionHeader(props: SectionHeaderProps) {
         )}
       </S.NameContainer>
       <S.NameDisplayContainer>
-        {!NameDisplay.Component && NameSuffix.Component && shouldDisplayContext && (
-          <NameSuffix.Component sectionInstance={sectionInstance} />
+        {!NameDisplay.Component && NameContext.Component && (
+          <NameContext.Component sectionInstance={sectionInstance} />
         )}
       </S.NameDisplayContainer>
     </S.SectionContainer>

--- a/src/components/molecules/SectionRenderer/useSectionCustomization.ts
+++ b/src/components/molecules/SectionRenderer/useSectionCustomization.ts
@@ -15,6 +15,10 @@ export function useSectionCustomization(customization: SectionCustomization = {}
     () => ({Component: customization.emptyDisplay?.component}),
     [customization.emptyDisplay]
   );
+  const NameContext = useMemo(
+    () => ({Component: customization.nameContext?.component}),
+    [customization.nameContext]
+  );
 
-  return {NameDisplay, EmptyDisplay, NameSuffix};
+  return {NameDisplay, EmptyDisplay, NameSuffix, NameContext};
 }

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -59,6 +59,9 @@ export interface SectionCustomization {
   emptyDisplay?: {
     component: SectionCustomComponent;
   };
+  nameContext?: {
+    component: SectionCustomComponent;
+  };
   disableHoverStyle?: boolean;
   beforeInitializationText?: string;
   isCheckVisibleOnHover?: boolean;

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
@@ -138,7 +138,7 @@ const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScop
     emptyDisplay: {
       component: K8sResourceSectionEmptyDisplay,
     },
-    nameSuffix: {
+    nameContext: {
       component: K8sResourceSectionNameSuffix,
     },
     isCheckVisibleOnHover: true,


### PR DESCRIPTION
This PR...

## Changes

Add a new option to section header for displaying context bellow

## Fixes

-

## How to test it

Connect to a kubernetes cluster

## Screenshots

![image](https://user-images.githubusercontent.com/5509112/149759492-bf0aad37-c80c-4de3-b648-4e2da9ee8ea7.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
