### PR TITLE
refactor: show icon for count of warnings/errors

### DIFF
--- a/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
+++ b/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
@@ -2,6 +2,8 @@ import {Menu} from 'antd';
 
 import styled from 'styled-components';
 
+import {Icon as RawIcon} from '@components/atoms';
+
 import {GlobalScrollbarStyle} from '@utils/scrollbar';
 
 import Colors from '@styles/Colors';
@@ -16,6 +18,16 @@ export const ErrorWarningContainer = styled.div<{$type: 'warning' | 'error'}>`
 
 export const Label = styled.span`
   margin-left: 5px;
+`;
+
+export const Icon = styled(RawIcon)<{$type: 'warning' | 'error'}>`
+  ${({$type}) => {
+    if ($type === 'error') {
+      return `
+      transform: translateY(-1.5px);
+    `;
+    }
+  }}
 `;
 
 export const StyledMenu = styled(Menu)`
@@ -34,9 +46,9 @@ export const StyledMenuItem = styled(Menu.Item)`
   padding: 0px 4px;
 `;
 
-export const WarningCountLabel = styled.span<{$type: 'warning' | 'error'}>`
+export const WarningCountContainer = styled.span<{$type: 'warning' | 'error'}>`
   ${({$type}) => `color: ${$type === 'warning' ? Colors.yellowWarning : Colors.redError};`}
-  margin-left: 5px;
+  margin-left: 8px;
 `;
 
 export const WarningKindLabel = styled.span`

--- a/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
+++ b/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
@@ -55,7 +55,9 @@ const RefDropdownMenu = (props: RefDropdownMenuProps) => {
         <S.StyledMenuItem key={warning.id} onClick={() => dispatch(selectK8sResource({resourceId: warning.id}))}>
           {warning.namespace && <Tag>{warning.namespace}</Tag>}
           <span>{warning.name}</span>
-          <S.WarningCountLabel $type={type}>({warning.count})</S.WarningCountLabel>
+          <S.WarningCountContainer $type={type}>
+            <S.Icon $type={type} name={type} /> {warning.count}
+          </S.WarningCountContainer>
           <S.WarningKindLabel>{warning.type}</S.WarningKindLabel>
         </S.StyledMenuItem>
       ))}


### PR DESCRIPTION
## Changes

- Add icon for the count of warnings/errors

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/151787772-9e8a8980-da24-42b4-aa50-647d8f482156.png)

![image](https://user-images.githubusercontent.com/47887589/151787746-78f95f8c-f298-41c5-ad78-e293aa27fd51.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
