### PR TITLE
fix: remove highlighting of matchLabels in a selector

### DIFF
--- a/src/components/molecules/Monaco/symbolProcessing.ts
+++ b/src/components/molecules/Monaco/symbolProcessing.ts
@@ -213,7 +213,11 @@ function processSymbol(
   if (parents.length > 0) {
     const parentName = parents[parents.length - 1].name;
 
-    if (parentName === 'labels' || parentName === 'matchLabels' || parentName === 'selector') {
+    if (
+      parentName === 'labels' ||
+      parentName === 'matchLabels' ||
+      (parentName === 'selector' && symbol.name !== 'matchLabels')
+    ) {
       addLabelFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);
     } else if (parentName === 'annotations') {
       addAnnotationFilterLink(lines, symbol, filterResources, newDisposables, newDecorations);


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
