### PR TITLE
refactor: create subsections for helm charts

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -13,7 +13,6 @@ interface SectionHeaderProps {
   sectionInstance: SectionInstance;
   sectionBlueprint: SectionBlueprint<any>;
   isCollapsed: boolean;
-  isCollapsedMode: 'collapsed' | 'expanded' | 'mixed';
   isLastSection: boolean;
   level: number;
   expandSection: () => void;
@@ -21,17 +20,8 @@ interface SectionHeaderProps {
 }
 
 function SectionHeader(props: SectionHeaderProps) {
-  const {
-    name,
-    sectionInstance,
-    sectionBlueprint,
-    isCollapsed,
-    isLastSection,
-    isCollapsedMode,
-    level,
-    expandSection,
-    collapseSection,
-  } = props;
+  const {name, sectionInstance, sectionBlueprint, isCollapsed, isLastSection, level, expandSection, collapseSection} =
+    props;
   const dispatch = useAppDispatch();
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
@@ -45,9 +35,19 @@ function SectionHeader(props: SectionHeaderProps) {
     }
   }, [isCollapsed, expandSection, collapseSection]);
 
-  const itemsLength = useMemo(() => {
-    return sectionInstance?.visibleDescendantItemIds?.length || 0;
-  }, [sectionInstance.visibleDescendantItemIds]);
+  const counter = useMemo(() => {
+    const counterDisplayMode = sectionBlueprint.customization?.counterDisplayMode;
+    if (!counterDisplayMode || counterDisplayMode === 'descendants') {
+      return sectionInstance?.visibleDescendantItemIds?.length || 0;
+    }
+    if (counterDisplayMode === 'items') {
+      return sectionInstance?.visibleItemIds.length;
+    }
+    if (counterDisplayMode === 'subsections') {
+      return sectionInstance?.visibleChildSectionIds?.length || 0;
+    }
+    return undefined;
+  }, [sectionInstance, sectionBlueprint]);
 
   const onCheck = useCallback(() => {
     if (!sectionInstance.checkable || !sectionInstance.visibleDescendantItemIds) {
@@ -112,9 +112,7 @@ function SectionHeader(props: SectionHeaderProps) {
             >
               {name}
             </S.Name>
-            {itemsLength > 0 && (
-              <S.ItemsLength selected={sectionInstance.isSelected && isCollapsed}>{itemsLength}</S.ItemsLength>
-            )}
+            {counter && <S.Counter selected={sectionInstance.isSelected && isCollapsed}>{counter}</S.Counter>}
             <S.BlankSpace level={level} onClick={toggleCollapse} />
             {NameSuffix.Component && NameSuffix.options?.isVisibleOnHover && isHovered && (
               <NameSuffix.Component sectionInstance={sectionInstance} />

--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -184,7 +184,6 @@ function SectionRenderer(props: SectionRendererProps) {
         sectionInstance={sectionInstance}
         sectionBlueprint={sectionBlueprint}
         isCollapsed={isCollapsed}
-        isCollapsedMode={isCollapsedMode}
         isLastSection={isLastSection}
         level={level}
         expandSection={expandSection}
@@ -218,7 +217,7 @@ function SectionRenderer(props: SectionRendererProps) {
               <S.SectionContainer style={{color: 'red'}}>
                 <S.Name $level={level + 1}>
                   {group.name}
-                  <S.ItemsLength selected={false}>{group.visibleItemIds.length}</S.ItemsLength>
+                  <S.Counter selected={false}>{group.visibleItemIds.length}</S.Counter>
                 </S.Name>
               </S.SectionContainer>
               {group.visibleItemIds.length ? (

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -124,7 +124,7 @@ export const Skeleton = styled(RawSkeleton)`
   width: 90%;
 `;
 
-export const ItemsLength = styled.span<{selected: boolean}>`
+export const Counter = styled.span<{selected: boolean}>`
   margin-left: 8px;
   font-size: 14px;
   ${props => (props.selected ? `color: ${Colors.blackPure};` : `color: ${FontColors.grey};`)}

--- a/src/components/organisms/HelmPane/HelmPane.tsx
+++ b/src/components/organisms/HelmPane/HelmPane.tsx
@@ -6,7 +6,7 @@ import {MonoPaneTitle} from '@components/atoms';
 import {SectionRenderer} from '@components/molecules';
 
 import AppContext from '@src/AppContext';
-import HelmChartSectionBlueprint from '@src/navsections/HelmChartSectionBlueprint';
+import RootHelmChartsSectionBlueprint from '@src/navsections/HelmChartSectionBlueprint';
 
 import * as S from './styled';
 
@@ -21,7 +21,7 @@ const HelmPane: React.FC = () => {
         <MonoPaneTitle>Helm</MonoPaneTitle>
       </S.TitleBar>
       <S.List id="helm-sections-container" height={navigatorHeight}>
-        <SectionRenderer sectionBlueprint={HelmChartSectionBlueprint} level={0} isLastSection={false} />
+        <SectionRenderer sectionBlueprint={RootHelmChartsSectionBlueprint} level={0} isLastSection={false} />
       </S.List>
     </span>
   );

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -28,3 +28,4 @@ export const DEFAULT_PLUGINS = [
 ];
 export const PLUGIN_DOCS_URL = 'https://kubeshop.github.io/monokle/plugins/';
 export const HELM_CHART_ENTRY_FILE = 'Chart.yaml';
+export const HELM_CHART_SECTION_NAME = 'Helm Charts';

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -63,6 +63,8 @@ export interface SectionCustomization {
   nameContext?: {
     component: SectionCustomComponent;
   };
+  /** If no value is provided, default value will be "descendants" */
+  counterDisplayMode?: 'descendants' | 'items' | 'subsections' | 'none';
   emptyGroupText?: string;
   disableHoverStyle?: boolean;
   beforeInitializationText?: string;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -1,105 +1,88 @@
-import {ROOT_FILE_ENTRY} from '@constants/constants';
+import {HELM_CHART_SECTION_NAME, ROOT_FILE_ENTRY} from '@constants/constants';
 
-import {HelmChartMapType, HelmValuesMapType} from '@models/appstate';
-import {HelmValuesFile} from '@models/helm';
+import {HelmValuesMapType} from '@models/appstate';
+import {HelmChart, HelmValuesFile} from '@models/helm';
 import {SectionBlueprint} from '@models/navigator';
 
 import {selectHelmValuesFile} from '@redux/reducers/main';
 
 import sectionBlueprintMap from '../sectionBlueprintMap';
 import HelmChartQuickAction from './HelmChartQuickAction';
-import HelmChartSectionEmptyDisplay from './HelmChartSectionEmptyDisplay';
 
-export type HelmChartScopeType = {
-  helmChartMap: HelmChartMapType;
+export type ValuesFilesScopeType = {
   helmValuesMap: HelmValuesMapType;
   previewValuesFileId: string | undefined;
   isInClusterMode: boolean;
   isFolderOpen: boolean;
-  isFolderLoading: boolean;
-  isPreviewLoading: boolean;
-  isHelmChartPreview: boolean;
 };
 
-export const HELM_CHART_SECTION_NAME = 'Helm Charts' as const;
-
-const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, HelmChartScopeType> = {
-  name: HELM_CHART_SECTION_NAME,
-  id: HELM_CHART_SECTION_NAME,
-  containerElementId: 'helm-sections-container',
-  rootSectionId: HELM_CHART_SECTION_NAME,
-  getScope: state => {
-    const kubeConfigPath = state.config.projectConfig?.kubeConfig?.path || state.config.kubeConfig.path;
-    return {
-      helmChartMap: state.main.helmChartMap,
-      helmValuesMap: state.main.helmValuesMap,
-      previewValuesFileId: state.main.previewValuesFileId,
-      isInClusterMode: kubeConfigPath
-        ? Boolean(state.main.previewResourceId && state.main.previewResourceId.endsWith(kubeConfigPath))
-        : false,
-      isFolderOpen: Boolean(state.main.fileMap[ROOT_FILE_ENTRY]),
-      isFolderLoading: state.ui.isFolderLoading,
-      isPreviewLoading: state.main.previewLoader.isLoading,
-      isHelmChartPreview: state.main.previewType === 'helm',
-    };
-  },
-  builder: {
-    getRawItems: scope => {
-      return Object.values(scope.helmValuesMap);
+export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
+  const valuesFilesSectionBlueprint: SectionBlueprint<HelmValuesFile, ValuesFilesScopeType> = {
+    name: 'Values Files',
+    id: `${helmChart.id}-values`,
+    containerElementId: 'helm-section-container',
+    rootSectionId: HELM_CHART_SECTION_NAME,
+    getScope: state => {
+      const kubeConfigPath = state.config.projectConfig?.kubeConfig?.path || state.config.kubeConfig.path;
+      return {
+        helmValuesMap: state.main.helmValuesMap,
+        isInClusterMode: kubeConfigPath
+          ? Boolean(state.main.previewResourceId && state.main.previewResourceId.endsWith(kubeConfigPath))
+          : false,
+        previewValuesFileId: state.main.previewValuesFileId,
+        isFolderOpen: Boolean(state.main.fileMap[ROOT_FILE_ENTRY]),
+      };
     },
-    getGroups: scope => {
-      return Object.values(scope.helmChartMap)
-        .map(helmChart => {
-          const helmValuesFiles = helmChart.valueFileIds
-            .map(valuesFile => scope.helmValuesMap[valuesFile])
-            .sort((a, b) => a.name.localeCompare(b.name));
-          return {id: helmChart.id, name: helmChart.name, itemIds: helmValuesFiles.map(vf => vf.id)};
-        })
-        .sort((a, b) => a.name.localeCompare(b.name));
-    },
-    isLoading: scope => {
-      if (scope.isPreviewLoading && !scope.isHelmChartPreview) {
-        return true;
-      }
-      return scope.isFolderLoading;
-    },
-    isInitialized: scope => {
-      return scope.isFolderOpen;
-    },
-    isEmpty: (scope, rawItems) => {
-      return scope.isFolderOpen && rawItems.length === 0;
-    },
-    shouldBeVisibleBeforeInitialized: true,
-  },
-  customization: {
-    emptyDisplay: {component: HelmChartSectionEmptyDisplay},
-    emptyGroupText: 'No values files found for this Chart.',
-    beforeInitializationText: 'Get started by browsing a folder in the File Explorer.',
-  },
-  itemBlueprint: {
-    getName: rawItem => rawItem.name,
-    getInstanceId: rawItem => rawItem.id,
     builder: {
-      isSelected: rawItem => {
-        return rawItem.isSelected;
+      getRawItems: scope => {
+        return helmChart.valueFileIds
+          .map(id => scope.helmValuesMap[id])
+          .filter((v): v is HelmValuesFile => v !== undefined);
       },
-      isDisabled: (rawItem, scope) =>
-        Boolean((scope.previewValuesFileId && scope.previewValuesFileId !== rawItem.id) || scope.isInClusterMode),
-    },
-    instanceHandler: {
-      onClick: (itemInstance, dispatch) => {
-        dispatch(selectHelmValuesFile({valuesFileId: itemInstance.id}));
+      isInitialized: scope => {
+        return scope.isFolderOpen;
       },
-    },
-    customization: {
-      quickAction: {
-        component: HelmChartQuickAction,
-        options: {isVisibleOnHover: true},
+      isEmpty: (scope, rawItems) => {
+        return scope.isFolderOpen && rawItems.length === 0;
       },
     },
-  },
-};
+    itemBlueprint: {
+      getName: rawItem => rawItem.name,
+      getInstanceId: rawItem => rawItem.id,
+      builder: {
+        isSelected: rawItem => {
+          return rawItem.isSelected;
+        },
+        isDisabled: (rawItem, scope) =>
+          Boolean((scope.previewValuesFileId && scope.previewValuesFileId !== rawItem.id) || scope.isInClusterMode),
+      },
+      instanceHandler: {
+        onClick: (itemInstance, dispatch) => {
+          dispatch(selectHelmValuesFile({valuesFileId: itemInstance.id}));
+        },
+      },
+      customization: {
+        quickAction: {
+          component: HelmChartQuickAction,
+          options: {isVisibleOnHover: true},
+        },
+      },
+    },
+  };
 
-sectionBlueprintMap.register(HelmChartSectionBlueprint);
+  const helmChartSectionBlueprint: SectionBlueprint<any, any> = {
+    name: helmChart.name,
+    id: helmChart.id,
+    containerElementId: 'helm-sections-container',
+    rootSectionId: HELM_CHART_SECTION_NAME,
+    childSectionIds: [valuesFilesSectionBlueprint.id],
+    getScope: () => {
+      return {};
+    },
+  };
 
-export default HelmChartSectionBlueprint;
+  sectionBlueprintMap.register(valuesFilesSectionBlueprint);
+  sectionBlueprintMap.register(helmChartSectionBlueprint);
+
+  return helmChartSectionBlueprint;
+}

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -46,6 +46,9 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
         return scope.isFolderOpen && rawItems.length === 0;
       },
     },
+    customization: {
+      counterDisplayMode: 'items',
+    },
     itemBlueprint: {
       getName: rawItem => rawItem.name,
       getInstanceId: rawItem => rawItem.id,
@@ -78,6 +81,9 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
     childSectionIds: [valuesFilesSectionBlueprint.id],
     getScope: () => {
       return {};
+    },
+    customization: {
+      counterDisplayMode: 'none',
     },
   };
 

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -1,0 +1,62 @@
+import {HELM_CHART_SECTION_NAME, ROOT_FILE_ENTRY} from '@constants/constants';
+
+import {HelmValuesFile} from '@models/helm';
+import {SectionBlueprint} from '@models/navigator';
+
+import {HelmChartEventEmitter} from '@redux/services/helm';
+
+import sectionBlueprintMap from '../sectionBlueprintMap';
+import {makeHelmChartSectionBlueprint} from './HelmChartSectionBlueprint';
+
+export type RootHelmChartsScopeType = {
+  isInClusterMode: boolean;
+  isFolderOpen: boolean;
+  isFolderLoading: boolean;
+  isPreviewLoading: boolean;
+  isHelmChartPreview: boolean;
+};
+
+const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmChartsScopeType> = {
+  name: HELM_CHART_SECTION_NAME,
+  id: HELM_CHART_SECTION_NAME,
+  containerElementId: 'helm-sections-container',
+  rootSectionId: HELM_CHART_SECTION_NAME,
+  childSectionIds: [],
+  getScope: state => {
+    const kubeConfigPath = state.config.projectConfig?.kubeConfig?.path || state.config.kubeConfig.path;
+    return {
+      isInClusterMode: kubeConfigPath
+        ? Boolean(state.main.previewResourceId && state.main.previewResourceId.endsWith(kubeConfigPath))
+        : false,
+      isFolderOpen: Boolean(state.main.fileMap[ROOT_FILE_ENTRY]),
+      isFolderLoading: state.ui.isFolderLoading,
+      isPreviewLoading: state.main.previewLoader.isLoading,
+      isHelmChartPreview: state.main.previewType === 'helm',
+    };
+  },
+  builder: {
+    isLoading: scope => {
+      if (scope.isPreviewLoading && !scope.isHelmChartPreview) {
+        return true;
+      }
+      return scope.isFolderLoading;
+    },
+    isInitialized: scope => {
+      return scope.isFolderOpen;
+    },
+    shouldBeVisibleBeforeInitialized: true,
+  },
+};
+
+sectionBlueprintMap.register(HelmChartSectionBlueprint);
+
+HelmChartEventEmitter.on('create', helmChart => {
+  const newHelmChartSectionBlueprint = makeHelmChartSectionBlueprint(helmChart);
+  if (HelmChartSectionBlueprint.childSectionIds) {
+    HelmChartSectionBlueprint.childSectionIds?.push(newHelmChartSectionBlueprint.id);
+  } else {
+    HelmChartSectionBlueprint.childSectionIds = [newHelmChartSectionBlueprint.id];
+  }
+});
+
+export default HelmChartSectionBlueprint;

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -46,6 +46,9 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmCharts
     },
     shouldBeVisibleBeforeInitialized: true,
   },
+  customization: {
+    counterDisplayMode: 'subsections',
+  },
 };
 
 sectionBlueprintMap.register(HelmChartSectionBlueprint);

--- a/src/navsections/HelmChartSectionBlueprint/index.ts
+++ b/src/navsections/HelmChartSectionBlueprint/index.ts
@@ -1,2 +1,3 @@
-export {default, HELM_CHART_SECTION_NAME} from './HelmChartSectionBlueprint';
-export type {HelmChartScopeType} from './HelmChartSectionBlueprint';
+export {default} from './RootHelmChartsSectionBlueprint';
+export {makeHelmChartSectionBlueprint} from './HelmChartSectionBlueprint';
+export {HELM_CHART_SECTION_NAME} from '@constants/constants';

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -224,7 +224,7 @@ const processSectionBlueprints = async (state: RootState, dispatch: AppDispatch)
     const hasSectionScopeChanged = Object.entries(isChangedByScopeKey).some(
       ([key, value]) => sectionScopeKeys.includes(key) && value === true
     );
-    if (!hasSectionScopeChanged) {
+    if (!hasSectionScopeChanged && sectionScopeKeys.length > 0) {
       log.debug(`Section ${sectionBlueprint.id} scope did not change`);
       return;
     }

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -13,6 +13,7 @@ import {HelmChart, HelmValuesFile} from '@models/helm';
 import {K8sResource} from '@models/k8sresource';
 
 import {
+  HelmChartEventEmitter,
   getHelmChartFromFileEntry,
   getHelmValuesFile,
   isHelmChartFolder,
@@ -382,6 +383,7 @@ function addFile(absolutePath: string, state: AppState, appConfig: AppConfig) {
       valueFileIds: [],
     };
     state.helmChartMap[helmChart.id] = helmChart;
+    HelmChartEventEmitter.emit('create', helmChart);
 
     parentFolderEntry?.children?.forEach(fileName => {
       if (!parentFolderEntry) {

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -1,3 +1,4 @@
+import {EventEmitter} from 'events';
 import log from 'loglevel';
 import micromatch from 'micromatch';
 import path from 'path';
@@ -14,6 +15,8 @@ import {K8sResource} from '@models/k8sresource';
 import {createFileEntry, extractK8sResourcesFromFile, fileIsExcluded, readFiles} from '@redux/services/fileEntry';
 
 import {getFileStats} from '@utils/files';
+
+export const HelmChartEventEmitter = new EventEmitter();
 
 /**
  * Gets the HelmValuesFile for a specific FileEntry
@@ -80,6 +83,7 @@ export function processHelmChartFolder(
     name: folder.substr(folder.lastIndexOf(path.sep) + 1),
     valueFileIds: [],
   };
+  HelmChartEventEmitter.emit('create', helmChart);
 
   files.forEach(file => {
     const filePath = path.join(folder, file);


### PR DESCRIPTION
In this PR I've created a "Values Files" subsection for each helm chart as a starting point for this issue - https://github.com/kubeshop/monokle/issues/586

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/153442661-66fdd788-bbd1-4f5b-8e60-c7d101df47e1.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
