### PR TITLE
fix: hover cluster load

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -104,16 +104,18 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
 
   const createClusterObjectsLabel = useCallback(() => {
     let content: any;
+    let className = '';
     if (isInClusterMode) {
       content = 'RELOAD';
     } else if (previewType === 'cluster' && previewLoader.isLoading) {
       content = <LoadingOutlined />;
     } else {
       content = 'LOAD';
+      className = highlightedItems.connectToCluster ? 'animated-highlight' : '';
     }
 
     return (
-      <S.ClusterActionText>{content}</S.ClusterActionText>
+      <S.ClusterActionText className={className}>{content}</S.ClusterActionText>
     );
   }, [previewType, previewLoader, isInClusterMode, highlightedItems]);
 

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -103,19 +103,17 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
   }, [kubeConfigPath, isKubeConfigPathValid]);
 
   const createClusterObjectsLabel = useCallback(() => {
+    let content: any;
     if (isInClusterMode) {
-      return <S.ClusterActionText>RELOAD</S.ClusterActionText>;
+      content = 'RELOAD';
+    } else if (previewType === 'cluster' && previewLoader.isLoading) {
+      content = <LoadingOutlined />;
+    } else {
+      content = 'LOAD';
     }
-    if (previewType === 'cluster' && previewLoader.isLoading) {
-      return <LoadingOutlined />;
-    }
+
     return (
-      <S.ClusterActionText
-        className={highlightedItems.connectToCluster ? 'animated-highlight' : ''}
-        $highlighted={highlightedItems.connectToCluster}
-      >
-        LOAD
-      </S.ClusterActionText>
+      <S.ClusterActionText>{content}</S.ClusterActionText>
     );
   }, [previewType, previewLoader, isInClusterMode, highlightedItems]);
 
@@ -162,9 +160,8 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
           {isKubeConfigPathValid ? (
             <>
               <S.Divider type="vertical" />
-              <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ClusterModeTooltip} placement="right">
+              <Tooltip mouseEnterDelay={TOOLTIP_DELAY} mouseLeaveDelay={0} title={ClusterModeTooltip} placement="right">
                 <S.Button
-                  disabled={Boolean(previewType === 'cluster' && previewLoader.isLoading) || isClusterActionDisabled}
                   type="link"
                   onClick={handleLoadCluster}
                 >


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- cluster load/reload tooltip dissapearing

## How to test it

- keep the cursor on the load/reload button for one second and click it

## Screenshots

- https://user-images.githubusercontent.com/5509112/151125037-3c73bac7-e4e2-4236-b1cf-9ce758894f9c.mov



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
