### PR TITLE
fix: project selection small improvements

### DIFF
--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -1,6 +1,5 @@
 import {useEffect, useRef, useState} from 'react';
 import {useHotkeys} from 'react-hotkeys-hook';
-import {useSelector} from 'react-redux';
 
 import {Dropdown, Modal, Tooltip} from 'antd';
 import Column from 'antd/lib/table/Column';
@@ -34,15 +33,17 @@ import * as S from './ProjectSelection.styled';
 
 const ProjectSelection = () => {
   const dispatch = useAppDispatch();
-  const activeProject = useSelector(activeProjectSelector);
-  const isInPreviewMode = useSelector(isInPreviewModeSelector);
+  const activeProject = useAppSelector(activeProjectSelector);
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
   const isStartProjectPaneVisible = useAppSelector(state => state.ui.isStartProjectPaneVisible);
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const projects: Project[] = useAppSelector(state => state.config.projects);
+
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
   const [isDropdownMenuVisible, setIsDropdownMenuVisible] = useState(false);
-  const deleteModalVisible = useRef({visible: false});
   const [searchText, setSearchText] = useState('');
+
+  const deleteModalVisible = useRef({visible: false});
   const dropdownButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const {openFileExplorer, fileExplorerProps} = useFileExplorer(
@@ -96,6 +97,7 @@ const ProjectSelection = () => {
       zIndex: 9999,
       onOk() {
         return new Promise(resolve => {
+          setIsDropdownMenuVisible(false);
           dispatch(setDeleteProject(project));
           resolve({});
           deleteModalVisible.current.visible = false;

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -79,7 +79,9 @@ const ProjectSelection = () => {
 
   const handleProjectChange = (project: Project) => {
     setIsDropdownMenuVisible(false);
-    setTimeout(() => dispatch(setOpenProject(project.rootFolder)), 400);
+    if (activeProject?.rootFolder !== project.rootFolder) {
+      setTimeout(() => dispatch(setOpenProject(project.rootFolder)), 400);
+    }
   };
 
   const handleCreateProject = (fromTemplate: boolean) => {
@@ -97,7 +99,10 @@ const ProjectSelection = () => {
       zIndex: 9999,
       onOk() {
         return new Promise(resolve => {
-          setIsDropdownMenuVisible(false);
+          if (activeProject?.rootFolder === project.rootFolder) {
+            setIsDropdownMenuVisible(false);
+          }
+
           dispatch(setDeleteProject(project));
           resolve({});
           deleteModalVisible.current.visible = false;


### PR DESCRIPTION
## Fixes

- Close project selection when deleting the active project and opening a new one
- Don't dispatch open project action when selecting from project selection dropdown the currently active project

## How to test it

- Delete active project and select a recent project or open a new one
- Select the active project from the project selection dropdown

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
