### PR TITLE
fix Helm chart folder recognition

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -221,18 +221,24 @@ function SectionRenderer(props: SectionRendererProps) {
                   <S.ItemsLength selected={false}>{group.visibleItemIds.length}</S.ItemsLength>
                 </S.Name>
               </S.SectionContainer>
-              {group.visibleItemIds.map(itemId => (
-                <ItemRenderer
-                  key={itemId}
-                  itemId={itemId}
-                  blueprint={itemBlueprint}
-                  level={level + 2}
-                  isLastItem={isLastVisibleItemIdInGroup(group.id, itemId)}
-                  isSectionCheckable={Boolean(sectionInstance.checkable)}
-                  sectionContainerElementId={sectionBlueprint.containerElementId}
-                  options={itemRendererOptions}
-                />
-              ))}
+              {group.visibleItemIds.length ? (
+                group.visibleItemIds.map(itemId => (
+                  <ItemRenderer
+                    key={itemId}
+                    itemId={itemId}
+                    blueprint={itemBlueprint}
+                    level={level + 2}
+                    isLastItem={isLastVisibleItemIdInGroup(group.id, itemId)}
+                    isSectionCheckable={Boolean(sectionInstance.checkable)}
+                    sectionContainerElementId={sectionBlueprint.containerElementId}
+                    options={itemRendererOptions}
+                  />
+                ))
+              ) : (
+                <S.EmptyGroupText>
+                  {sectionBlueprint.customization?.emptyGroupText || 'No items in this group.'}
+                </S.EmptyGroupText>
+              )}
             </React.Fragment>
           );
         })}

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -108,6 +108,11 @@ export const Name = styled.span<NameProps>`
   }}
 `;
 
+export const EmptyGroupText = styled.span`
+  margin-left: 26px;
+  font-size: 12px;
+`;
+
 export const Collapsible = styled.span`
   margin-left: auto;
   margin-right: 15px;

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -63,6 +63,7 @@ export interface SectionCustomization {
   nameContext?: {
     component: SectionCustomComponent;
   };
+  emptyGroupText?: string;
   disableHoverStyle?: boolean;
   beforeInitializationText?: string;
   isCheckVisibleOnHover?: boolean;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -73,6 +73,7 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, HelmChartScope
   },
   customization: {
     emptyDisplay: {component: HelmChartSectionEmptyDisplay},
+    emptyGroupText: 'No values files found for this Chart.',
     beforeInitializationText: 'Get started by browsing a folder in the File Explorer.',
   },
   itemBlueprint: {

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -274,7 +274,9 @@ const processSectionBlueprints = async (state: RootState, dispatch: AppDispatch)
       visibleItemIds: g.itemIds.filter(itemId => itemInstanceMap[itemId].isVisible === true),
     }));
     const visibleItemIds = itemInstances?.filter(i => i.isVisible === true).map(i => i.id) || [];
-    const visibleGroupIds = sectionInstanceGroups.filter(g => g.visibleItemIds.length > 0).map(g => g.id);
+    const visibleGroupIds = sectionBlueprint.customization?.emptyGroupText
+      ? sectionInstanceGroups.map(g => g.id)
+      : sectionInstanceGroups.filter(g => g.visibleItemIds.length > 0).map(g => g.id);
     const sectionInstance: SectionInstance = {
       id: sectionBlueprint.id,
       rootSectionId: sectionBlueprint.rootSectionId,

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -1,6 +1,7 @@
 import {shallowEqual} from 'react-redux';
 
 import asyncLib from 'async';
+import _ from 'lodash';
 import log from 'loglevel';
 import {Middleware} from 'redux';
 
@@ -273,10 +274,18 @@ const processSectionBlueprints = async (state: RootState, dispatch: AppDispatch)
       ...g,
       visibleItemIds: g.itemIds.filter(itemId => itemInstanceMap[itemId].isVisible === true),
     }));
-    const visibleItemIds = itemInstances?.filter(i => i.isVisible === true).map(i => i.id) || [];
+    const visibleItemIds = itemInstances
+      ? _(itemInstances)
+          .filter(i => i.isVisible === true)
+          .map(i => i.id)
+          .value()
+      : [];
     const visibleGroupIds = sectionBlueprint.customization?.emptyGroupText
       ? sectionInstanceGroups.map(g => g.id)
-      : sectionInstanceGroups.filter(g => g.visibleItemIds.length > 0).map(g => g.id);
+      : _(sectionInstanceGroups)
+          .filter(g => g.visibleItemIds.length > 0)
+          .map(g => g.id)
+          .value();
     const sectionInstance: SectionInstance = {
       id: sectionBlueprint.id,
       rootSectionId: sectionBlueprint.rootSectionId,

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -26,7 +26,7 @@ export function getHelmValuesFile(fileEntry: FileEntry, helmValuesMap: HelmValue
  */
 
 export function isHelmChartFolder(files: string[]) {
-  return files.indexOf('Chart.yaml') !== -1 && files.indexOf('values.yaml') !== -1;
+  return files.indexOf('Chart.yaml') !== -1;
 }
 
 /**


### PR DESCRIPTION
This PR...

## Changes

- added option to show empty section groups if there's an `emptyGroupText` property set
- correctly show charts for which we did not find any values files

## Fixes

- isHelmChartFolder to only check for `Chart.yaml` file

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/152343102-70559ea9-6404-463b-9219-0bdb69f99079.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
