### PR TITLE
fix: persist left pane last size

### DIFF
--- a/src/components/atoms/SplitView/SplitView.tsx
+++ b/src/components/atoms/SplitView/SplitView.tsx
@@ -172,10 +172,6 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const calculateLeftWidthOnDrawersChange = () => {
-    if (hideLeft) {
-      return 0;
-    }
-
     if (leftWidth > MIN_LEFT_PANE_WIDTH / viewWidth) {
       return leftWidth;
     }
@@ -303,9 +299,9 @@ const SplitView: FunctionComponent<SplitViewProps> = ({
   };
 
   const calculateLeftNavCombination = (clientX: number, movingDirection: string) => {
-    const combinedPixelWidth = Math.floor((hideLeft ? 0 : leftWidth) * viewWidth + navWidth * viewWidth);
+    const combinedPixelWidth = Math.floor(leftWidth * viewWidth + navWidth * viewWidth);
     const newLeftWidth = Math.floor(leftWidth * viewWidth + clientX - separatorLeftNavXPosition);
-    const newNavWidth = Math.floor(combinedPixelWidth - (hideLeft ? 0 : newLeftWidth));
+    const newNavWidth = Math.floor(combinedPixelWidth - newLeftWidth);
 
     setSeparatorLeftNavXPosition(clientX);
 


### PR DESCRIPTION
This PR reopening closed left panel should remember last size

## Changes

- removed setLeftWidth to zero

## Fixes

-

## How to test it

- resize left pane
- close left pane (try it )
- close the app and reopen (try it)

## Screenshots

- 

https://user-images.githubusercontent.com/20525304/150517459-25c624ad-6b31-46e4-9f59-957f3f87ceca.mp4



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
