### PR TITLE
feat: separate scrollbar for steps and form on modal

### DIFF
--- a/src/components/organisms/TemplateModal/TemplateModal.tsx
+++ b/src/components/organisms/TemplateModal/TemplateModal.tsx
@@ -206,10 +206,6 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
                       <S.TableHead>Description</S.TableHead>
                       <S.TableData>{template.description}</S.TableData>
                     </tr>
-                    <tr>
-                      <S.TableHead>Description</S.TableHead>
-                      <S.TableData>{template.description}</S.TableData>
-                    </tr>
                   </tbody>
                 </S.Table>
               </>

--- a/src/components/organisms/TemplateModal/TemplateModal.tsx
+++ b/src/components/organisms/TemplateModal/TemplateModal.tsx
@@ -159,7 +159,7 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
         )}
       >
         <S.Container ref={containerRef}>
-          <div>
+          <S.StepsContainer>
             <Steps direction="vertical" current={activeFormIndex}>
               <S.Step title="Information" />
               {template.forms.map(form => {
@@ -167,9 +167,9 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
               })}
               <S.Step title="Result" />
             </Steps>
-          </div>
+          </S.StepsContainer>
 
-          <div style={{paddingRight: '10px'}}>
+          <S.FormContainer>
             {isLoading ? (
               <Skeleton />
             ) : activeFormIndex === 0 ? (
@@ -202,6 +202,10 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
                         </S.TableData>
                       </tr>
                     )}
+                    <tr>
+                      <S.TableHead>Description</S.TableHead>
+                      <S.TableData>{template.description}</S.TableData>
+                    </tr>
                     <tr>
                       <S.TableHead>Description</S.TableHead>
                       <S.TableData>{template.description}</S.TableData>
@@ -241,7 +245,7 @@ const TemplateModal: React.FC<TemplateModalProps> = props => {
                 templateForm={activeForm}
               />
             ) : null}
-          </div>
+          </S.FormContainer>
         </S.Container>
       </ResizableBox>
     </S.Modal>

--- a/src/components/organisms/TemplateModal/styled.tsx
+++ b/src/components/organisms/TemplateModal/styled.tsx
@@ -12,10 +12,14 @@ export const Container = styled.div`
   display: grid;
   grid-template-columns: 200px 1fr;
   grid-column-gap: 10px;
+  margin: 24px 0px;
+`;
+
+export const FormContainer = styled.div`
+  padding-right: 10px;
   max-height: 500px;
   overflow-y: auto;
   overflow-x: hidden;
-  margin: 24px 0px;
   ${GlobalScrollbarStyle};
 `;
 
@@ -44,21 +48,29 @@ export const Modal = styled(AntModal)`
   }
 `;
 
-export const StyledTextArea = styled(Input.TextArea)`
-  margin-top: 20px;
-  width: 100%;
-  ::-webkit-scrollbar {
-    width: 0;
-    background: transparent;
-  }
-`;
-
 export const Step = styled(Steps.Step)`
   & .ant-steps-item-title {
     width: 155px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+  }
+`;
+
+export const StepsContainer = styled.div`
+  padding-right: 5px;
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  ${GlobalScrollbarStyle};
+`;
+
+export const StyledTextArea = styled(Input.TextArea)`
+  margin-top: 20px;
+  width: 100%;
+  ::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
   }
 `;
 


### PR DESCRIPTION
## Changes

- Have separate overflows for steps and forms on the modal ( if you scroll the form, steps will remain in place and vice-versa). 

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/150350879-8a5a8c72-b063-42c4-9c3c-3c55076b76bb.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
