### PR TITLE
fix: ensured passing of main process env to kubeclient exec authenticator

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,7 +39,7 @@ import {downloadPlugin, loadPluginMap, updatePlugin} from './pluginService';
 import {AlertEnum, AlertType} from '@models/alert';
 import {setAlert} from '@redux/reducers/alert';
 import {checkNewVersion, runHelm, runKustomize, saveFileDialog, selectFileDialog} from '@root/electron/commands';
-import {setAppRehydrating} from '@redux/reducers/main';
+import {setAppRehydrating, setMainProcessEnv} from '@redux/reducers/main';
 import {setPluginMap, setTemplatePackMap, setTemplateMap, setExtensionsDirs} from '@redux/reducers/extension';
 import autoUpdater from './auto-update';
 import {indexOf} from 'lodash';
@@ -72,7 +72,6 @@ setProjectsRootFolder(userHomeDir);
 ipcMain.on('get-user-home-dir', event => {
   event.returnValue = userHomeDir;
 });
-
 
 ipcMain.on(DOWNLOAD_PLUGIN, async (event, pluginUrl: string) => {
   try {
@@ -344,7 +343,7 @@ export const createWindow = (givenPath?: string) => {
       };
       dispatchToWindow(win, setAlert(alert));
     }
-    win.webContents.send('executed-from', {path: givenPath});
+    win.webContents.send('executed-from', {path: givenPath });
 
     const pluginMap = await loadPluginMap(pluginsDir);
     const uniquePluginNames = Object.values(pluginMap).map((plugin) => `${plugin.repository.owner}-${plugin.repository.name}`);
@@ -364,8 +363,8 @@ export const createWindow = (givenPath?: string) => {
     dispatch(setPluginMap(pluginMap));
     dispatch(setTemplatePackMap(templatePackMap));
     dispatch(setTemplateMap(templateMap));
+    dispatch(setMainProcessEnv( PROCESS_ENV ));
     convertRecentFilesToRecentProjects(dispatch);
-
   });
 
   return win;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,7 +39,7 @@ import {downloadPlugin, loadPluginMap, updatePlugin} from './pluginService';
 import {AlertEnum, AlertType} from '@models/alert';
 import {setAlert} from '@redux/reducers/alert';
 import {checkNewVersion, runHelm, runKustomize, saveFileDialog, selectFileDialog} from '@root/electron/commands';
-import {setAppRehydrating, setMainProcessEnv} from '@redux/reducers/main';
+import {setAppRehydrating} from '@redux/reducers/main';
 import {setPluginMap, setTemplatePackMap, setTemplateMap, setExtensionsDirs} from '@redux/reducers/extension';
 import autoUpdater from './auto-update';
 import {indexOf} from 'lodash';
@@ -344,6 +344,7 @@ export const createWindow = (givenPath?: string) => {
       dispatchToWindow(win, setAlert(alert));
     }
     win.webContents.send('executed-from', {path: givenPath });
+    win.webContents.send('set-main-process-env', {mainProcessEnv: PROCESS_ENV });
 
     const pluginMap = await loadPluginMap(pluginsDir);
     const uniquePluginNames = Object.values(pluginMap).map((plugin) => `${plugin.repository.owner}-${plugin.repository.name}`);
@@ -363,7 +364,6 @@ export const createWindow = (givenPath?: string) => {
     dispatch(setPluginMap(pluginMap));
     dispatch(setTemplatePackMap(templatePackMap));
     dispatch(setTemplateMap(templateMap));
-    dispatch(setMainProcessEnv( PROCESS_ENV ));
     convertRecentFilesToRecentProjects(dispatch);
   });
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "4.7.0",
-    "@kubernetes/client-node": "0.16.1",
+    "@kubernetes/client-node": "0.16.2",
     "@reduxjs/toolkit": "1.7.1",
     "@rjsf/antd": "3.2.1",
     "@rjsf/core": "3.2.1",
@@ -103,6 +103,7 @@
     "es6-tween": "5.5.11",
     "execa": "5.1.1",
     "fast-deep-equal": "3.1.3",
+    "fix-path": "^3.0.0",
     "flat": "5.0.2",
     "jsonpath-plus": "6.0.1",
     "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "es6-tween": "5.5.11",
     "execa": "5.1.1",
     "fast-deep-equal": "3.1.3",
