### PR TITLE
fix: helm charts/values removal

### DIFF
--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -14,7 +14,7 @@ import {createFileEntry, extractK8sResourcesFromFile, fileIsExcluded, readFiles}
 import {getFileStats} from '@utils/files';
 
 /**
- * Gets the file HelmValuesFile for a specific FileEntry
+ * Gets the HelmValuesFile for a specific FileEntry
  */
 
 export function getHelmValuesFile(fileEntry: FileEntry, helmValuesMap: HelmValuesMapType) {

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -14,11 +14,19 @@ import {createFileEntry, extractK8sResourcesFromFile, fileIsExcluded, readFiles}
 import {getFileStats} from '@utils/files';
 
 /**
- * Checks if the specified fileEntry is a kustomization file
+ * Gets the file HelmValuesFile for a specific FileEntry
  */
 
 export function getHelmValuesFile(fileEntry: FileEntry, helmValuesMap: HelmValuesMapType) {
   return Object.values(helmValuesMap).find(valuesFile => valuesFile.filePath === fileEntry.filePath);
+}
+
+/**
+ * Gets the file HelmValuesFile for a specific FileEntry
+ */
+
+export function getHelmChartFromFileEntry(fileEntry: FileEntry, helmChartMap: HelmChartMapType) {
+  return Object.values(helmChartMap).find(chart => chart.filePath === fileEntry.filePath);
 }
 
 /**

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -22,7 +22,7 @@ export function getHelmValuesFile(fileEntry: FileEntry, helmValuesMap: HelmValue
 }
 
 /**
- * Gets the file HelmValuesFile for a specific FileEntry
+ * Gets the HelmChart for a specific FileEntry
  */
 
 export function getHelmChartFromFileEntry(fileEntry: FileEntry, helmChartMap: HelmChartMapType) {


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- removes helm charts and helm values files from helmChartMap and helmValuesMap when their corresponding files are deleted

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
