### PR TITLE
feat: If there is no recent projects - hide panel

### DIFF
--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -16,6 +16,7 @@ import styled from 'styled-components';
 
 import {ROOT_FILE_ENTRY, TOOLTIP_DELAY} from '@constants/constants';
 
+import {Project} from '@models/appconfig';
 import {LeftMenuSelectionType} from '@models/ui';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
@@ -97,6 +98,7 @@ const iconMenuWidth = 45;
 const PaneManager = () => {
   const dispatch = useAppDispatch();
   const activeProject = useAppSelector(activeProjectSelector);
+  const projects: Project[] = useAppSelector(state => state.config.projects);
   const fileMap = useAppSelector(state => state.main.fileMap);
   const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
   const isProjectLoading = useAppSelector(state => state.config.isProjectLoading);
@@ -233,9 +235,11 @@ const PaneManager = () => {
           <div style={{flex: 3}}>
             <StartProjectPane />
           </div>
-          <div style={{flex: 1, borderLeft: `1px solid ${Colors.grey3}`}}>
-            <RecentProjectsPane />
-          </div>
+          {Boolean(projects.length) && (
+            <div style={{flex: 1, borderLeft: `1px solid ${Colors.grey3}`}}>
+              <RecentProjectsPane />
+            </div>
+          )}
         </div>
       </StyledColumnPanes>
     );


### PR DESCRIPTION
This PR...

## Changes

- Hide panel of recent projects if there is no projects

## How to test it

- open monokle? remove all recent projects, panel should be hidden after delete of last recent project

## Screenshots
 
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/6247094/151008829-9d641055-4ab8-4c71-93db-0c7aedb06576.png">



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
