### PR TITLE
feat: load default plugins

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -345,10 +345,10 @@ export const createWindow = (givenPath?: string) => {
     win.webContents.send('executed-from', {path: givenPath});
 
     const pluginMap = await loadPluginMap(pluginsDir);
-    const pluginRepoNames = Object.values(pluginMap).map((plugin) => plugin.repository.name);
+    const uniquePluginNames = Object.values(pluginMap).map((plugin) => `${plugin.repository.owner}-${plugin.repository.name}`);
 
     const defaultPluginsToLoad = DEFAULT_PLUGINS.filter((defaultPlugin) => {
-      return !pluginRepoNames.includes(defaultPlugin.name);
+      return !uniquePluginNames.includes(`${defaultPlugin.owner}- ${defaultPlugin.name}`);
     });
 
     const downloadedPlugins = await Promise.all(defaultPluginsToLoad

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -348,7 +348,7 @@ export const createWindow = (givenPath?: string) => {
     const uniquePluginNames = Object.values(pluginMap).map((plugin) => `${plugin.repository.owner}-${plugin.repository.name}`);
 
     const defaultPluginsToLoad = DEFAULT_PLUGINS.filter((defaultPlugin) => {
-      return !uniquePluginNames.includes(`${defaultPlugin.owner}- ${defaultPlugin.name}`);
+      return !uniquePluginNames.includes(`${defaultPlugin.owner}-${defaultPlugin.name}`);
     });
 
     const downloadedPlugins = await Promise.all(defaultPluginsToLoad

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -17,3 +17,9 @@ export const DEFAULT_KUBECONFIG_DEBOUNCE = 1000;
 export const ACTIONS_PANE_FOOTER_HEIGHT = 200;
 export const ACTIONS_PANE_TAB_PANE_OFFSET = 106;
 export const TEMPLATES_HEIGHT_OFFSET = 190;
+export const DEFAULT_PLUGINS = [
+  {
+    name: 'monokle-default-templates-plugin',
+    url: 'https://github.com/kubeshop/monokle-default-templates-plugin',
+  }
+];

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -19,6 +19,7 @@ export const ACTIONS_PANE_TAB_PANE_OFFSET = 106;
 export const TEMPLATES_HEIGHT_OFFSET = 190;
 export const DEFAULT_PLUGINS = [
   {
+    owner: 'kubeshop',
     name: 'monokle-default-templates-plugin',
     url: 'https://github.com/kubeshop/monokle-default-templates-plugin',
   }


### PR DESCRIPTION
This PR...

## Changes

- loads default plugins

## Fixes

- fix: #1049 

## How to test it

- Start monokle with and without plugins and the https://github.com/kubeshop/monokle-default-templates-plugin will be loaded

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
