### PR TITLE
fix: recent project folder path max width

### DIFF
--- a/src/components/organisms/RecentProjectsPane/RecentProjectsPane.tsx
+++ b/src/components/organisms/RecentProjectsPane/RecentProjectsPane.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Row} from 'antd';
+import {Row, Tooltip} from 'antd';
 
 import {DateTime} from 'luxon';
 
@@ -53,7 +53,9 @@ const RecentProjectsPane = () => {
                 >
                   {project.name}
                 </S.ProjectName>
-                <S.ProjectPath>{project.rootFolder}</S.ProjectPath>
+                <Tooltip title={project.rootFolder}>
+                  <S.ProjectPath>{project.rootFolder}</S.ProjectPath>
+                </Tooltip>
                 <S.ProjectLastOpened>
                   {getRelativeDate(project.lastOpened)
                     ? `last opened ${getRelativeDate(project.lastOpened)}`

--- a/src/components/organisms/RecentProjectsPane/Styled.tsx
+++ b/src/components/organisms/RecentProjectsPane/Styled.tsx
@@ -33,6 +33,15 @@ export const ProjectItem = styled.div<{activeproject: boolean}>`
   padding-left: ${props => (props.activeproject ? '12px' : 'unset')};
   border-left: 4px solid ${props => (props.activeproject ? Colors.lightSeaGreen : 'transparent')};
   color: ${props => (props.activeproject ? Colors.lightSeaGreen : Colors.whitePure)};
+  cursor: pointer;
+
+  :hover {
+    background: ${Colors.blackPearl};
+    margin-left: -12px;
+    margin-right: -12px;
+    padding-left: 12px;
+    padding-right: 12px;
+  }
 `;
 
 export const ProjectName = styled.div`
@@ -56,6 +65,7 @@ export const ProjectPath = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   width: auto;
+  max-width: 300px;
 `;
 
 export const ProjectLastOpened = styled.div`


### PR DESCRIPTION
This PR...

## Changes

- added max-width to the recent folder project path
- add hover to the recent project list item

## Fixes

-

## How to test it

-

## Screenshots

- 

https://user-images.githubusercontent.com/20525304/151191070-9af6da2b-313d-4cb0-aba2-821e72d211a8.mp4



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
