### PR TITLE
plugin manager pane styling improvements

### DIFF
--- a/src/components/organisms/PluginManagerPane/PluginInformation.styled.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginInformation.styled.tsx
@@ -6,40 +6,43 @@ import Colors from '@styles/Colors';
 
 export const Container = styled.div`
   display: grid;
-  grid-template-columns: 40px 1fr;
+  grid-template-columns: max-content 1fr;
+  grid-column-gap: 18px;
   position: relative;
   margin-bottom: 16px;
 `;
 
 export const IconContainer = styled.span`
-  height: 50px;
-  width: 50px;
+  height: 32px;
+  width: 32px;
 `;
 
 export const InfoContainer = styled.span`
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 `;
 
 export const Name = styled.span`
-  font-weight: 600;
+  width: 100%;
+  color: ${Colors.whitePure};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 6px;
 `;
 
 export const Description = styled.span`
-  font-weight: 300;
+  color: ${Colors.grey7};
 `;
 
-export const Footer = styled.span`
+export const AdditionalInformation = styled.div`
+  color: ${Colors.grey6};
+  line-height: 20px;
+  font-size: 12px;
+  margin: 6px 0px;
   display: flex;
-  justify-content: space-between;
-`;
-
-export const Author = styled.span`
-  color: ${Colors.grey500};
-`;
-
-export const Version = styled.span`
-  font-style: italic;
+  flex-direction: column;
 `;
 
 export const DeleteOutlined = styled(RawDeleteOutlined)`

--- a/src/components/organisms/PluginManagerPane/PluginInformation.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginInformation.tsx
@@ -4,7 +4,8 @@ import {Popconfirm} from 'antd';
 
 import {ExclamationOutlined} from '@ant-design/icons';
 
