### PR TITLE
feat: add confirm dialog on window close with unsaved files

### DIFF
--- a/electron/utils.ts
+++ b/electron/utils.ts
@@ -1,3 +1,5 @@
+import {dialog} from 'electron';
+
 import {AnyAction} from '@reduxjs/toolkit';
 
 import {existsSync, mkdirSync, writeFileSync} from 'fs';
@@ -112,3 +114,31 @@ export const saveInitialK8sSchema = (userDataDir: string) => {
     writeFileSync(schemaPath, String(data));
   }
 };
+
+export function askActionConfirmation({
+  action,
+  unsavedResourceCount,
+}: {
+  action: string;
+  unsavedResourceCount: number;
+}): boolean {
+  if (unsavedResourceCount === 0) {
+    return true;
+  }
+
+  const shortAction = _.capitalize(action.split(' ')[0]);
+  const message =
+    unsavedResourceCount === 1 ? 'You have an unsaved resource' : `You have ${unsavedResourceCount} unsaved resources`;
+
+  const choice = dialog.showMessageBoxSync({
+    type: 'info',
+    title: 'Confirmation',
+    message,
+    detail: `Progress will be lost if you choose to ${action}. You can't undo this action.`,
+    buttons: [shortAction, 'Cancel'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+
+  return choice === 0;
+}

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -13,6 +13,7 @@ import {isKustomizationResource} from '@redux/services/kustomize';
 import {getResourceKindHandler} from '@src/kindhandlers';
 
 import {mergeConfigs, populateProjectConfig} from './services/projectConfig';
+import {isUnsavedResource} from './services/resource';
 
 export const rootFolderSelector = createSelector(
   (state: RootState) => state.main.fileMap,
@@ -34,6 +35,11 @@ export const activeResourcesSelector = createSelector(
         ((previewResource === undefined && previewValuesFile === undefined) || r.filePath.startsWith(PREVIEW_PREFIX)) &&
         !r.filePath.startsWith(CLUSTER_DIFF_PREFIX)
     )
+);
+
+export const unsavedResourcesSelector = createSelector(
+  (state: RootState) => state.main.resourceMap,
+  resourceMap => Object.values(resourceMap).filter(isUnsavedResource)
 );
 
 export const selectedResourceSelector = createSelector(


### PR DESCRIPTION
This PR resolves #991

## Changes

- It now shows a confirmation dialog when you close the window with unsaved files.

## Fixes

- none

## How to test it

- Create a new resource and be sure to use the default "Don't save".
- Close the window or quit the application.

## Screenshots

<img width="833" alt="Screenshot 2022-02-05 at 10 57 58" src="https://user-images.githubusercontent.com/7761005/152638297-e4019603-85a5-4e6c-afb6-2d848571c0c7.png">

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
