### PR TITLE
fix: disable validation for go templates

### DIFF
--- a/src/hooks/useResourceYamlSchema.ts
+++ b/src/hooks/useResourceYamlSchema.ts
@@ -2,12 +2,17 @@ import {useEffect} from 'react';
 
 import {K8sResource} from '@models/k8sresource';
 
+import {isSupportedHelmResource} from '@redux/services/helm';
 import {isKustomizationPatch} from '@redux/services/kustomize';
 import {getResourceSchema} from '@redux/services/schema';
 
 function useResourceYamlSchema(yaml: any, resource: K8sResource | undefined) {
   useEffect(() => {
     if (!resource) {
+      yaml &&
+        yaml.yamlDefaults.setDiagnosticsOptions({
+          validate: false,
+        });
       return;
     }
 
@@ -16,7 +21,7 @@ function useResourceYamlSchema(yaml: any, resource: K8sResource | undefined) {
 
     if (resource) {
       resourceSchema = getResourceSchema(resource);
-      validate = !isKustomizationPatch(resource);
+      validate = !isKustomizationPatch(resource) && isSupportedHelmResource(resource);
     }
 
     yaml &&

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -34,7 +34,7 @@ export function isHelmChartFolder(files: string[]) {
  * @param resource
  * @returns @boolean
  */
-function isSupportedHelmResource(resource: K8sResource): boolean {
+export function isSupportedHelmResource(resource: K8sResource): boolean {
   const helmVariableRegex = /{{.*}}/g;
 
   return Boolean(resource.text.match(helmVariableRegex)?.length) === false;


### PR DESCRIPTION
This PR...

## Changes

- disables yaml validation for all files that do not contain k8s resources
- disable yaml validation for resources that contain go templates

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
