### PR TITLE
fix: add badge to tool icons

### DIFF
--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
-import {Button, Space, Tooltip} from 'antd';
+import {Badge, Button, Space, Tooltip} from 'antd';
 import 'antd/dist/antd.less';
 
 import {
@@ -22,7 +22,12 @@ import {LeftMenuSelection} from '@models/ui';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setLeftMenuSelection, setRightMenuSelection, toggleLeftMenu, toggleRightMenu} from '@redux/reducers/ui';
-import {activeProjectSelector, isInPreviewModeSelector} from '@redux/selectors';
+import {
+  activeProjectSelector,
+  helmChartsSelector,
+  isInPreviewModeSelector,
+  kustomizationsSelector,
+} from '@redux/selectors';
 
 import {
   ActionsPane,
@@ -99,6 +104,8 @@ const PaneManager = () => {
   const rightMenuSelection = useAppSelector(state => state.ui.rightMenu.selection);
   const rightActive = useAppSelector(state => state.ui.rightMenu.isActive);
   const activeProject = useSelector(activeProjectSelector);
+  const kustomizeResources = useAppSelector(kustomizationsSelector);
+  const helmChartResources = useAppSelector(helmChartsSelector);
 
   // TODO: refactor this to get the size of the page header dinamically
   const contentHeight = useMemo(() => {
@@ -159,7 +166,13 @@ const PaneManager = () => {
               onClick={() => setLeftActiveMenu('kustomize-pane')}
               sectionNames={[KUSTOMIZATION_SECTION_NAME, KUSTOMIZE_PATCH_SECTION_NAME]}
             >
-              <MenuIcon iconName="kustomize" active={leftActive} isSelected={leftMenuSelection === 'kustomize-pane'} />
+              <Badge count={kustomizeResources.length || 0} color={Colors.blue6} size="default" dot>
+                <MenuIcon
+                  iconName="kustomize"
+                  active={leftActive}
+                  isSelected={leftMenuSelection === 'kustomize-pane'}
+                />
+              </Badge>
             </MenuButton>
           </Tooltip>
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title="Helm Charts" placement="right">
@@ -169,7 +182,9 @@ const PaneManager = () => {
               onClick={() => setLeftActiveMenu('helm-pane')}
               sectionNames={[HELM_CHART_SECTION_NAME]}
             >
-              <MenuIcon iconName="helm" active={leftActive} isSelected={leftMenuSelection === 'helm-pane'} />
+              <Badge count={helmChartResources.length || 0} color={Colors.blue6} size="default" dot>
+                <MenuIcon iconName="helm" active={leftActive} isSelected={leftMenuSelection === 'helm-pane'} />
+              </Badge>
             </MenuButton>
           </Tooltip>
 


### PR DESCRIPTION
This PR Show existence of Kustomizations/Helm Charts on toolbar buttons

## Changes

- Added a badge for helm/kustomize tool icons if there are exists resources 

## Fixes

-

## How to test it

- open a project with kustomize/ helm resources 
- show the badge on the tool icon

## Screenshots

- 
<img width="328" alt="Screen Shot 2022-01-20 at 1 12 26 PM" src="https://user-images.githubusercontent.com/20525304/150328136-f6f60c13-2b86-488e-ad55-d2b8fd143244.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
