### PR TITLE
fix: mark active project in recent projects pane

### DIFF
--- a/src/components/organisms/RecentProjectsPane/RecentProjectsPane.tsx
+++ b/src/components/organisms/RecentProjectsPane/RecentProjectsPane.tsx
@@ -8,6 +8,8 @@ import {Project} from '@models/appconfig';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setOpenProject} from '@redux/reducers/appConfig';
+import {toggleStartProjectPane} from '@redux/reducers/ui';
+import {activeProjectSelector} from '@redux/selectors';
 
 import {MonoPaneTitle, MonoPaneTitleCol} from '@atoms';
 
@@ -17,6 +19,7 @@ const RecentProjectsPane = () => {
   const dispatch = useAppDispatch();
 
   const projects: Project[] = useAppSelector(state => state.config.projects);
+  const activeProject = useAppSelector(activeProjectSelector);
 
   const openProject = (project: Project) => {
     dispatch(setOpenProject(project.rootFolder));
@@ -41,17 +44,24 @@ const RecentProjectsPane = () => {
       </Row>
       <Row>
         <S.ProjectsContainer>
-          {projects.map((project: Project) => (
-            <S.ProjectItem key={project.rootFolder}>
-              <S.ProjectName onClick={() => openProject(project)}>{project.name}</S.ProjectName>
-              <S.ProjectPath>{project.rootFolder}</S.ProjectPath>
-              <S.ProjectLastOpened>
-                {getRelativeDate(project.lastOpened)
-                  ? `last opened ${getRelativeDate(project.lastOpened)}`
-                  : 'Not opened yet'}
-              </S.ProjectLastOpened>
-            </S.ProjectItem>
-          ))}
+          {projects.map((project: Project) => {
+            const isActivePropject = project.rootFolder === activeProject?.rootFolder;
+            return (
+              <S.ProjectItem key={project.rootFolder} activeproject={isActivePropject}>
+                <S.ProjectName
+                  onClick={() => (isActivePropject ? dispatch(toggleStartProjectPane()) : openProject(project))}
+                >
+                  {project.name}
+                </S.ProjectName>
+                <S.ProjectPath>{project.rootFolder}</S.ProjectPath>
+                <S.ProjectLastOpened>
+                  {getRelativeDate(project.lastOpened)
+                    ? `last opened ${getRelativeDate(project.lastOpened)}`
+                    : 'Not opened yet'}
+                </S.ProjectLastOpened>
+              </S.ProjectItem>
+            );
+          })}
         </S.ProjectsContainer>
       </Row>
     </>

--- a/src/components/organisms/RecentProjectsPane/Styled.tsx
+++ b/src/components/organisms/RecentProjectsPane/Styled.tsx
@@ -1,3 +1,5 @@
+import {Button} from 'antd';
+
 import styled from 'styled-components';
 
 import {GlobalScrollbarStyle} from '@utils/scrollbar';
@@ -25,12 +27,15 @@ export const ProjectsContainer = styled.div`
   ${GlobalScrollbarStyle}
 `;
 
-export const ProjectItem = styled.div`
+export const ProjectItem = styled.div<{activeproject: boolean}>`
   margin-bottom: 16px;
+  margin-left: ${props => (props.activeproject ? '-12px' : 'unset')};
+  padding-left: ${props => (props.activeproject ? '12px' : 'unset')};
+  border-left: 4px solid ${props => (props.activeproject ? Colors.lightSeaGreen : 'transparent')};
+  color: ${props => (props.activeproject ? Colors.lightSeaGreen : Colors.whitePure)};
 `;
 
 export const ProjectName = styled.div`
-  color: ${Colors.whitePure};
   font-size: 14px;
   white-space: nowrap;
   overflow: hidden;
@@ -60,4 +65,9 @@ export const ProjectLastOpened = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   width: auto;
+`;
+
+export const BackToProjectButton = styled(Button)`
+  font-size: 12px;
+  color: ${Colors.lightSeaGreen};
 `;


### PR DESCRIPTION
This PR...

## Changes

- add styles to the active project item in the recent projects list 

## Fixes

- mark active project in recent projects pane

## How to test it

-

## Screenshots

- 
<img width="344" alt="Screen Shot 2022-01-26 at 1 30 49 PM" src="https://user-images.githubusercontent.com/20525304/151155928-9cbe51cc-c6fa-44ae-a51f-3a53fad7783e.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
