### PR TITLE
fix: add new resource button disabled color when in preview mode

### DIFF
--- a/src/components/organisms/NavigatorPane/NavigatorPane.styled.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.styled.tsx
@@ -40,10 +40,10 @@ export const FiltersNumber = styled.div`
   margin-left: 5px;
 `;
 
-export const PlusButton = styled(Button)<{$highlighted?: boolean}>`
-  ${({$highlighted}) => `
+export const PlusButton = styled(Button)<{$highlighted: boolean; $disabled: boolean}>`
+  ${({$disabled, $highlighted}) => `
     border-radius: ${$highlighted ? '100%' : 'inherit'} !important;
-    color: ${$highlighted ? Colors.whitePure : Colors.blue6} !important`};
+    color: ${$highlighted ? Colors.whitePure : $disabled ? 'rgba(255, 255, 255, 0.3)' : Colors.blue6} !important`};
 
   &:after {
     ${({$highlighted}) => `

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -120,13 +120,14 @@ const NavPane: React.FC = () => {
           </MonoPaneTitle>
           <S.TitleBarRightButtons>
             <S.PlusButton
-              className={highlightedItems.createResource ? 'animated-highlight' : ''}
+              $disabled={!isFolderOpen || isInPreviewMode}
               $highlighted={highlightedItems.createResource}
-              disabled={!isFolderOpen || isInClusterMode || isInPreviewMode}
-              onClick={onClickNewResource}
-              type="link"
-              size="small"
+              className={highlightedItems.createResource ? 'animated-highlight' : ''}
+              disabled={!isFolderOpen || isInPreviewMode}
               icon={<PlusOutlined />}
+              size="small"
+              type="link"
+              onClick={onClickNewResource}
             />
             <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
               <Button


### PR DESCRIPTION
## Fixes

- Disabled color for Add New Resource button when in preview mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/151018283-2facedef-111e-4952-a0b6-7327ab1fb3d6.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
