### PR TITLE
fix: close modal if selecting from dropdown the same selected resource

### DIFF
--- a/src/components/organisms/QuickSearchActions/QuickSearchActions.tsx
+++ b/src/components/organisms/QuickSearchActions/QuickSearchActions.tsx
@@ -137,8 +137,10 @@ const QuickSearchActionsV3: React.FC = () => {
       } else if (type === 'resource') {
         if (!filteredResources[option]) {
           selectK8sResourceWithConfirm(option, resourceMap[option].name, dispatch);
-        } else if (selectedResourceId !== option) {
-          dispatch(selectK8sResource({resourceId: option}));
+        } else {
+          if (selectedResourceId !== option) {
+            dispatch(selectK8sResource({resourceId: option}));
+          }
           dispatch(closeQuickSearchActionsPopup());
         }
       }


### PR DESCRIPTION
## Fixes

- Close quick search modal if you select the resource that is already selected in the navigator

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
