### PR TITLE
fix: use context name instead of cluster in UI

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -145,8 +145,8 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
   const clusterMenu = (
     <Menu>
       {kubeConfigContexts.map((context: any) => (
-        <Menu.Item key={context.cluster} onClick={handleClusterChange}>
-          {context.cluster}
+        <Menu.Item key={context.name} onClick={handleClusterChange}>
+          {context.name}
         </Menu.Item>
       ))}
     </Menu>

--- a/src/redux/thunks/loadKubeConfig.ts
+++ b/src/redux/thunks/loadKubeConfig.ts
@@ -24,11 +24,11 @@ export const loadContexts = async (
         const kc = new k8s.KubeConfig();
         kc.loadFromFile(configPath);
 
-        const selectedContext = kc.contexts.find(c => c.cluster === currentContext);
+        const selectedContext = kc.contexts.find(c => c.name === currentContext);
         if (selectedContext) {
-          kc.setCurrentContext(selectedContext && selectedContext.cluster);
+          kc.setCurrentContext(selectedContext && selectedContext.name);
         } else {
-          kc.setCurrentContext((kc.contexts && kc.contexts.length > 0 && kc.contexts[0].cluster) || '');
+          kc.setCurrentContext((kc.contexts && kc.contexts.length > 0 && kc.contexts[0].name) || '');
         }
 
         const kubeConfig: KubeConfig = {


### PR DESCRIPTION
This PR changes the cluster selector to show the context name instead of context cluster - because multiple contexts can use the same cluster but will have different names

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
