### PR TITLE
show Chart.yaml, improve helm pane styling and section blueprint functionality

### DIFF
--- a/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/ItemRenderer.tsx
@@ -24,11 +24,13 @@ export type ItemRendererProps<ItemType, ScopeType> = {
   isLastItem: boolean;
   isSectionCheckable: boolean;
   sectionContainerElementId: string;
+  indentation: number;
   options?: ItemRendererOptions;
 };
 
 function ItemRenderer<ItemType, ScopeType>(props: ItemRendererProps<ItemType, ScopeType>) {
-  const {itemId, blueprint, level, isLastItem, isSectionCheckable, sectionContainerElementId, options} = props;
+  const {itemId, blueprint, level, isLastItem, isSectionCheckable, sectionContainerElementId, indentation, options} =
+    props;
   const {instanceHandler} = blueprint;
 
   const dispatch = useAppDispatch();
@@ -80,6 +82,7 @@ function ItemRenderer<ItemType, ScopeType>(props: ItemRendererProps<ItemType, Sc
         level={level}
         isLastItem={isLastItem}
         hasOnClick={Boolean(instanceHandler?.onClick)}
+        $indentation={indentation}
         $isSectionCheckable={isSectionCheckable}
         $hasCustomNameDisplay={Boolean(NameDisplay.Component)}
       >

--- a/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/ItemRenderer/styled.tsx
@@ -12,6 +12,7 @@ type ItemContainerProps = {
   level: number;
   isLastItem: boolean;
   hasOnClick: boolean;
+  $indentation: number;
   $isSectionCheckable: boolean;
   $hasCustomNameDisplay: boolean;
 };
@@ -21,7 +22,10 @@ export const ItemContainer = styled.span<ItemContainerProps>`
   align-items: center;
   width: 100%;
   user-select: none;
-  padding-left: ${props => (props.$isSectionCheckable ? '32px;' : '26px;')}
+  ${props => {
+    const defaultIndentation = props.$isSectionCheckable ? 32 : 26;
+    return `padding-left: ${defaultIndentation + props.$indentation}px;`;
+  }}
   padding-right: 8px;
   margin-bottom: 2px;
   ${props => props.hasOnClick && `cursor: pointer;`}

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -91,7 +91,6 @@ function SectionHeader(props: SectionHeaderProps) {
       <S.NameContainer
         isHovered={isHovered}
         isCheckable={Boolean(sectionBlueprint.builder?.makeCheckable)}
-        $nameColor={sectionBlueprint.customization?.nameColor}
         $hasCustomNameDisplay={Boolean(NameDisplay.Component)}
         $indentation={indentation}
       >
@@ -119,6 +118,7 @@ function SectionHeader(props: SectionHeaderProps) {
               $isSelected={sectionInstance.isSelected && isCollapsed}
               $isHighlighted={sectionInstance.isSelected && isCollapsed}
               $isCheckable={Boolean(sectionInstance.checkable)}
+              $nameColor={sectionBlueprint.customization?.nameColor}
               $level={level}
               onClick={toggleCollapse}
             >

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -15,13 +15,23 @@ interface SectionHeaderProps {
   isCollapsed: boolean;
   isLastSection: boolean;
   level: number;
+  indentation: number;
   expandSection: () => void;
   collapseSection: () => void;
 }
 
 function SectionHeader(props: SectionHeaderProps) {
-  const {name, sectionInstance, sectionBlueprint, isCollapsed, isLastSection, level, expandSection, collapseSection} =
-    props;
+  const {
+    name,
+    sectionInstance,
+    sectionBlueprint,
+    isCollapsed,
+    isLastSection,
+    level,
+    indentation,
+    expandSection,
+    collapseSection,
+  } = props;
   const dispatch = useAppDispatch();
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
@@ -82,6 +92,7 @@ function SectionHeader(props: SectionHeaderProps) {
         isHovered={isHovered}
         isCheckable={Boolean(sectionBlueprint.builder?.makeCheckable)}
         $hasCustomNameDisplay={Boolean(NameDisplay.Component)}
+        $indentation={indentation}
       >
         {sectionInstance.checkable &&
           sectionInstance.isInitialized &&

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -91,6 +91,7 @@ function SectionHeader(props: SectionHeaderProps) {
       <S.NameContainer
         isHovered={isHovered}
         isCheckable={Boolean(sectionBlueprint.builder?.makeCheckable)}
+        $nameColor={sectionBlueprint.customization?.nameColor}
         $hasCustomNameDisplay={Boolean(NameDisplay.Component)}
         $indentation={indentation}
       >

--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -219,7 +219,7 @@ function SectionRenderer(props: SectionRendererProps) {
             itemId={itemId}
             blueprint={itemBlueprint}
             level={level + 1}
-            isLastItem={isLastVisibleItemId(itemId)}
+            isLastItem={isLastVisibleItemId(itemId) && !childSectionIds}
             isSectionCheckable={Boolean(sectionInstance.checkable)}
             sectionContainerElementId={sectionBlueprint.containerElementId}
             options={itemRendererOptions}

--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -17,11 +17,12 @@ type SectionRendererProps = {
   sectionBlueprint: SectionBlueprint<any>;
   level: number;
   isLastSection: boolean;
+  parentIndentation?: number;
   itemRendererOptions?: ItemRendererOptions;
 };
 
 function SectionRenderer(props: SectionRendererProps) {
-  const {sectionBlueprint, level, isLastSection, itemRendererOptions} = props;
+  const {sectionBlueprint, level, isLastSection, itemRendererOptions, parentIndentation} = props;
 
   const {itemBlueprint, name: sectionName, id: sectionId} = sectionBlueprint;
 
@@ -45,6 +46,23 @@ function SectionRenderer(props: SectionRendererProps) {
   const {EmptyDisplay} = useSectionCustomization(sectionBlueprint.customization);
 
   const collapsedSectionIds = useAppSelector(state => state.navigator.collapsedSectionIds);
+
+  const sectionIndentation = useMemo(() => {
+    const indentation = sectionBlueprint.customization?.indentation;
+    if (!parentIndentation && !indentation) {
+      return undefined;
+    }
+    if (parentIndentation && !indentation) {
+      return parentIndentation;
+    }
+    if (!parentIndentation && indentation) {
+      return indentation;
+    }
+    if (parentIndentation && indentation) {
+      return parentIndentation + indentation;
+    }
+    return undefined;
+  }, [parentIndentation, sectionBlueprint.customization?.indentation]);
 
   const isCollapsedMode = useMemo(() => {
     if (!sectionInstance?.id) {
@@ -188,6 +206,7 @@ function SectionRenderer(props: SectionRendererProps) {
         level={level}
         expandSection={expandSection}
         collapseSection={collapseSection}
+        indentation={sectionIndentation || 0}
       />
       {sectionInstance &&
         sectionInstance.isVisible &&
@@ -204,6 +223,7 @@ function SectionRenderer(props: SectionRendererProps) {
             isSectionCheckable={Boolean(sectionInstance.checkable)}
             sectionContainerElementId={sectionBlueprint.containerElementId}
             options={itemRendererOptions}
+            indentation={sectionIndentation || 0}
           />
         ))}
       {sectionInstance?.isVisible &&
@@ -231,6 +251,7 @@ function SectionRenderer(props: SectionRendererProps) {
                     isSectionCheckable={Boolean(sectionInstance.checkable)}
                     sectionContainerElementId={sectionBlueprint.containerElementId}
                     options={itemRendererOptions}
+                    indentation={sectionIndentation || 0}
                   />
                 ))
               ) : (
@@ -248,6 +269,7 @@ function SectionRenderer(props: SectionRendererProps) {
             sectionBlueprint={child}
             level={level + 1}
             isLastSection={child.id === lastVisibleChildSectionId}
+            parentIndentation={sectionIndentation}
           />
         ))}
     </>

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -8,6 +8,7 @@ type NameContainerProps = {
   isHovered?: boolean;
   isCheckable?: boolean;
   $hasCustomNameDisplay: boolean;
+  $indentation: number;
 };
 
 type SectionContainerProps = {
@@ -28,7 +29,10 @@ export const NameContainer = styled.span<NameContainerProps>`
   display: flex;
   align-items: center;
   width: 100%;
-  ${props => props.isCheckable && `padding-left: 24px;`}
+  ${props => {
+    const defaultIndentation = props.isCheckable ? 24 : 0;
+    return `padding-left: ${defaultIndentation + props.$indentation}px;`;
+  }}
   ${props => !props.isHovered && 'padding-right: 30px;'}
   ${props => props.$hasCustomNameDisplay && 'padding: 0;'}
 `;

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -5,10 +5,11 @@ import styled from 'styled-components';
 import Colors, {FontColors} from '@styles/Colors';
 
 type NameContainerProps = {
-  isHovered?: boolean;
-  isCheckable?: boolean;
   $hasCustomNameDisplay: boolean;
   $indentation: number;
+  isHovered?: boolean;
+  isCheckable?: boolean;
+  $nameColor?: string;
 };
 
 type SectionContainerProps = {
@@ -35,6 +36,7 @@ export const NameContainer = styled.span<NameContainerProps>`
   }}
   ${props => !props.isHovered && 'padding-right: 30px;'}
   ${props => props.$hasCustomNameDisplay && 'padding: 0;'}