-import {AnyPlugin} from '@models/plugin';
+import {AnyPlugin, isTemplatePluginModule} from '@models/plugin';
+import {AnyTemplate} from '@models/template';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {deletePlugin} from '@redux/services/templates';
@@ -21,6 +22,14 @@ const PluginInformation: React.FC<IProps> = props => {
 
   const dispatch = useAppDispatch();
   const pluginsDir = useAppSelector(state => state.extension.pluginsDir);
+  const pluginTemplates = useAppSelector(state =>
+    plugin.modules
+      .filter(isTemplatePluginModule)
+      .map(module => module.path)
+      .map(templatePath => state.extension.templateMap[templatePath])
+      .filter((t): t is AnyTemplate => t !== undefined)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  );
 
   const handleDelete = () => {
     if (pluginsDir) {
@@ -37,9 +46,10 @@ const PluginInformation: React.FC<IProps> = props => {
       <S.InfoContainer>
         <S.Name>{plugin.name}</S.Name>
         <S.Description>{plugin.description || 'No description'}</S.Description>
-        <S.Footer>
-          <S.Author>{plugin.author}</S.Author> <S.Version>{plugin.version}</S.Version>
-        </S.Footer>
+        <S.AdditionalInformation>
+          <span>Author: {plugin.author}</span>
+          <span>Version: {plugin.version}</span>
+        </S.AdditionalInformation>
       </S.InfoContainer>
 
       <Popconfirm
@@ -52,7 +62,12 @@ const PluginInformation: React.FC<IProps> = props => {
             <p>Are you sure you want to delete {plugin.name}?</p>
             <p>
               <ExclamationOutlined style={{color: 'red'}} />
-              This will also delete all the templates corresponding to the plugin.
+              This action will delete the following templates:
+              <ul>
+                {pluginTemplates.map(t => (
+                  <li key={t.id}>{t.name}</li>
+                ))}
+              </ul>
             </p>
           </>
         )}

--- a/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
@@ -45,7 +45,7 @@ function PluginManagerPane() {
   return (
     <div>
       <PluginInstallModal isVisible={isInstallModalVisible} onClose={onCloseInstallPlugin} />
-      <TitleBar title="Plugin Manager">
+      <TitleBar title="Plugins">
         <Tooltip title={PluginManagerPaneReloadTooltip} placement="bottom">
           <Button
             disabled={sortedPluginEntries.length === 0}

--- a/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
@@ -22,7 +22,10 @@ function PluginManagerPane() {
   const pluginMap = useAppSelector(state => state.extension.pluginMap);
   const templateMap = useAppSelector(state => state.extension.templateMap);
   const templatePackMap = useAppSelector(state => state.extension.templatePackMap);
-  const plugins = useMemo(() => Object.values(pluginMap), [pluginMap]);
+
+  const sortedPluginEntries = useMemo(() => {
+    return Object.entries(pluginMap).sort((a, b) => a[1].name.localeCompare(b[1].name));
+  }, [pluginMap]);
 
   const [isInstallModalVisible, setInstallModalVisible] = useState<boolean>(false);
 
@@ -45,7 +48,7 @@ function PluginManagerPane() {
       <TitleBar title="Plugin Manager">
         <Tooltip title={PluginManagerPaneReloadTooltip} placement="bottom">
           <Button
-            disabled={plugins.length === 0}
+            disabled={sortedPluginEntries.length === 0}
             onClick={onClickReload}
             type="link"
             size="small"
@@ -55,15 +58,15 @@ function PluginManagerPane() {
         <Button onClick={onClickInstallPlugin} type="link" size="small" icon={<PlusOutlined />} />
       </TitleBar>
       <S.Container>
-        {plugins.length === 0 ? (
+        {sortedPluginEntries.length === 0 ? (
           <>{isLoadingExistingPlugins ? <Skeleton /> : <p>No plugins installed yet.</p>}</>
         ) : (
           <>
-            {plugins.length > 0 &&
-              Object.entries(pluginMap).map(([path, activePlugin]) => (
+            {sortedPluginEntries.length > 0 &&
+              sortedPluginEntries.map(([path, activePlugin]) => (
                 <PluginInformation key={activePlugin.name} plugin={activePlugin} pluginPath={path} />
               ))}
-            {!plugins.length && <S.NotFoundLabel>No plugins found.</S.NotFoundLabel>}
+            {!sortedPluginEntries.length && <S.NotFoundLabel>No plugins found.</S.NotFoundLabel>}
           </>
         )}
       </S.Container>

--- a/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginManagerPane.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useMemo, useState} from 'react';
 
-import {Button, Input, Skeleton, Tooltip} from 'antd';
+import {Button, Skeleton, Tooltip} from 'antd';
 
 import {PlusOutlined, ReloadOutlined} from '@ant-design/icons';
 
@@ -15,44 +15,14 @@ import PluginInformation from './PluginInformation';
 import PluginInstallModal from './PluginInstallModal';
 import * as S from './PluginManagerPane.styled';
 
-const filterPluginBySearchedValue = (searchedValue: string, name: string) => {
-  let shouldBeFiltered = true;
-  const splittedSearchedValue = searchedValue.split(' ');
-
-  for (let i = 0; i < splittedSearchedValue.length; i += 1) {
-    if (!name.split(' ').find(namePart => namePart.toLowerCase().includes(splittedSearchedValue[i].toLowerCase()))) {
-      shouldBeFiltered = false;
-      break;
-    }
-  }
-
-  return shouldBeFiltered;
-};
-
 function PluginManagerPane() {
   const dispatch = useAppDispatch();
   const isLoadingExistingPlugins = useAppSelector(state => state.extension.isLoadingExistingPlugins);
+
   const pluginMap = useAppSelector(state => state.extension.pluginMap);
   const templateMap = useAppSelector(state => state.extension.templateMap);
   const templatePackMap = useAppSelector(state => state.extension.templatePackMap);
-
-  const [searchedValue, setSearchedValue] = useState<string>();
-
   const plugins = useMemo(() => Object.values(pluginMap), [pluginMap]);
-  const activePlugins = useMemo(
-    () =>
-      Object.entries(pluginMap).filter(
-        p => p[1].isActive && (searchedValue ? filterPluginBySearchedValue(searchedValue, p[1].name) : true)
-      ),
-    [pluginMap, searchedValue]
-  );
-  const inactivePlugins = useMemo(
-    () =>
-      Object.entries(pluginMap).filter(
-        p => !p[1].isActive && (searchedValue ? filterPluginBySearchedValue(searchedValue, p[1].name) : true)
-      ),
-    [pluginMap, searchedValue]
-  );
 
   const [isInstallModalVisible, setInstallModalVisible] = useState<boolean>(false);
 
@@ -85,33 +55,15 @@ function PluginManagerPane() {
         <Button onClick={onClickInstallPlugin} type="link" size="small" icon={<PlusOutlined />} />
       </TitleBar>
       <S.Container>
-        <Input.Search
-          placeholder="Search plugin by name"
-          style={{marginBottom: '20px'}}
-          value={searchedValue}
-          onChange={e => setSearchedValue(e.target.value)}
-        />
         {plugins.length === 0 ? (
           <>{isLoadingExistingPlugins ? <Skeleton /> : <p>No plugins installed yet.</p>}</>
         ) : (
           <>
-            {activePlugins.length > 0 && (
-              <>
-                <h2>Active plugins</h2>
-                {activePlugins.map(([path, activePlugin]) => (
-                  <PluginInformation key={activePlugin.name} plugin={activePlugin} pluginPath={path} />
-                ))}
-              </>
-            )}
-            {inactivePlugins.length > 0 && (
-              <>
-                <h2>Inactive plugins</h2>
-                {inactivePlugins.map(([path, inactivePlugin]) => (
-                  <PluginInformation key={inactivePlugin.name} plugin={inactivePlugin} pluginPath={path} />
-                ))}
-              </>
-            )}
-            {!activePlugins.length && !inactivePlugins.length && <S.NotFoundLabel>No plugins found.</S.NotFoundLabel>}
+            {plugins.length > 0 &&
+              Object.entries(pluginMap).map(([path, activePlugin]) => (
+                <PluginInformation key={activePlugin.name} plugin={activePlugin} pluginPath={path} />
+              ))}
+            {!plugins.length && <S.NotFoundLabel>No plugins found.</S.NotFoundLabel>}
           </>
         )}
       </S.Container>

--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
@@ -37,9 +37,9 @@ export const InfoContainer = styled.div`
   overflow: hidden;
 `;
 
-export const Name = styled.span<{$width: number}>`
-  ${props => `width: ${props.$width}`}
-  color:${Colors.whitePure};
+export const Name = styled.span`
+  width: 100%;
+  color: ${Colors.whitePure};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useMeasure} from 'react-use';
 
 import {Tooltip} from 'antd';
 
@@ -24,14 +23,12 @@ interface IProps {
 const TemplateInformation: React.FC<IProps> = props => {
   const {template, onClickOpenTemplate, disabled} = props;
 
-  const [infoContainerRef, {width: infoContainerWidth}] = useMeasure<HTMLDivElement>();
-
   return (
     <S.Container>
       <S.Image src={template.icon ? template.icon : TemplateIcon} alt="Template_Icon" />
 
-      <S.InfoContainer ref={infoContainerRef}>
-        <S.Name $width={infoContainerWidth}>{template.name}</S.Name>
+      <S.InfoContainer>
+        <S.Name>{template.name}</S.Name>
 
         <S.Description>{_.truncate(template.description, {length: 140})}</S.Description>
 

--- a/src/components/organisms/TemplateManagerPane/TemplateManagerPane.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateManagerPane.tsx
@@ -47,7 +47,7 @@ const TemplatesPane: React.FC = () => {
   const templatePackMap = useAppSelector(state => state.extension.templatePackMap);
 
   const [searchedValue, setSearchedValue] = useState<string>();
-  const [templatesToShow, setTemplatesToShow] = useState<Record<string, AnyTemplate>>();
+  const [visibleTemplateEntries, setVisibleTemplateEntries] = useState<[string, AnyTemplate][]>();
 
   const windowSize = useWindowSize();
 
@@ -79,15 +79,15 @@ const TemplatesPane: React.FC = () => {
 
   useEffect(() => {
     if (!searchedValue) {
-      setTemplatesToShow(templateMap);
+      setVisibleTemplateEntries(Object.entries(templateMap).sort((a, b) => a[1].name.localeCompare(b[1].name)));
     } else {
-      setTemplatesToShow(
-        Object.fromEntries(
-          Object.entries(templateMap).filter(templateEntry => {
+      setVisibleTemplateEntries(
+        Object.entries(templateMap)
+          .filter(templateEntry => {
             const templateName = templateEntry[1].name;
             return filterTemplateBySearchedValue(searchedValue, templateName);
           })
-        )
+          .sort((a, b) => a[1].name.localeCompare(b[1].name))
       );
     }
   }, [searchedValue, templateMap]);
@@ -110,7 +110,7 @@ const TemplatesPane: React.FC = () => {
       <S.Container>
         {isLoading ? (
           <S.Skeleton />
-        ) : !templatesToShow ? (
+        ) : !visibleTemplateEntries ? (
           <p>No templates available.</p>
         ) : (
           <>
@@ -122,13 +122,13 @@ const TemplatesPane: React.FC = () => {
               />
             </S.SearchInputContainer>
 
-            {!Object.keys(templatesToShow).length ? (
+            {!visibleTemplateEntries.length ? (
               <S.NotFoundLabel>No templates found.</S.NotFoundLabel>
             ) : (
               <S.TemplatesContainer $height={templatesHeight}>
-                {Object.values(templatesToShow).map(template => (
+                {visibleTemplateEntries.map(([path, template]) => (
                   <TemplateInformation
-                    key={template.id}
+                    key={path}
                     template={template}
                     disabled={isInPreviewMode}
                     onClickOpenTemplate={() => onClickOpenTemplate(template)}


### PR DESCRIPTION
This PR...

## Changes

- removed search bar
- improved styling to match the design from templates manager
- improved popconfirm message to list all templates that will be removed
- sorted templates and plugins in their panes

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/150795972-8c060f67-e5d8-49f7-817b-a4d268f5f089.png)

![image](https://user-images.githubusercontent.com/20538711/150796007-eaf7c3cb-c04a-450e-841e-10d1debb90cf.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
