### PR TITLE
fix: dismiss project management selection by press escape 

### DIFF
--- a/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
@@ -21,7 +21,7 @@ export const BackToProjectButton = styled(RawButton)`
   color: ${Colors.blue6};
 `;
 
-export const Button = styled(RawButton)`
+export const Button = styled(props => <RawButton {...props} />)`
   display: flex;
   align-items: center;
   margin-right: 0px !important;

--- a/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
@@ -21,7 +21,7 @@ export const BackToProjectButton = styled(RawButton)`
   color: ${Colors.blue6};
 `;
 
-export const Button = styled(props => <RawButton {...props} />)`
+export const Button = styled(RawButton)`
   display: flex;
   align-items: center;
   margin-right: 0px !important;

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -1,4 +1,5 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
+import {useHotkeys} from 'react-hotkeys-hook';
 import {useSelector} from 'react-redux';
 
 import {Dropdown, Modal, Tooltip} from 'antd';
@@ -41,6 +42,7 @@ const ProjectSelection = () => {
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [isDropdownMenuVisible, setIsDropdownMenuVisible] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const dropdownButtonRef = useRef<HTMLButtonElement>();
 
   const {openFileExplorer, fileExplorerProps} = useFileExplorer(
     ({folderPath}) => {
@@ -50,6 +52,11 @@ const ProjectSelection = () => {
     },
     {isDirectoryExplorer: true}
   );
+
+  useHotkeys('escape', () => {
+    setIsDropdownMenuVisible(false);
+    dropdownButtonRef.current?.blur();
+  });
 
   useEffect(() => {
     if (searchText) {
@@ -227,7 +234,7 @@ const ProjectSelection = () => {
         onVisibleChange={setIsDropdownMenuVisible}
       >
         <Tooltip mouseEnterDelay={TOOLTIP_DELAY} placement="bottomRight" title={ProjectManagementTooltip}>
-          <S.Button disabled={previewLoader.isLoading || isInPreviewMode} type="link">
+          <S.Button ref={dropdownButtonRef} disabled={previewLoader.isLoading || isInPreviewMode} type="link">
             <S.FolderOpenOutlined />
             <S.ProjectName>{activeProject.name}</S.ProjectName>
             <S.DownOutlined />

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -42,7 +42,7 @@ const ProjectSelection = () => {
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [isDropdownMenuVisible, setIsDropdownMenuVisible] = useState(false);
   const [searchText, setSearchText] = useState('');
-  const dropdownButtonRef = useRef<HTMLButtonElement>();
+  const dropdownButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const {openFileExplorer, fileExplorerProps} = useFileExplorer(
     ({folderPath}) => {


### PR DESCRIPTION
This PR...

## Changes

- added escape keyboard fn to Project management selection

## Fixes

- dismiss project management selection by press escape 

## How to test it

-

## Screenshots

- 

https://user-images.githubusercontent.com/20525304/151131405-f470bd23-ee42-4de3-8685-61f1615af5dc.mp4



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
