### PR TITLE
fix: delete icon overflow text template information

### DIFF
--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
@@ -6,7 +6,7 @@ import Colors from '@styles/Colors';
 
 export const Container = styled.div`
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-template-columns: max-content 1fr 40px;
   position: relative;
   margin-bottom: 16px;
 `;

--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
@@ -66,7 +66,13 @@ const TemplateInformation: React.FC<IProps> = props => {
         <S.Footer>
           <S.Author>{template.author}</S.Author> <S.Version>{template.version}</S.Version>
         </S.Footer>
-        <Button onClick={onClickOpenTemplate} type="primary" ghost size="small" style={{marginTop: '8px'}}>
+        <Button
+          onClick={onClickOpenTemplate}
+          type="primary"
+          ghost
+          size="small"
+          style={{marginTop: '8px', alignSelf: 'flex-start', width: '50%'}}
+        >
           Open
         </Button>
       </S.InfoContainer>


### PR DESCRIPTION
This PR styling Template information item

## Changes

- styled the template information item

## Fixes

- delete icon overflows the text 

## How to test it

-

## Screenshots

-
## Before
<img width="350" alt="Screen Shot 2022-01-19 at 4 16 55 PM" src="https://user-images.githubusercontent.com/20525304/150148700-ed24562c-e406-40fc-b6b7-8ee13a88fb2b.png">

## After
<img width="343" alt="Screen Shot 2022-01-19 at 4 16 41 PM" src="https://user-images.githubusercontent.com/20525304/150148742-dd9da339-a986-4d48-88ff-84da083752fb.png">


## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
