### PR TITLE
fix: filter only files by isSupported and isExcluded

### DIFF
--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -138,12 +138,12 @@ const SaveResourceToFileFolderModal: React.FC = () => {
     const files: string[] = [];
 
     Object.entries(fileMap).forEach(([key, value]) => {
-      if ((!value.isSupported || value.isExcluded) && ROOT_FILE_ENTRY !== key) {
-        return;
-      }
       if (value.children) {
         folders.push(key.replace(path.sep, ''));
       } else {
+        if (!value.isSupported || value.isExcluded) {
+          return;
+        }
         files.push(key.replace(path.sep, ''));
       }
     });

--- a/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
+++ b/src/components/organisms/NewResourceWizard/NewResourceWizard.tsx
@@ -302,12 +302,12 @@ const NewResourceWizard = () => {
     const files: string[] = [];
 
     Object.entries(fileMap).forEach(([key, value]) => {
-      if (!value.isSupported || value.isExcluded) {
-        return;
-      }
       if (value.children) {
         folders.push(key.replace(path.sep, ''));
       } else {
+        if (!value.isSupported || value.isExcluded) {
+          return;
+        }
         files.push(key.replace(path.sep, ''));
       }
     });


### PR DESCRIPTION
## Fixes

- Filter only files by `IsSupported` and `isExcluded` for the dropdown options from `Save to folder` and `Append to file`

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/151338413-14e07dad-b338-4889-9c79-e5afd5315a9f.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