+  ${props => props.$nameColor && `color: ${props.$nameColor};`}
 `;
 
 export const SectionContainer = styled.li<SectionContainerProps>`

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -9,7 +9,6 @@ type NameContainerProps = {
   $indentation: number;
   isHovered?: boolean;
   isCheckable?: boolean;
-  $nameColor?: string;
 };
 
 type SectionContainerProps = {
@@ -36,7 +35,6 @@ export const NameContainer = styled.span<NameContainerProps>`
   }}
   ${props => !props.isHovered && 'padding-right: 30px;'}
   ${props => props.$hasCustomNameDisplay && 'padding: 0;'}
-  ${props => props.$nameColor && `color: ${props.$nameColor};`}
 `;
 
 export const SectionContainer = styled.li<SectionContainerProps>`
@@ -86,6 +84,7 @@ type NameProps = {
   $isHighlighted?: boolean;
   $isCheckable?: boolean;
   $level: number;
+  $nameColor?: string;
 };
 
 export const Name = styled.span<NameProps>`
@@ -110,7 +109,7 @@ export const Name = styled.span<NameProps>`
     if (props.$isSelected) {
       return `color: ${Colors.blackPure};`;
     }
-    return `color: ${Colors.whitePure};`;
+    return props.$nameColor ? `color: ${props.$nameColor}` : `color: ${Colors.whitePure};`;
   }}
 `;
 

--- a/src/components/organisms/PaneManager/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton.tsx
@@ -55,10 +55,6 @@ const MenuButton: React.FC<IMenuButtonProps> = props => {
     shallowEqual
   );
 
-  const isAnyHelmValuesFileSelected = useMemo(() => {
-    return Object.values(helmValuesMap).some(v => v.isSelected);
-  }, [helmValuesMap]);
-
   const isAnySectionSelected = useMemo(() => {
     if (!sectionInstanceByName) {
       return false;
@@ -69,11 +65,8 @@ const MenuButton: React.FC<IMenuButtonProps> = props => {
   const style: React.CSSProperties = {};
 
   const hasGradientBackground = useMemo(() => {
-    return Boolean(
-      (isAnySectionSelected || (shouldWatchSelectedPath && selectedPath && !isAnyHelmValuesFileSelected)) &&
-        (!isSelected || !isActive)
-    );
-  }, [isAnySectionSelected, shouldWatchSelectedPath, selectedPath, isAnyHelmValuesFileSelected, isSelected, isActive]);
+    return Boolean((isAnySectionSelected || (shouldWatchSelectedPath && selectedPath)) && (!isSelected || !isActive));
+  }, [isAnySectionSelected, shouldWatchSelectedPath, selectedPath, isSelected, isActive]);
 
   if (hasGradientBackground) {
     if (isHovered) {

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -65,6 +65,8 @@ export interface SectionCustomization {
   };
   /** If no value is provided, default value will be "descendants" */
   counterDisplayMode?: 'descendants' | 'items' | 'subsections' | 'none';
+  /** Number of pixels to indent this section, by default all sections/susections are aligned */
+  indentation?: number;
   emptyGroupText?: string;
   disableHoverStyle?: boolean;
   beforeInitializationText?: string;

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -67,6 +67,7 @@ export interface SectionCustomization {
   counterDisplayMode?: 'descendants' | 'items' | 'subsections' | 'none';
   /** Number of pixels to indent this section, by default all sections/susections are aligned */
   indentation?: number;
+  nameColor?: string;
   emptyGroupText?: string;
   disableHoverStyle?: boolean;
   beforeInitializationText?: string;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -6,6 +6,8 @@ import {SectionBlueprint} from '@models/navigator';
 
 import {selectFile, selectHelmValuesFile} from '@redux/reducers/main';
 
+import Colors from '@styles/Colors';
+
 import sectionBlueprintMap from '../sectionBlueprintMap';
 import HelmChartQuickAction from './HelmChartQuickAction';
 
@@ -56,6 +58,7 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
     customization: {
       counterDisplayMode: 'items',
       indentation: 8,
+      nameColor: Colors.grey400,
     },
     itemBlueprint: {
       getName: rawItem => rawItem.name,

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -55,6 +55,7 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
     },
     customization: {
       counterDisplayMode: 'items',
+      indentation: 8,
     },
     itemBlueprint: {
       getName: rawItem => rawItem.name,
@@ -128,6 +129,7 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
     },
     customization: {
       counterDisplayMode: 'none',
+      indentation: 8,
     },
   };
 


### PR DESCRIPTION
This PR...

## Changes

- added Chart.yaml as an item directly under the helm chart
- slightly changed the color "Values Files" subsection
- added indentation to it's easier to see where each subsection is 

## Fixes

-

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/20538711/153875515-9be4915f-e83c-4325-81ad-4a40cf3051ad.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
