### PR TITLE
fix: show files to be replaced for <root>

### DIFF
--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -218,7 +218,9 @@ const SaveResourceToFileFolderModal: React.FC = () => {
 
         if (
           (subfolders.length && subfolders.find(dirent => dirent.name === fullFileName)) ||
-          fileMap[`\\${path.join(selectedFolder, fullFileName)}`]
+          (selectedFolder === ROOT_FILE_ENTRY
+            ? fileMap[`\\${fullFileName}`]
+            : fileMap[`\\${path.join(selectedFolder, fullFileName)}`])
         ) {
           filesToBeReplaced.push(fullFileName);
         } else {

--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -219,8 +219,8 @@ const SaveResourceToFileFolderModal: React.FC = () => {
         if (
           (subfolders.length && subfolders.find(dirent => dirent.name === fullFileName)) ||
           (selectedFolder === ROOT_FILE_ENTRY
-            ? fileMap[`\\${fullFileName}`]
-            : fileMap[`\\${path.join(selectedFolder, fullFileName)}`])
+            ? fileMap[`${path.sep}${fullFileName}`]
+            : fileMap[`${path.sep}${path.join(selectedFolder, fullFileName)}`])
         ) {
           filesToBeReplaced.push(fullFileName);
         } else {


### PR DESCRIPTION
## Fixes

- Show the files that will be replaced when selecting `<root>` folder

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/150379565-67b9c88e-5833-44bb-928d-53a9bccc979b.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
