### PR TITLE
feat: error boundary for template form renderer

### DIFF
--- a/src/components/molecules/TemplateFormRenderer/TemplateFormErrorBoundary.tsx
+++ b/src/components/molecules/TemplateFormRenderer/TemplateFormErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import log from 'loglevel';
+
+class TemplateFormErrorBoundary extends React.Component<any, {hasError: boolean}> {
+  constructor(props: any) {
+    super(props);
+    this.state = {hasError: false};
+  }
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    log.warn(error, errorInfo);
+  }
+  render() {
+    const {hasError} = this.state;
+    const {children} = this.props;
+    if (hasError) {
+      return <p>Something went wrong.</p>;
+    }
+    return children;
+  }
+}
+
+export default TemplateFormErrorBoundary;

--- a/src/components/molecules/TemplateFormRenderer/TemplateFormRenderer.tsx
+++ b/src/components/molecules/TemplateFormRenderer/TemplateFormRenderer.tsx
@@ -11,6 +11,8 @@ import {Primitive} from 'type-fest';
 
 import {TemplateForm} from '@models/template';
 
+import TemplateFormErrorBoundary from './TemplateFormErrorBoundary';
+
 const Form = withTheme(AntDTheme);
 
 const readTemplateFormSchemas = (templateForm: TemplateForm) => {
@@ -54,7 +56,7 @@ const TemplateFormRenderer: React.FC<{
   }
 
   return (
-    <>
+    <TemplateFormErrorBoundary>
       <h1>{templateForm.name}</h1>
       <p>{templateForm.description}</p>
       <Divider />
@@ -70,7 +72,7 @@ const TemplateFormRenderer: React.FC<{
           {isLastForm ? 'Submit' : 'Next'}
         </Button>
       </Form>
-    </>
+    </TemplateFormErrorBoundary>
   );
 };
 


### PR DESCRIPTION
This PR...

## Changes

- added Error Boundary component to catch errors thrown by `rjsf` , which happened when either the form or form ui schemas were invalid and the app would crash

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
