### PR TITLE
fix: enable cluster selector when in preview mode

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -159,7 +159,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
               placement="bottomCenter"
               arrow
               trigger={['click']}
-              disabled={previewLoader.isLoading || isInPreviewMode}
+              disabled={previewLoader.isLoading || isInClusterMode}
               visible={isClusterDropdownOpen}
               onVisibleChange={setIsClusterDropdownOpen}
             >


### PR DESCRIPTION
## Fixes

- Enable cluster selector when in preview mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/151353540-09317733-a873-4aa3-8df6-56ce43064eda.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
