### PR TITLE
fix: keep dropdown open when deleting project

### DIFF
--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -41,6 +41,7 @@ const ProjectSelection = () => {
   const projects: Project[] = useAppSelector(state => state.config.projects);
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [isDropdownMenuVisible, setIsDropdownMenuVisible] = useState(false);
+  const deleteModalVisible = useRef({visible: false});
   const [searchText, setSearchText] = useState('');
   const dropdownButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -87,7 +88,7 @@ const ProjectSelection = () => {
 
   const handleDeleteProject = (project: Project) => {
     const title = `Do you want to remove ${project?.name}?`;
-
+    deleteModalVisible.current.visible = true;
     Modal.confirm({
       title,
       icon: <ExclamationCircleOutlined />,
@@ -97,10 +98,19 @@ const ProjectSelection = () => {
         return new Promise(resolve => {
           dispatch(setDeleteProject(project));
           resolve({});
+          deleteModalVisible.current.visible = false;
         });
       },
-      onCancel() {},
+      onCancel() {
+        deleteModalVisible.current.visible = false;
+      },
     });
+  };
+
+  const onDropdownVisibleChange = (visible: boolean) => {
+    if (!deleteModalVisible.current.visible) {
+      setIsDropdownMenuVisible(visible);
+    }
   };
 
   const getRelativeDate = (isoDate: string | undefined) => {
@@ -231,7 +241,7 @@ const ProjectSelection = () => {
         placement="bottomCenter"
         trigger={['click']}
         visible={isDropdownMenuVisible}
-        onVisibleChange={setIsDropdownMenuVisible}
+        onVisibleChange={onDropdownVisibleChange}
       >
         <Tooltip mouseEnterDelay={TOOLTIP_DELAY} placement="bottomRight" title={ProjectManagementTooltip}>
           <S.Button ref={dropdownButtonRef} disabled={previewLoader.isLoading || isInPreviewMode} type="link">


### PR DESCRIPTION
This PR...

## Changes

- add a flag to prevent change dropdown visible state while clicking on the modal 

## Fixes

- keep dropdown open when deleting project

## How to test it

-

## Screenshots

-

https://user-images.githubusercontent.com/20525304/151176133-709ac260-e200-490d-9817-3b7f97d1b7a0.mp4



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
