### PR TITLE
fix: added more properties to ignore during validation

### DIFF
--- a/src/constants/clusterResource.ts
+++ b/src/constants/clusterResource.ts
@@ -1,5 +1,10 @@
 export const CLUSTER_RESOURCE_IGNORED_PATHS = [
   '...creationTimestamp',
+  '...lastProbeTime',
+  '...finishedAt',
+  '...createdAt',
+  '...startedAt',
+  '...x_kubernetes_preserve_unknown_fields',
   'metadata#annotations#kubectl.kubernetes.io/last-applied-configuration',
   'metadata#annotations#deployment.kubernetes.io/revision',
   'metadata#resourceVersion',

--- a/src/redux/services/__test__/manifests/invalid-deployment/invalid-deployment.yaml
+++ b/src/redux/services/__test__/manifests/invalid-deployment/invalid-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     heritage: "Helm"
     release: "argocd"
     chart: redis-ha-4.12.15
+  uid:
 spec:
   strategy:
     type: null
@@ -104,3 +105,5 @@ spec:
         - name: data
           emptyDir:
             {}
+status:
+  ignored: true

--- a/src/redux/services/validation.ts
+++ b/src/redux/services/validation.ts
@@ -14,7 +14,14 @@ import {getResourceSchema} from './schema';
  * Validates the specified resource against its JSON Schema and adds validation details
  */
 
-const ignoredProperties = ['lastProbeTime', 'creationTimestamp'];
+const ignoredProperties = [
+  'lastProbeTime',
+  'creationTimestamp',
+  'finishedAt',
+  'createdAt',
+  'startedAt',
+  'x_kubernetes_preserve_unknown_fields',
+];
 const validatorCache = new Map<string, ValidateFunction>();
 
 function getErrorPosition(valueNode: ParsedNode, lineCounter: LineCounter | undefined): RefPosition | undefined {

--- a/src/redux/services/validation.ts
+++ b/src/redux/services/validation.ts
@@ -12,15 +12,22 @@ import {getResourceSchema} from './schema';
 
 /**
  * Validates the specified resource against its JSON Schema and adds validation details
+ * This overlaps with CLUSTER_RESOURCE_IGNORED_PATHS and should probably be moved into corresponding
+ * kindHandlers
  */
 
 const ignoredProperties = [
-  'lastProbeTime',
-  'creationTimestamp',
-  'finishedAt',
-  'createdAt',
-  'startedAt',
-  'x_kubernetes_preserve_unknown_fields',
+  '*lastProbeTime',
+  '*creationTimestamp',
+  '*finishedAt',
+  '*createdAt',
+  '*startedAt',
+  '*x_kubernetes_preserve_unknown_fields',
+  '/metadata/resourceVersion*',
+  '/metadata/selfLink*',
+  '/metadata/uid*',
+  '/metadata/generation*',
+  '/status*',
 ];
 const validatorCache = new Map<string, ValidateFunction>();
 
@@ -69,7 +76,15 @@ export function validateResource(resource: K8sResource) {
       if (validate.errors) {
         errors.push(
           ...validate.errors
-            .filter(err => !ignoredProperties.some(ignored => err.dataPath.endsWith(ignored)))
+            .filter(
+              err =>
+                !ignoredProperties.some(
+                  ignored =>
+                    (ignored.startsWith('*') && err.dataPath.endsWith(ignored.substring(1))) ||
+                    (ignored.endsWith('*') && err.dataPath.startsWith(ignored.substring(0, ignored.length - 1))) ||
+                    err.dataPath === ignored
+                )
+            )
             .map(err => {
               const parsedDoc = getParsedDoc(resource);
 


### PR DESCRIPTION
This PR adds the following properties to the list of ignored properties during validation:

- finishedAt
- createdAt
- startedAt
- x_kubernetes_preserve_unknown_fields

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
