### PR TITLE
fix: number of resources from file not updating on append

### DIFF
--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -810,12 +810,6 @@ export const mainSlice = createSlice({
 
         if (resourceFileEntry) {
           resourceFileEntry.timestamp = resourcePayload.fileTimestamp;
-          const resourcesFromFile = Object.values(state.resourceMap).filter(
-            r => r.filePath === resourceFileEntry.filePath
-          );
-          resourcesFromFile.forEach(r => {
-            delete state.resourceMap[r.id];
-          });
         } else {
           const newFileEntry = {...createFileEntry(relativeFilePath), isSupported: true};
           newFileEntry.timestamp = resourcePayload.fileTimestamp;


### PR DESCRIPTION
## Fixes

- Update the number of resources when appending a new/unsaved resource to a file

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
