### PR TITLE
fix: fallback to source editor if no form available

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -311,13 +311,14 @@ const ActionsPane = (props: {contentHeight: string}) => {
   }, [selectedResourceId, resourceMap]);
 
   useEffect(() => {
-    if (
-      (activeTabKey === 'metadataForm' || activeTabKey === 'form') &&
-      (!selectedResourceId || !(resourceKindHandler && resourceKindHandler.formEditorOptions))
-    ) {
+    if (activeTabKey === 'form' && !(resourceKindHandler && resourceKindHandler.formEditorOptions?.editorSchema)) {
       setActiveTabKey('source');
     }
-  }, [selectedResourceId, selectedResource, activeTabKey, resourceKindHandler]);
+
+    if (activeTabKey === 'metadataForm' && (!resourceKindHandler || isKustomizationResource(selectedResource))) {
+      setActiveTabKey('source');
+    }
+  }, [selectedResource, activeTabKey, resourceKindHandler]);
 
   const isSelectedResourceUnsaved = useCallback(() => {
     if (!selectedResource) {


### PR DESCRIPTION
This PR...

## Changes

- check if there are no forms fallback to the source editor tab

## Fixes

- #1212 

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
