### PR TITLE
fix: validator-cache now uses resource kind+apiVersion for key

### DIFF
--- a/src/redux/services/validation.ts
+++ b/src/redux/services/validation.ts
@@ -40,7 +40,8 @@ export function validateResource(resource: K8sResource) {
     return;
   }
 
-  if (!validatorCache.has(resource.kind)) {
+  const validatorCacheKey = resource.kind + resource.version;
+  if (!validatorCache.has(validatorCacheKey)) {
     const ajv = new Ajv({
       unknownFormats: 'ignore',
       validateSchema: false,
@@ -49,10 +50,10 @@ export function validateResource(resource: K8sResource) {
       verbose: true,
       allErrors: true,
     });
-    validatorCache.set(resource.kind, ajv.compile(resourceSchema));
+    validatorCache.set(validatorCacheKey, ajv.compile(resourceSchema));
   }
 
-  const validate = validatorCache.get(resource.kind);
+  const validate = validatorCache.get(validatorCacheKey);
   if (validate) {
     try {
       validate(resource.content);


### PR DESCRIPTION
This PR fixes the validator cache to use the correct schema for validation - see screenshot - no more errors!

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/1917063/151338011-bd84cf10-9542-4b6c-9707-d90eecea5d25.png)

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
