### PR TITLE
fix: set default value for undefined lastOpen date

### DIFF
--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -170,7 +170,10 @@ export const configSlice = createSlice({
       }
 
       project.created = new Date().toISOString();
-      state.projects = _.sortBy([project, ...state.projects], (p: Project) => p.lastOpened).reverse();
+      state.projects = _.sortBy(
+        [project, ...state.projects],
+        (p: Project) => p.lastOpened || new Date(-8640000000000000).toISOString()
+      ).reverse();
       electronStore.set('appConfig.projects', state.projects);
     },
     deleteProject: (state: Draft<AppConfig>, action: PayloadAction<Project>) => {


### PR DESCRIPTION
This PR...

## Changes

- added default value for `project,lastOpened` in the new created project   

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