-    "fix-path": "^3.0.0",
     "flat": "5.0.2",
     "jsonpath-plus": "6.0.1",
     "lodash": "4.17.21",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import FileExplorer from '@components/atoms/FileExplorer';
 
 import {useFileExplorer} from '@hooks/useFileExplorer';
 
+import {setMainProcessEnv} from '@utils/env';
 import {getFileStats} from '@utils/files';
 import {useWindowSize} from '@utils/hooks';
 
@@ -151,6 +152,18 @@ const App = () => {
       ipcRenderer.removeListener('open-project', onOpenProjectFolderFromMainThread);
     };
   }, [onOpenProjectFolderFromMainThread]);
+
+  const onSetMainProcessEnv = useCallback((_: any, args: any) => {
+    setMainProcessEnv(args.mainProcessEnv);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    ipcRenderer.on('set-main-process-env', onSetMainProcessEnv);
+    return () => {
+      ipcRenderer.removeListener('set-main-process-env', onSetMainProcessEnv);
+    };
+  }, [onSetMainProcessEnv]);
 
   useDebounce(
     () => {

--- a/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
+++ b/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
@@ -15,6 +15,7 @@ import {kubeConfigContextSelector, kubeConfigPathSelector} from '@redux/selector
 
 import {useTargetClusterNamespaces} from '@hooks/useTargetClusterNamespaces';
 
+import {createKubeClient} from '@utils/kubeclient';
 import {getDefaultNamespaceForApply} from '@utils/resources';
 
 import Colors from '@styles/Colors';
@@ -60,6 +61,7 @@ const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
   const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
   const kubeConfigContext = useAppSelector(kubeConfigContextSelector);
 
+  const configState = useAppSelector(state => state.config);
   const {defaultNamespace, defaultOption} = getDefaultNamespaceForApply(resources);
   const [namespaces] = useTargetClusterNamespaces();
 
@@ -74,10 +76,8 @@ const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
         setErrorMessage('Namespace name must not be empty!');
         return;
       }
-      const kc = new k8s.KubeConfig();
-      kc.loadFromFile(kubeConfigPath);
-      kc.setCurrentContext(kubeConfigContext);
 
+      const kc = createKubeClient(configState);
       const k8sCoreV1Api = kc.makeApiClient(k8s.CoreV1Api);
 
       k8sCoreV1Api

--- a/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
+++ b/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
@@ -1,5 +1,3 @@
-import * as k8s from '@kubernetes/client-node';
-
 import {LegacyRef, useEffect, useMemo, useState} from 'react';
 import {MonacoDiffEditor} from 'react-monaco-editor';
 import {ResizableBox} from 'react-resizable';
@@ -26,6 +24,7 @@ import Icon from '@components/atoms/Icon';
 import ModalConfirmWithNamespaceSelect from '@components/molecules/ModalConfirmWithNamespaceSelect';
 
 import {useWindowSize} from '@utils/hooks';
+import {createKubeClient} from '@utils/kubeclient';
 import {KUBESHOP_MONACO_THEME} from '@utils/monaco';
 import {removeIgnoredPathsFromResourceContent} from '@utils/resources';
 
@@ -61,6 +60,7 @@ const DiffModal = () => {
   const [shouldDiffIgnorePaths, setShouldDiffIgnorePaths] = useState<boolean>(true);
   const [selectedMatchingResourceId, setSelectedMathingResourceId] = useState<string>();
   const [targetResourceText, setTargetResourceText] = useState<string>();
+  const configState = useAppSelector(state => state.config);
 
   const windowSize = useWindowSize();
 
@@ -186,9 +186,7 @@ const DiffModal = () => {
     }
 
     const getClusterResources = async () => {
-      const kc = new k8s.KubeConfig();
-      kc.loadFromFile(kubeConfigPath);
-      kc.setCurrentContext(kubeConfigContext);
+      const kc = createKubeClient(configState);
 
       const resourceKindHandler = getResourceKindHandler(targetResource.kind);
       const resourcesFromCluster =

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -195,12 +195,6 @@ function getLocalResourceMap(state: Draft<AppState>) {
   return localResourceMap;
 }
 
-let mainProcessEnv: any | undefined;
-
-export function getMainProcessEnv() {
-  return mainProcessEnv;
-}
-
 /**
  * The main reducer slice
  */
@@ -209,9 +203,6 @@ export const mainSlice = createSlice({
   name: 'main',
   initialState: initialState.main,
   reducers: {
-    setMainProcessEnv: (state: Draft<AppState>, action: PayloadAction<any>) => {
-      mainProcessEnv = action.payload;
-    },
     setAppRehydrating: (state: Draft<AppState>, action: PayloadAction<boolean>) => {
       state.isRehydrating = action.payload;
       if (!action.payload) {
@@ -1130,6 +1121,5 @@ export const {
   addMultipleKindHandlers,
   addKindHandler,
   seenNotifications,
-  setMainProcessEnv,
 } = mainSlice.actions;
 export default mainSlice.reducer;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -38,6 +38,7 @@ import {setRootFolder} from '@redux/thunks/setRootFolder';
 
 import electronStore from '@utils/electronStore';
 import {getFileStats, getFileTimestamp} from '@utils/files';
+import {createKubeClient} from '@utils/kubeclient';
 import {makeResourceNameKindNamespaceIdentifier} from '@utils/resources';
 
 import {getKnownResourceKinds, getResourceKindHandler} from '@src/kindhandlers';
@@ -194,6 +195,12 @@ function getLocalResourceMap(state: Draft<AppState>) {
   return localResourceMap;
 }
 
+let mainProcessEnv: any | undefined;
+
+export function getMainProcessEnv() {
+  return mainProcessEnv;
+}
+
 /**
  * The main reducer slice
  */
@@ -202,6 +209,9 @@ export const mainSlice = createSlice({
   name: 'main',
   initialState: initialState.main,
   reducers: {
+    setMainProcessEnv: (state: Draft<AppState>, action: PayloadAction<any>) => {
+      mainProcessEnv = action.payload;
+    },
     setAppRehydrating: (state: Draft<AppState>, action: PayloadAction<boolean>) => {
       state.isRehydrating = action.payload;
       if (!action.payload) {
@@ -437,13 +447,11 @@ export const mainSlice = createSlice({
       }
       if (state.previewType === 'cluster' && state.previewKubeConfigPath && state.previewKubeConfigContext) {
         try {
-          const kubeConfig = new k8s.KubeConfig();
-          kubeConfig.loadFromFile(state.previewKubeConfigPath);
-          kubeConfig.setCurrentContext(state.previewKubeConfigContext);
+          const kubeClient = createKubeClient(state.previewKubeConfigPath, state.previewKubeConfigContext);
 
           const kindHandler = getResourceKindHandler(resource.kind);
           if (kindHandler?.deleteResourceInCluster) {
-            kindHandler.deleteResourceInCluster(kubeConfig, resource);
+            kindHandler.deleteResourceInCluster(kubeClient, resource);
             deleteResource(resource, state.resourceMap);
           }
         } catch (err) {
@@ -1122,5 +1130,6 @@ export const {
   addMultipleKindHandlers,
   addKindHandler,
   seenNotifications,
+  setMainProcessEnv,
 } = mainSlice.actions;
 export default mainSlice.reducer;

--- a/src/redux/services/getClusterObjects.ts
+++ b/src/redux/services/getClusterObjects.ts
@@ -1,14 +1,10 @@
-import * as k8s from '@kubernetes/client-node';
+import {KubeConfig} from '@kubernetes/client-node';
 
 import {getK8sObjectsAsYaml} from '@redux/thunks/utils';
 
 import {getRegisteredKindHandlers} from '@src/kindhandlers';
 
-const getClusterObjects = (configPath: string, currentContext: string) => {
-  const kc = new k8s.KubeConfig();
-  kc.loadFromFile(configPath);
-  kc.setCurrentContext(currentContext);
-
+const getClusterObjects = async (kc: KubeConfig) => {
   return Promise.allSettled(
     getRegisteredKindHandlers().map(resourceKindHandler =>
       resourceKindHandler

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -1,5 +1,3 @@
-import * as k8s from '@kubernetes/client-node';
-
 import fs from 'fs';
 import log from 'loglevel';
 import path from 'path';
@@ -23,6 +21,7 @@ import {isKustomizationPatch, isKustomizationResource, processKustomizations} fr
 import {clearRefNodesCache, isUnsatisfiedRef, refMapperMatchesKind} from '@redux/services/resourceRefs';
 
 import {getFileTimestamp} from '@utils/files';
+import {createKubeClient} from '@utils/kubeclient';
 
 import {
   getDependentResourceKinds,
@@ -274,11 +273,8 @@ export function getNamespaces(resourceMap: ResourceMapType) {
 }
 
 export async function getTargetClusterNamespaces(kubeconfigPath: string, context: string) {
-  const kc = new k8s.KubeConfig();
-  kc.loadFromFile(kubeconfigPath);
-  kc.setCurrentContext(context);
-
-  const namespaces = await NamespaceHandler.listResourcesInCluster(kc);
+  const kubeClient = createKubeClient(kubeconfigPath, context);
+  const namespaces = await NamespaceHandler.listResourcesInCluster(kubeClient);
 
   const ns: string[] = [];
   namespaces.forEach(namespace => {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -58,5 +58,16 @@ function shellEnvSync() {
     }
   }
 }
+
+let mainProcessEnv: any | undefined;
+
+export function getMainProcessEnv() {
+  return mainProcessEnv;
+}
+
+export function setMainProcessEnv(env: any) {
+  mainProcessEnv = env;
+}
+
 export const PROCESS_ENV: any = shellEnvSync();
 export const RESOURCES_PATH = process.resourcesPath;

--- a/src/utils/kubeclient.ts
+++ b/src/utils/kubeclient.ts
@@ -16,8 +16,8 @@ export function createKubeClient(config: string | AppConfig, context?: string) {
 
   kc.loadFromFile(path);
   let currentContext =
-    context || typeof config === 'string'
-      ? undefined
+    typeof config === 'string'
+      ? context
       : config.projectConfig?.kubeConfig?.currentContext || config.kubeConfig.currentContext;
 
   if (!currentContext) {

--- a/src/utils/kubeclient.ts
+++ b/src/utils/kubeclient.ts
@@ -4,7 +4,7 @@ import log from 'loglevel';
 
 import {AppConfig} from '@models/appconfig';
 
-import {getMainProcessEnv} from '@redux/reducers/main';
+import {getMainProcessEnv} from '@utils/env';
 
 export function createKubeClient(config: string | AppConfig, context?: string) {
   const kc = new k8s.KubeConfig();

--- a/src/utils/kubeclient.ts
+++ b/src/utils/kubeclient.ts
@@ -1,0 +1,55 @@
+import * as k8s from '@kubernetes/client-node';
+
+import log from 'loglevel';
+
+import {AppConfig} from '@models/appconfig';
+
+import {getMainProcessEnv} from '@redux/reducers/main';
+
+export function createKubeClient(config: string | AppConfig, context?: string) {
+  const kc = new k8s.KubeConfig();
+
+  const path = typeof config === 'string' ? config : config.projectConfig?.kubeConfig?.path || config.kubeConfig.path;
+  if (!path) {
+    throw new Error('Missing path to kubeconfing');
+  }
+
+  kc.loadFromFile(path);
+  let currentContext =
+    context || typeof config === 'string'
+      ? undefined
+      : config.projectConfig?.kubeConfig?.currentContext || config.kubeConfig.currentContext;
+
+  if (!currentContext) {
+    currentContext = kc.currentContext;
+    log.warn(`Missing currentContext, using default in kubeconfig: ${currentContext}`);
+  } else {
+    kc.setCurrentContext(currentContext);
+  }
+
+  // find the context
+  const ctxt = kc.contexts.find(c => c.name === currentContext);
+  if (ctxt) {
+    // find the user
+    const user = kc.users.find(usr => usr.name === ctxt.user);
+
+    // does the user use the ExecAuthenticator? -> apply process env
+    if (user?.exec) {
+      const mainProcessEnv = getMainProcessEnv();
+      if (mainProcessEnv) {
+        const envValues = Object.keys(mainProcessEnv).map(k => {
+          return {name: k, value: mainProcessEnv[k]};
+        });
+        if (user.exec.env) {
+          envValues.push(...user.exec.env);
+        }
+
+        user.exec.env = envValues;
+      }
+    }
+  } else {
+    throw new Error(`Selected context ${currentContext} not found in kubeconfig at ${path}`);
+  }
+
+  return kc;
+}


### PR DESCRIPTION
This PR ensures that all kubeclient instances are created consistently - and ensures that kubeconfig users with exec authentication use the main process env for exec call

## Changes

-

## Fixes

#1285 

## How to test it

- create a context in kubeconfig that has a user that uses exec authentication (aws) - and attempt to preview this context in Monokle

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
