### PR TITLE
fix: diffing cluster resource would lead to error

### DIFF
--- a/src/components/organisms/ClusterResourceDiffModal/ClusterResourceDiffModal.tsx
+++ b/src/components/organisms/ClusterResourceDiffModal/ClusterResourceDiffModal.tsx
@@ -58,7 +58,7 @@ const ClusterResourceDiffModal = () => {
   const windowSize = useWindowSize();
 
   const isDiffModalVisible = useMemo(
-    () => Boolean(targetResourceId) && Boolean(isInClusterMode),
+    () => Boolean(targetResourceId) && isInClusterMode,
     [isInClusterMode, targetResourceId]
   );
 
@@ -77,8 +77,8 @@ const ClusterResourceDiffModal = () => {
   }, [windowSize.width]);
 
   const cleanTargetResourceText = useMemo(() => {
-    if (!targetResource?.content) {
-      return;
+    if (!isDiffModalVisible || !targetResource || !targetResource.content) {
+      return undefined;
     }
 
     if (!shouldDiffIgnorePaths) {
@@ -88,7 +88,7 @@ const ClusterResourceDiffModal = () => {
     return stringify(removeIgnoredPathsFromResourceContent(targetResource.content, targetResource.namespace), {
       sortMapEntries: true,
     });
-  }, [shouldDiffIgnorePaths, targetResource]);
+  }, [isDiffModalVisible, shouldDiffIgnorePaths, targetResource]);
 
   const areResourcesDifferent = useMemo(() => {
     return cleanTargetResourceText !== matchingResourceText;
@@ -107,7 +107,7 @@ const ClusterResourceDiffModal = () => {
   }, [kubeConfigContext, selectedMatchingResourceId, resourceMap]);
 
   const matchingLocalResources = useMemo(() => {
-    if (!targetResource) {
+    if (!isDiffModalVisible || !targetResource) {
       return;
     }
 
@@ -121,7 +121,7 @@ const ClusterResourceDiffModal = () => {
         );
       })
     );
-  }, [resourceMap, targetResource]);
+  }, [isDiffModalVisible, resourceMap, targetResource]);
 
   const onCloseHandler = () => {
     if (isApplyModalVisible) {
@@ -178,7 +178,7 @@ const ClusterResourceDiffModal = () => {
   };
 
   useEffect(() => {
-    if (!targetResource || !resourceMap || !matchingLocalResources) {
+    if (!isDiffModalVisible || !targetResource || !targetResource.content || !resourceMap || !matchingLocalResources) {
       return;
     }
 
@@ -235,7 +235,7 @@ const ClusterResourceDiffModal = () => {
     }
 
     setHasDiffModalLoaded(true);
-  }, [dispatch, matchingLocalResources, resourceMap, targetResource]);
+  }, [dispatch, isDiffModalVisible, matchingLocalResources, resourceMap, targetResource]);
 
   return (
     <>

--- a/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
+++ b/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
@@ -139,6 +139,7 @@ const DiffModal = () => {
 
   const cleanMatchingResourceText = useMemo(() => {
     if (
+      !isDiffModalVisible ||
       !matchingResourceText ||
       !targetResource?.content ||
       !selectedMatchingResourceId ||
@@ -158,12 +159,13 @@ const DiffModal = () => {
     const cleanDiffContentString = stringify(newDiffContentObject, {sortMapEntries: true});
     return cleanDiffContentString;
   }, [
-    hasDiffModalLoaded,
-    matchingResourcesById,
+    isDiffModalVisible,
     matchingResourceText,
-    selectedMatchingResourceId,
-    shouldDiffIgnorePaths,
     targetResource,
+    selectedMatchingResourceId,
+    matchingResourcesById,
+    hasDiffModalLoaded,
+    shouldDiffIgnorePaths,
   ]);
 
   const areResourcesDifferent = useMemo(() => {
@@ -179,7 +181,7 @@ const DiffModal = () => {
   };
 
   useEffect(() => {
-    if (!targetResource || !resourceMap) {
+    if (!isDiffModalVisible || !targetResource || !resourceMap) {
       return;
     }
 
@@ -258,7 +260,15 @@ const DiffModal = () => {
 
     setTargetResourceText(stringify(targetResource.content, {sortMapEntries: true}));
     getClusterResources();
-  }, [kubeConfigContext, dispatch, kubeConfigPath, resourceMap, resourceFilter.namespace, targetResource]);
+  }, [
+    kubeConfigContext,
+    dispatch,
+    kubeConfigPath,
+    resourceMap,
+    resourceFilter.namespace,
+    targetResource,
+    isDiffModalVisible,
+  ]);
 
   useEffect(() => {
     if (!isDiffModalVisible) {


### PR DESCRIPTION
## Fixes

- Sometimes, diffing a cluster resource was leading to an error, fixed it by not executing logic inside the component if the modal is not visible

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
