### PR TITLE
fix: truncate step name + max height for modal content

### DIFF
--- a/src/components/organisms/TemplateModal/TemplateModal.tsx
+++ b/src/components/organisms/TemplateModal/TemplateModal.tsx
@@ -17,8 +17,6 @@ import {TemplateFormRenderer} from '@components/molecules';
 
 import * as S from './styled';
 
-const {Step} = Steps;
-
 type TemplateModalProps = {template: AnyTemplate; onClose: () => void};
 
 type FormDataList = Record<string, Primitive>[];
@@ -136,16 +134,16 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
         )}
       >
         <S.Container ref={containerRef}>
-          <div style={{minWidth: 200}}>
+          <div>
             <Steps direction="vertical" current={activeFormIndex}>
               {template.forms.map(form => {
-                return <Step key={form.name} title={form.name} />;
+                return <S.Step key={form.name} title={form.name} />;
               })}
-              <Step title="Result" />
+              <S.Step title="Result" />
             </Steps>
           </div>
 
-          <div style={{width: '100%'}}>
+          <div style={{paddingRight: '10px'}}>
             {isLoading ? (
               <Skeleton />
             ) : resultMessage ? (

--- a/src/components/organisms/TemplateModal/styled.tsx
+++ b/src/components/organisms/TemplateModal/styled.tsx
@@ -1,9 +1,18 @@
-import {Modal as AntModal, Input} from 'antd';
+import {Modal as AntModal, Input, Steps} from 'antd';
 
 import styled from 'styled-components';
 
+import {GlobalScrollbarStyle} from '@utils/scrollbar';
+
 export const Container = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-column-gap: 10px;
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin: 24px 0px;
+  ${GlobalScrollbarStyle};
 `;
 
 export const Modal = styled(AntModal)`
@@ -32,5 +41,14 @@ export const StyledTextArea = styled(Input.TextArea)`
   ::-webkit-scrollbar {
     width: 0;
     background: transparent;
+  }
+`;
+
+export const Step = styled(Steps.Step)`
+  & .ant-steps-item-title {
+    width: 155px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 `;


### PR DESCRIPTION
## Fixes

- Max height for the template modal with scrollbar
- Truncate step name if too long

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/150170912-33045910-cc08-4843-be40-33599aa4a0a3.png)

![image](https://user-images.githubusercontent.com/47887589/150171023-a68716c4-97db-4621-8fc7-a7a6e15c57bf.png)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
