### PR TITLE
fix: disable tool menu when no active project

### DIFF
--- a/src/components/organisms/PaneManager/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo, useState} from 'react';
 import {shallowEqual} from 'react-redux';
 
-import {Button} from 'antd';
+import {Button, ButtonProps} from 'antd';
 
 import _ from 'lodash';
 import styled from 'styled-components';
@@ -25,14 +25,16 @@ const StyledButton = styled(Button)<{$isHovered: boolean; $hasGradientBackground
   }}
 `;
 
-const MenuButton: React.FC<{
+interface IMenuButtonProps extends ButtonProps {
   shouldWatchSelectedPath?: boolean;
   sectionNames?: string[];
   isSelected: boolean;
   isActive: boolean;
   onClick: () => void;
-}> = props => {
-  const {children, sectionNames, shouldWatchSelectedPath, isSelected, isActive, onClick} = props;
+}
+
+const MenuButton: React.FC<IMenuButtonProps> = props => {
+  const {children, sectionNames, shouldWatchSelectedPath, isSelected, isActive, onClick, ...buttonProps} = props;
 
   const selectedPath = useAppSelector(state => state.main.selectedPath);
   const helmValuesMap = useAppSelector(state => state.main.helmValuesMap);
@@ -82,6 +84,7 @@ const MenuButton: React.FC<{
       style={style}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      {...buttonProps}
     />
   );
 };

--- a/src/components/organisms/PaneManager/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton.tsx
@@ -30,7 +30,6 @@ interface IMenuButtonProps extends ButtonProps {
   sectionNames?: string[];
   isSelected: boolean;
   isActive: boolean;
-  onClick: () => void;
 }
 
 const MenuButton: React.FC<IMenuButtonProps> = props => {

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -178,9 +178,10 @@ const PaneManager = () => {
 
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={PluginManagerTooltip} placement="right">
             <MenuButton
-              isSelected={leftMenuSelection === 'templates-pane'}
+              isSelected={Boolean(activeProject) && leftMenuSelection === 'templates-pane'}
               isActive={leftActive}
               onClick={() => setLeftActiveMenu('templates-pane')}
+              disabled={!activeProject}
             >
               <MenuIcon
                 icon={FormatPainterOutlined}
@@ -249,6 +250,7 @@ const PaneManager = () => {
       ) : (
         <StyledColumnPanes style={{width: contentWidth}}>
           <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-start', height: '100%'}}>
+            {leftMenuSelection === 'plugin-manager' && leftActive && <PluginManagerPane />}
             <div style={{flex: 3, height: '100%'}}>
               <StartProjectPane />
             </div>

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -143,6 +143,7 @@ const PaneManager = () => {
               isActive={leftActive}
               shouldWatchSelectedPath
               onClick={() => setLeftActiveMenu('file-explorer')}
+              disabled={!activeProject}
             >
               <MenuIcon
                 style={{marginLeft: 4}}
@@ -158,6 +159,7 @@ const PaneManager = () => {
               isActive={leftActive}
               onClick={() => setLeftActiveMenu('kustomize-pane')}
               sectionNames={[KUSTOMIZATION_SECTION_NAME, KUSTOMIZE_PATCH_SECTION_NAME]}
+              disabled={!activeProject}
             >
               <MenuIcon iconName="kustomize" active={leftActive} isSelected={leftMenuSelection === 'kustomize-pane'} />
             </MenuButton>
@@ -168,6 +170,7 @@ const PaneManager = () => {
               isActive={leftActive}
               onClick={() => setLeftActiveMenu('helm-pane')}
               sectionNames={[HELM_CHART_SECTION_NAME]}
+              disabled={!activeProject}
             >
               <MenuIcon iconName="helm" active={leftActive} isSelected={leftMenuSelection === 'helm-pane'} />
             </MenuButton>

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -149,13 +149,13 @@ const PaneManager = () => {
                 style={{marginLeft: 4}}
                 icon={isFolderOpen ? FolderOpenOutlined : FolderOutlined}
                 active={leftActive}
-                isSelected={leftMenuSelection === 'file-explorer'}
+                isSelected={Boolean(activeProject) && leftMenuSelection === 'file-explorer'}
               />
             </MenuButton>
           </Tooltip>
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title="Kustomizations" placement="right">
             <MenuButton
-              isSelected={leftMenuSelection === 'kustomize-pane'}
+              isSelected={Boolean(activeProject) && leftMenuSelection === 'kustomize-pane'}
               isActive={leftActive}
               onClick={() => setLeftActiveMenu('kustomize-pane')}
               sectionNames={[KUSTOMIZATION_SECTION_NAME, KUSTOMIZE_PATCH_SECTION_NAME]}
@@ -166,7 +166,7 @@ const PaneManager = () => {
           </Tooltip>
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title="Helm Charts" placement="right">
             <MenuButton
-              isSelected={leftMenuSelection === 'helm-pane'}
+              isSelected={Boolean(activeProject) && leftMenuSelection === 'helm-pane'}
               isActive={leftActive}
               onClick={() => setLeftActiveMenu('helm-pane')}
               sectionNames={[HELM_CHART_SECTION_NAME]}

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -140,7 +140,7 @@ const PaneManager = () => {
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={FileExplorerTooltip} placement="right">
             <MenuButton
               isSelected={leftMenuSelection === 'file-explorer'}
-              isActive={leftActive}
+              isActive={Boolean(activeProject) && leftActive}
               shouldWatchSelectedPath
               onClick={() => setLeftActiveMenu('file-explorer')}
               disabled={!activeProject}
@@ -148,7 +148,7 @@ const PaneManager = () => {
               <MenuIcon
                 style={{marginLeft: 4}}
                 icon={isFolderOpen ? FolderOpenOutlined : FolderOutlined}
-                active={leftActive}
+                active={Boolean(activeProject) && leftActive}
                 isSelected={Boolean(activeProject) && leftMenuSelection === 'file-explorer'}
               />
             </MenuButton>
@@ -156,37 +156,45 @@ const PaneManager = () => {
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title="Kustomizations" placement="right">
             <MenuButton
               isSelected={Boolean(activeProject) && leftMenuSelection === 'kustomize-pane'}
-              isActive={leftActive}
+              isActive={Boolean(activeProject) && leftActive}
               onClick={() => setLeftActiveMenu('kustomize-pane')}
               sectionNames={[KUSTOMIZATION_SECTION_NAME, KUSTOMIZE_PATCH_SECTION_NAME]}
               disabled={!activeProject}
             >
-              <MenuIcon iconName="kustomize" active={leftActive} isSelected={leftMenuSelection === 'kustomize-pane'} />
+              <MenuIcon
+                iconName="kustomize"
+                active={Boolean(activeProject) && leftActive}
+                isSelected={Boolean(activeProject) && leftMenuSelection === 'kustomize-pane'}
+              />
             </MenuButton>
           </Tooltip>
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title="Helm Charts" placement="right">
             <MenuButton
               isSelected={Boolean(activeProject) && leftMenuSelection === 'helm-pane'}
-              isActive={leftActive}
+              isActive={Boolean(activeProject) && leftActive}
               onClick={() => setLeftActiveMenu('helm-pane')}
               sectionNames={[HELM_CHART_SECTION_NAME]}
               disabled={!activeProject}
             >
-              <MenuIcon iconName="helm" active={leftActive} isSelected={leftMenuSelection === 'helm-pane'} />
+              <MenuIcon
+                iconName="helm"
+                active={Boolean(activeProject) && leftActive}
+                isSelected={Boolean(activeProject) && leftMenuSelection === 'helm-pane'}
+              />
             </MenuButton>
           </Tooltip>
 
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={PluginManagerTooltip} placement="right">
             <MenuButton
               isSelected={Boolean(activeProject) && leftMenuSelection === 'templates-pane'}
-              isActive={leftActive}
+              isActive={Boolean(activeProject) && leftActive}
               onClick={() => setLeftActiveMenu('templates-pane')}
               disabled={!activeProject}
             >
               <MenuIcon
                 icon={FormatPainterOutlined}
-                active={leftActive}
-                isSelected={leftMenuSelection === 'templates-pane'}
+                active={Boolean(activeProject) && leftActive}
+                isSelected={Boolean(activeProject) && leftMenuSelection === 'templates-pane'}
               />
             </MenuButton>
           </Tooltip>
@@ -249,12 +257,16 @@ const PaneManager = () => {
         </StyledColumnPanes>
       ) : (
         <StyledColumnPanes style={{width: contentWidth}}>
-          <div style={{display: 'flex', flexDirection: 'row', alignItems: 'flex-start', height: '100%'}}>
-            {leftMenuSelection === 'plugin-manager' && leftActive && <PluginManagerPane />}
-            <div style={{flex: 3, height: '100%'}}>
+          <div style={{display: 'flex', flexDirection: 'row', height: '100%'}}>
+            {leftMenuSelection === 'plugin-manager' && leftActive && (
+              <div style={{borderRight: `1px solid ${Colors.grey3}`}}>
+                <PluginManagerPane />
+              </div>
+            )}
+            <div style={{flex: 3}}>
               <StartProjectPane />
             </div>
-            <div style={{flex: 1, height: '100%', borderLeft: `1px solid ${Colors.grey3}`}}>
+            <div style={{flex: 1, borderLeft: `1px solid ${Colors.grey3}`}}>
               <RecentProjectsPane />
             </div>
           </div>

--- a/src/components/organisms/StartProjectPane/StartProjectPane.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPane.tsx
@@ -59,6 +59,7 @@ const StyledActionContainer = styled.div`
 const StyledActionText = styled.div`
   color: ${Colors.blue6};
   font-size: 12px;
+  text-align: center;
 `;
 
 const StyledActionTitle = styled.div`


### PR DESCRIPTION
This PR...

## Changes

- disable tool buttons on Get Start screen

## Fixes

- add disabled prop to the menu button

## How to test it

- open Get Start screen
- show disabled `File Explorer - kustomize - helm` buttons

## Screenshots

-
<img width="1193" alt="Screen Shot 2022-01-19 at 12 35 48 PM" src="https://user-images.githubusercontent.com/20525304/150113685-40bdb305-c761-4db4-bad5-fc7bd0d39263.png">
<img width="1181" alt="Screen Shot 2022-01-19 at 2 11 52 PM" src="https://user-images.githubusercontent.com/20525304/150127114-50084480-897c-4dcc-9bbf-8bd2e365ca1e.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
