### PR TITLE
fix: wrap folder name with quotes

### DIFF
--- a/electron/commands.ts
+++ b/electron/commands.ts
@@ -25,7 +25,7 @@ export const runKustomize = (options: KustomizeCommandOptions, event: Electron.I
       cmd += '--enable-helm ';
     }
 
-    let stdout = execSync(`${cmd} ${options.folder}`, {
+    let stdout = execSync(`${cmd} "${options.folder}"`, {
       env: {
         NODE_ENV: PROCESS_ENV.NODE_ENV,
         PUBLIC_URL: PROCESS_ENV.PUBLIC_URL,

--- a/src/redux/services/previewReferencedHelmChart.ts
+++ b/src/redux/services/previewReferencedHelmChart.ts
@@ -37,7 +37,7 @@ export const previewReferencedHelmChart = async (
   await fsWriteFilePromise(newTempValuesFilePath, parsedValuesFileContent);
 
   const helmArgs = {
-    helmCommand: `helm install --kube-context ${kubeconfigContext} -f ${newTempValuesFilePath} --repo ${chartRepo} ${chartName} --version ${chartVersion} --generate-name --dry-run`,
+    helmCommand: `helm install --kube-context ${kubeconfigContext} -f "${newTempValuesFilePath}" --repo ${chartRepo} ${chartName} --version ${chartVersion} --generate-name --dry-run`,
     kubeconfig: kubeconfigPath,
   };
 

--- a/src/redux/thunks/applyResource.ts
+++ b/src/redux/thunks/applyResource.ts
@@ -58,11 +58,11 @@ function applyKustomization(
   const args =
     kustomizeCommand === 'kubectl'
       ? namespace
-        ? `kubectl --context ${context} --namespace ${namespace} apply -k ${folder}`
-        : `kubectl --context ${context} apply -k ${folder}`
+        ? `kubectl --context ${context} --namespace ${namespace} apply -k "${folder}"`
+        : `kubectl --context ${context} apply -k "${folder}"`
       : namespace
-      ? `kustomize build ${folder} | kubectl --context ${context} --namespace ${namespace} apply -k -`
-      : `kustomize build ${folder} | kubectl --context ${context} apply -k -`;
+      ? `kustomize build "${folder}" | kubectl --context ${context} --namespace ${namespace} apply -k -`
+      : `kustomize build "${folder}" | kubectl --context ${context} apply -k -`;
 
   const child =
     kustomizeCommand === 'kubectl'

--- a/src/redux/thunks/previewHelmValuesFile.ts
+++ b/src/redux/thunks/previewHelmValuesFile.ts
@@ -49,8 +49,8 @@ export const previewHelmValuesFile = createAsyncThunk<
       const args = {
         helmCommand:
           helmPreviewMode === 'template'
-            ? `helm template -f ${folder}${path.sep}${valuesFile.name} ${chart.name} ${folder}`
-            : `helm install --kube-context ${currentContext} -f ${folder}${path.sep}${valuesFile.name} ${chart.name} ${folder} --dry-run`,
+            ? `helm template -f "${folder}${path.sep}${valuesFile.name}" ${chart.name} "${folder}"`
+            : `helm install --kube-context ${currentContext} -f "${folder}${path.sep}${valuesFile.name}" ${chart.name} "${folder}" --dry-run`,
         kubeconfig,
       };
 


### PR DESCRIPTION
## Fixes

- Wrap folder name in quotes when running kustomize

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
