### PR TITLE
fix: deploy resource to other namespace

### DIFF
--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindPrefix.tsx
@@ -22,8 +22,7 @@ const Container = styled.span`
 `;
 
 const StyledTag = styled(Tag)<{$isSelected: boolean}>`
-  margin-left: 0px;
-  margin-right: 5px;
+  margin: 1px 5px 1px 0px;
   color: ${props => (props.$isSelected ? Colors.blackPure : Colors.whitePure)};
   font-weight: ${props => (props.$isSelected ? 700 : undefined)};
   font-size: 12px;

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -31,7 +31,7 @@ const applyMultipleResources = (
   const yamlToApply = resourcesToApply
     .map(r => {
       const resourceContent = _.cloneDeep(r.content);
-      if (r.namespace && r.namespace !== resourceContent.metadata.namespace) {
+      if (r.namespace && namespace && r.namespace !== namespace) {
         delete resourceContent.metadata.namespace;
       }
 

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -31,7 +31,7 @@ const applyMultipleResources = (
   const yamlToApply = resourcesToApply
     .map(r => {
       const resourceContent = _.cloneDeep(r.content);
-      if (resourceContent.metadata.namespace) {
+      if (r.namespace && r.namespace !== resourceContent.metadata.namespace) {
         delete resourceContent.metadata.namespace;
       }
 

--- a/src/redux/services/applyMultipleResources.ts
+++ b/src/redux/services/applyMultipleResources.ts
@@ -1,4 +1,6 @@
+import _ from 'lodash';
 import log from 'loglevel';
+import {stringify} from 'yaml';
 
 import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
@@ -27,7 +29,14 @@ const applyMultipleResources = (
   }
 
   const yamlToApply = resourcesToApply
-    .map(r => r.text)
+    .map(r => {
+      const resourceContent = _.cloneDeep(r.content);
+      if (resourceContent.metadata.namespace) {
+        delete resourceContent.metadata.namespace;
+      }
+
+      return stringify(resourceContent);
+    })
     .reduce<string>((fullYaml, currentText) => {
       if (doesTextStartWithYamlDocumentDelimiter(currentText)) {
         return `${fullYaml}\n${currentText}`;

--- a/src/redux/thunks/applyResource.ts
+++ b/src/redux/thunks/applyResource.ts
@@ -34,7 +34,7 @@ import {getShellPath} from '@utils/shell';
 
 function applyK8sResource(resource: K8sResource, kubeconfig: string, context: string, namespace?: string) {
   const resourceContent = _.cloneDeep(resource.content);
-  if (resourceContent.metadata.namespace) {
+  if (resource.namespace && resource.namespace !== resourceContent.metadata.namespace) {
     delete resourceContent.metadata.namespace;
   }
 

--- a/src/redux/thunks/applyResource.ts
+++ b/src/redux/thunks/applyResource.ts
@@ -34,7 +34,7 @@ import {getShellPath} from '@utils/shell';
 
 function applyK8sResource(resource: K8sResource, kubeconfig: string, context: string, namespace?: string) {
   const resourceContent = _.cloneDeep(resource.content);
-  if (resource.namespace && resource.namespace !== resourceContent.metadata.namespace) {
+  if (resource.namespace && namespace && namespace !== resource.namespace) {
     delete resourceContent.metadata.namespace;
   }
 

--- a/src/redux/thunks/applyResource.ts
+++ b/src/redux/thunks/applyResource.ts
@@ -1,4 +1,5 @@
 import {spawn} from 'child_process';
+import _ from 'lodash';
 import log from 'loglevel';
 import {stringify} from 'yaml';
 
@@ -32,7 +33,12 @@ import {getShellPath} from '@utils/shell';
  */
 
 function applyK8sResource(resource: K8sResource, kubeconfig: string, context: string, namespace?: string) {
-  return applyYamlToCluster(resource.text, kubeconfig, context, namespace);
+  const resourceContent = _.cloneDeep(resource.content);
+  if (resourceContent.metadata.namespace) {
+    delete resourceContent.metadata.namespace;
+  }
+
+  return applyYamlToCluster(stringify(resourceContent), kubeconfig, context, namespace);
 }
 
 /**


### PR DESCRIPTION
## Fixes

- Delete the local resource namespace ( if exists ) when deploying to the cluster so you can deploy it to other namespaces different than the one from metadata
- Add navigator resource namespace tag vertical margin

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
