### PR TITLE
feat: colors for panel manager, chnage position of plugin button

### DIFF
--- a/src/components/organisms/PageHeader/PageHeader.tsx
+++ b/src/components/organisms/PageHeader/PageHeader.tsx
@@ -9,7 +9,13 @@ import {HelmChart, HelmValuesFile} from '@models/helm';
 import {K8sResource} from '@models/k8sresource';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {toggleNotifications, toggleSettings, toggleStartProjectPane} from '@redux/reducers/ui';
+import {
+  setLeftMenuSelection,
+  toggleLeftMenu,
+  toggleNotifications,
+  toggleSettings,
+  toggleStartProjectPane,
+} from '@redux/reducers/ui';
 import {activeResourcesSelector, isInPreviewModeSelector, kubeConfigContextSelector} from '@redux/selectors';
 import {stopPreview} from '@redux/services/preview';
 
@@ -33,6 +39,8 @@ const ExitButton = (props: {onClick: () => void}) => {
 
 const PageHeader = () => {
   const dispatch = useAppDispatch();
+  const leftMenuSelection = useAppSelector(state => state.ui.leftMenu.selection);
+  const leftActive = useAppSelector(state => state.ui.leftMenu.isActive);
   const activeResources = useAppSelector(activeResourcesSelector);
   const currentContext = useAppSelector(kubeConfigContextSelector);
   const helmChartMap = useAppSelector(state => state.main.helmChartMap);
@@ -65,6 +73,21 @@ const PageHeader = () => {
       setHelmChart(undefined);
     }
   }, [previewResourceId, previewValuesFileId, helmValuesMap, resourceMap, helmChartMap]);
+
+  const openPlugins = () => {
+    if (leftMenuSelection === 'plugin-manager') {
+      dispatch(toggleLeftMenu());
+    } else {
+      if (isStartProjectPaneVisible) {
+        dispatch(toggleStartProjectPane());
+      }
+      dispatch(setLeftMenuSelection('plugin-manager'));
+
+      if (!leftActive) {
+        dispatch(toggleLeftMenu());
+      }
+    }
+  };
 
   const toggleSettingsDrawer = () => {
     dispatch(toggleSettings());
@@ -139,12 +162,20 @@ const PageHeader = () => {
                 </Badge>
               </S.IconContainerSpan>
             </Tooltip>
+            <Tooltip
+              mouseEnterDelay={TOOLTIP_DELAY}
+              title={leftMenuSelection === 'plugin-manager' && leftActive ? 'Hide Plugins' : 'View Plugins'}
+              placement="right"
+            >
+              <S.IconContainerSpan>
+                <S.PluginsOutlined onClick={openPlugins} />
+              </S.IconContainerSpan>
+            </Tooltip>
             <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={SettingsTooltip}>
               <S.IconContainerSpan>
                 <S.SettingsOutlined onClick={toggleSettingsDrawer} />
               </S.IconContainerSpan>
             </Tooltip>
-
             <HelpMenu />
           </S.SettingsCol>
         </S.Row>

--- a/src/components/organisms/PageHeader/styled.tsx
+++ b/src/components/organisms/PageHeader/styled.tsx
@@ -1,4 +1,5 @@
 import {
+  ApiOutlined,
   BellOutlined as RawBellOutlined,
   CloseCircleOutlined as RawCloseCircleOutlined,
   CopyOutlined as RawCopyOutlined,
@@ -23,6 +24,12 @@ export const Row = styled(RawRow.default)`
 `;
 
 export const BellOutlined = styled(RawBellOutlined)`
+  color: ${FontColors.elementSelectTitle};
+  font-size: 24px;
+  cursor: pointer;
+`;
+
+export const PluginsOutlined = styled(ApiOutlined)`
   color: ${FontColors.elementSelectTitle};
   font-size: 24px;
   cursor: pointer;
@@ -110,9 +117,9 @@ export const ResourceSpan = styled.span`
 
 export const SettingsCol = styled(Col)`
   display: grid;
-  grid-template-columns: repeat(3, max-content);
+  grid-template-columns: repeat(4, max-content);
   align-items: center;
-  grid-column-gap: 12px;
+  grid-column-gap: 25px;
 `;
 
 export const SettingsOutlined = styled(RawSettingOutlined)`

--- a/src/components/organisms/PaneManager/MenuIcon.tsx
+++ b/src/components/organisms/PaneManager/MenuIcon.tsx
@@ -28,7 +28,11 @@ const MenuIcon = (props: {
   };
 
   if (active && isSelected) {
-    style.color = Colors.grey400;
+    style.color = Colors.grey7;
+  }
+
+  if (!active) {
+    style.color = Colors.grey5;
   }
 
   if (IconComponent) {

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -5,7 +5,6 @@ import 'antd/dist/antd.less';
 
 import {
   ApartmentOutlined,
-  ApiOutlined,
   CodeOutlined,
   FolderOpenOutlined,
   FolderOutlined,
@@ -334,20 +333,6 @@ const PaneManager = () => {
                 active={Boolean(activeProject) && leftActive}
                 isSelected={Boolean(activeProject) && leftMenuSelection === 'templates-pane'}
               />
-            </MenuButton>
-          </Tooltip>
-
-          <Tooltip
-            mouseEnterDelay={TOOLTIP_DELAY}
-            title={leftMenuSelection === 'plugin-manager' && leftActive ? 'Hide Plugins' : 'View Plugins'}
-            placement="right"
-          >
-            <MenuButton
-              isSelected={leftMenuSelection === 'plugin-manager'}
-              isActive={leftActive}
-              onClick={() => setLeftActiveMenu('plugin-manager')}
-            >
-              <MenuIcon icon={ApiOutlined} active={leftActive} isSelected={leftMenuSelection === 'plugin-manager'} />
             </MenuButton>
           </Tooltip>
         </Space>


### PR DESCRIPTION
This PR...

## Changes

- Change placing of  plugin button

## How to test it

- open monokle and obser controls at top right 

## Screenshots

- 
<img width="958" alt="image" src="https://user-images.githubusercontent.com/6247094/151006893-c2a2a48d-56e6-49d8-8558-9e51d38c989e.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
