### PR TITLE
fix: remove hasUserPerformedClickOnClusterIcon

### DIFF
--- a/electron/src/initKubeconfig.ts
+++ b/electron/src/initKubeconfig.ts
@@ -35,11 +35,6 @@ function initKubeconfig(dispatch: (action: AnyAction) => void, userHomeDir: stri
     return;
   }
   const storedKubeconfig: string | undefined = electronStore.get('appConfig.kubeconfig');
-  const hasUserPerformedClickOnClusterIcon: boolean = electronStore.get('appConfig.hasUserPerformedClickOnClusterIcon');
-
-  if (hasUserPerformedClickOnClusterIcon) {
-    dispatch(onUserPerformedClickOnClusterIcon());
-  }
 
   if (storedKubeconfig && storedKubeconfig.trim().length > 0) {
     dispatch(setKubeConfig(getKubeConfigContext(storedKubeconfig)));

--- a/src/components/organisms/SettingsDrawer/Settings.tsx
+++ b/src/components/organisms/SettingsDrawer/Settings.tsx
@@ -56,7 +56,6 @@ export const Settings = ({
   const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const fileInput = useRef<HTMLInputElement>(null);
   const [inputRef, focusInput] = useFocus<Input>();
-  const hasUserPerformedClickOnClusterIcon = useAppSelector(state => state.uiCoach.hasUserPerformedClickOnClusterIcon);
   const wasRehydrated = useAppSelector(state => state.main.wasRehydrated);
   const [isClusterActionDisabled, setIsClusterActionDisabled] = useState(
     Boolean(!config?.kubeConfig?.path) || Boolean(!config?.kubeConfig?.isPathValid)
@@ -220,7 +219,7 @@ export const Settings = ({
       <S.Div>
         <S.Heading>
           KUBECONFIG
-          {isClusterActionDisabled && hasUserPerformedClickOnClusterIcon && wasRehydrated && (
+          {isClusterActionDisabled && wasRehydrated && (
             <S.WarningOutlined
               className={isClusterPaneIconHighlighted ? 'animated-highlight' : ''}
               isKubeconfigPathValid={Boolean(config?.kubeConfig?.isPathValid)}


### PR DESCRIPTION
This PR...

## Changes

- removes hasUserPerformedClickOnClusterIcon

## Fixes

-  kubeconfig error is visible on a clean install

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
