### PR TITLE
fix: quick search tooltip & resize settings icons

### DIFF
--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -3,13 +3,14 @@ import {useSelector} from 'react-redux';
 import {ResizableBox} from 'react-resizable';
 import {useMeasure} from 'react-use';
 
-import {Badge, Button} from 'antd';
+import {Badge, Button, Tooltip} from 'antd';
 
 import {FilterOutlined, PlusOutlined} from '@ant-design/icons';
 
 import styled from 'styled-components';
 
 import {NAVIGATOR_HEIGHT_OFFSET, ROOT_FILE_ENTRY} from '@constants/constants';
+import {QuickFilterTooltip} from '@constants/tooltips';
 
 import {ResourceFilterType} from '@models/appstate';
 
@@ -129,15 +130,17 @@ const NavPane: React.FC = () => {
               type="link"
               onClick={onClickNewResource}
             />
-            <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
-              <Button
-                disabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
-                type="link"
-                size="small"
-                icon={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
-                onClick={resourceFilterButtonHandler}
-              />
-            </Badge>
+            <Tooltip title={QuickFilterTooltip}>
+              <Badge count={appliedFilters.length} size="small" offset={[-2, 2]} color={Colors.greenOkay}>
+                <Button
+                  disabled={(!isFolderOpen && !isInClusterMode && !isInPreviewMode) || activeResources.length === 0}
+                  type="link"
+                  size="small"
+                  icon={<FilterOutlined style={appliedFilters.length ? {color: Colors.greenOkay} : {}} />}
+                  onClick={resourceFilterButtonHandler}
+                />
+              </Badge>
+            </Tooltip>
             <ClusterCompareButton />
           </S.TitleBarRightButtons>
         </S.TitleBar>

--- a/src/components/organisms/PageHeader/HelpMenu.tsx
+++ b/src/components/organisms/PageHeader/HelpMenu.tsx
@@ -11,8 +11,10 @@ import DiscordLogo from '@assets/DiscordLogo.svg';
 import {FontColors} from '@styles/Colors';
 
 const IconContainerSpan = styled.span`
+  width: 18px;
+  height: 18px;
   color: ${FontColors.elementSelectTitle};
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
 `;
 

--- a/src/components/organisms/PageHeader/styled.tsx
+++ b/src/components/organisms/PageHeader/styled.tsx
@@ -25,7 +25,6 @@ export const Row = styled(RawRow.default)`
 
 export const BellOutlined = styled(RawBellOutlined)`
   color: ${FontColors.elementSelectTitle};
-  font-size: 24px;
   cursor: pointer;
 `;
 
@@ -76,8 +75,10 @@ export const Header = styled(RawHeader.default)`
 `;
 
 export const IconContainerSpan = styled.span`
+  width: 18px;
+  height: 18px;
   color: ${FontColors.elementSelectTitle};
-  font-size: 24px;
+  font-size: 18px;
   cursor: pointer;
 `;
 
@@ -111,20 +112,18 @@ export const ResourceSpan = styled.span`
 
 export const SettingsCol = styled(Col)`
   display: grid;
-  grid-template-columns: repeat(4, max-content);
+  grid-template-columns: repeat(4, 18px);
   align-items: center;
   grid-column-gap: 12px;
 `;
 
 export const SettingsOutlined = styled(RawSettingOutlined)`
   color: ${FontColors.elementSelectTitle};
-  font-size: 24px;
   cursor: pointer;
 `;
 
 export const ApiOutlined = styled(RawApiOutlined)`
   color: ${FontColors.elementSelectTitle};
-  font-size: 24px;
   cursor: pointer;
 `;
 

--- a/src/components/organisms/PageHeader/styled.tsx
+++ b/src/components/organisms/PageHeader/styled.tsx
@@ -25,6 +25,7 @@ export const Row = styled(RawRow.default)`
 
 export const BellOutlined = styled(RawBellOutlined)`
   color: ${FontColors.elementSelectTitle};
+  font-size: 18px;
   cursor: pointer;
 `;
 
@@ -119,11 +120,13 @@ export const SettingsCol = styled(Col)`
 
 export const SettingsOutlined = styled(RawSettingOutlined)`
   color: ${FontColors.elementSelectTitle};
+  font-size: 18px;
   cursor: pointer;
 `;
 
 export const ApiOutlined = styled(RawApiOutlined)`
   color: ${FontColors.elementSelectTitle};
+  font-size: 18px;
   cursor: pointer;
 `;
 

--- a/src/constants/tooltips.ts
+++ b/src/constants/tooltips.ts
@@ -53,4 +53,4 @@ export const NewProjectFromFolderTooltip = 'New project from existing folder';
 export const NewEmptyProjectTooltip = 'New Empty Project';
 export const SearchProjectTooltip = 'Search for project by name or path';
 export const PluginDrawerTooltip = 'Open Plugins Manager';
-export const QuickFilterTooltip = 'quick-filter CTRL + P';
+export const QuickFilterTooltip = 'Filter results – Hint: quick-filter using CTRL + P';

--- a/src/constants/tooltips.ts
+++ b/src/constants/tooltips.ts
@@ -53,3 +53,4 @@ export const NewProjectFromFolderTooltip = 'New project from existing folder';
 export const NewEmptyProjectTooltip = 'New Empty Project';
 export const SearchProjectTooltip = 'Search for project by name or path';
 export const PluginDrawerTooltip = 'Open Plugins Manager';
+export const QuickFilterTooltip = 'quick-filter CTRL + P';


### PR DESCRIPTION
This PR...

## Changes

- added a tooltip for quick search 
- set setting icons size 18px

## Fixes

-

## How to test it

-

## Screenshots

- 
<img width="1025" alt="Screen Shot 2022-01-26 at 1 59 51 PM" src="https://user-images.githubusercontent.com/20525304/151159443-4b3d57d4-d6d6-4181-b9c1-b5687de6fbcf.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
