### PR TITLE
fix: plugin pane delete icon overlap

### DIFF
--- a/src/components/organisms/PluginManagerPane/PluginInformation.styled.tsx
+++ b/src/components/organisms/PluginManagerPane/PluginInformation.styled.tsx
@@ -6,7 +6,7 @@ import Colors from '@styles/Colors';
 
 export const Container = styled.div`
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-template-columns: max-content 1fr 20px;
   grid-column-gap: 18px;
   position: relative;
   margin-bottom: 16px;


### PR DESCRIPTION
## Fixes

- No overlap for the delete icon in `Plugin Pane`

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/150961282-5c5b40e8-cc99-4985-97e5-8948b396f119.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
