### PR TITLE
Helm and Kustomize panes fixes

### DIFF
--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -8,7 +8,6 @@ import {selectFile, selectHelmValuesFile} from '@redux/reducers/main';
 
 import Colors from '@styles/Colors';
 
-import sectionBlueprintMap from '../sectionBlueprintMap';
 import HelmChartQuickAction from './HelmChartQuickAction';
 
 export type ValuesFilesScopeType = {
@@ -136,8 +135,5 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
     },
   };
 
-  sectionBlueprintMap.register(valuesFilesSectionBlueprint);
-  sectionBlueprintMap.register(helmChartSectionBlueprint);
-
-  return helmChartSectionBlueprint;
+  return {helmChartSectionBlueprint, valuesFilesSectionBlueprint};
 }

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionEmptyDisplay.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionEmptyDisplay.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function HelmChartSectionEmptyDisplay() {
-  return <p style={{paddingTop: 16}}>No Helm Charts found in the current folder.</p>;
-}
-
-export default HelmChartSectionEmptyDisplay;

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -18,7 +18,7 @@ export type RootHelmChartsScopeType = {
   helmChartsLength: number;
 };
 
-const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmChartsScopeType> = {
+const RootHelmChartsSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmChartsScopeType> = {
   name: HELM_CHART_SECTION_NAME,
   id: HELM_CHART_SECTION_NAME,
   containerElementId: 'helm-sections-container',
@@ -60,15 +60,17 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmCharts
   },
 };
 
-sectionBlueprintMap.register(HelmChartSectionBlueprint);
+sectionBlueprintMap.register(RootHelmChartsSectionBlueprint);
 
 HelmChartEventEmitter.on('create', helmChart => {
-  const newHelmChartSectionBlueprint = makeHelmChartSectionBlueprint(helmChart);
-  if (HelmChartSectionBlueprint.childSectionIds) {
-    HelmChartSectionBlueprint.childSectionIds?.push(newHelmChartSectionBlueprint.id);
+  const {valuesFilesSectionBlueprint, helmChartSectionBlueprint} = makeHelmChartSectionBlueprint(helmChart);
+  if (RootHelmChartsSectionBlueprint.childSectionIds) {
+    RootHelmChartsSectionBlueprint.childSectionIds?.push(helmChartSectionBlueprint.id);
   } else {
-    HelmChartSectionBlueprint.childSectionIds = [newHelmChartSectionBlueprint.id];
+    RootHelmChartsSectionBlueprint.childSectionIds = [helmChartSectionBlueprint.id];
   }
+  sectionBlueprintMap.register(valuesFilesSectionBlueprint);
+  sectionBlueprintMap.register(helmChartSectionBlueprint);
 });
 
-export default HelmChartSectionBlueprint;
+export default RootHelmChartsSectionBlueprint;

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -7,6 +7,7 @@ import {HelmChartEventEmitter} from '@redux/services/helm';
 
 import sectionBlueprintMap from '../sectionBlueprintMap';
 import {makeHelmChartSectionBlueprint} from './HelmChartSectionBlueprint';
+import RootHelmChartsSectionEmptyDisplay from './RootHelmChartsSectionEmptyDisplay';
 
 export type RootHelmChartsScopeType = {
   isInClusterMode: boolean;
@@ -14,6 +15,7 @@ export type RootHelmChartsScopeType = {
   isFolderLoading: boolean;
   isPreviewLoading: boolean;
   isHelmChartPreview: boolean;
+  helmChartsLength: number;
 };
 
 const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmChartsScopeType> = {
@@ -32,6 +34,7 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmCharts
       isFolderLoading: state.ui.isFolderLoading,
       isPreviewLoading: state.main.previewLoader.isLoading,
       isHelmChartPreview: state.main.previewType === 'helm',
+      helmChartsLength: Object.values(state.main.helmChartMap).length,
     };
   },
   builder: {
@@ -44,10 +47,16 @@ const HelmChartSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmCharts
     isInitialized: scope => {
       return scope.isFolderOpen;
     },
+    isEmpty: scope => {
+      return scope.helmChartsLength === 0;
+    },
     shouldBeVisibleBeforeInitialized: true,
   },
   customization: {
     counterDisplayMode: 'subsections',
+    emptyDisplay: {
+      component: RootHelmChartsSectionEmptyDisplay,
+    },
   },
 };
 

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionEmptyDisplay.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionEmptyDisplay.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function RootHelmChartsSectionEmptyDisplay() {
+  return <p style={{paddingTop: 16}}>No Helm Charts found in the current project.</p>;
+}
+
+export default RootHelmChartsSectionEmptyDisplay;

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
@@ -75,6 +75,7 @@ const KustomizationSectionBlueprint: SectionBlueprint<K8sResource, Kustomization
       component: KustomizationSectionEmptyDisplay,
     },
     beforeInitializationText: 'Get started by browsing a folder in the File Explorer.',
+    counterDisplayMode: 'items',
   },
   itemBlueprint: {
     getName: rawItem => rawItem.name,

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationSectionEmptyDisplay.tsx
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationSectionEmptyDisplay.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function KustomizationSectionEmptyDisplay() {
-  return <p style={{paddingTop: 16}}>No Kustomizations found in the current folder.</p>;
+  return <p style={{paddingTop: 16}}>No Kustomizations found in the current project.</p>;
 }
 
 export default KustomizationSectionEmptyDisplay;


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- kustomizations items count
- helm chart not visible when it's only one in a project
- empty displays for both kustomize/helm sections

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
