### PR TITLE
fix: update helm chart name on file change

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionRenderer.tsx
+++ b/src/components/molecules/SectionRenderer/SectionRenderer.tsx
@@ -24,7 +24,7 @@ type SectionRendererProps = {
 function SectionRenderer(props: SectionRendererProps) {
   const {sectionBlueprint, level, isLastSection, itemRendererOptions, parentIndentation} = props;
 
-  const {itemBlueprint, name: sectionName, id: sectionId} = sectionBlueprint;
+  const {itemBlueprint, id: sectionId} = sectionBlueprint;
 
   const sectionInstance: SectionInstance | undefined = useAppSelector(
     state => state.navigator.sectionInstanceMap[sectionId]
@@ -189,7 +189,7 @@ function SectionRenderer(props: SectionRendererProps) {
     }
     return (
       <S.EmptyDisplayContainer level={level}>
-        <h1>{sectionBlueprint.name}</h1>
+        <h1>{sectionInstance.name}</h1>
         <p>Section is empty.</p>
       </S.EmptyDisplayContainer>
     );
@@ -198,7 +198,7 @@ function SectionRenderer(props: SectionRendererProps) {
   return (
     <>
       <SectionHeader
-        name={sectionName}
+        name={sectionInstance.name}
         sectionInstance={sectionInstance}
         sectionBlueprint={sectionBlueprint}
         isCollapsed={isCollapsed}

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -101,13 +101,14 @@ export interface ItemGroupBlueprint {
 }
 
 export interface SectionBlueprint<RawItemType, ScopeType = any> {
-  name: string;
   id: string;
+  name: string;
   getScope: (state: RootState) => ScopeType;
   containerElementId: string;
   rootSectionId: string;
   childSectionIds?: string[];
   builder?: {
+    transformName?: (originalName: string, scope: ScopeType) => string;
     getRawItems?: (scope: ScopeType) => RawItemType[];
     getGroups?: (scope: ScopeType) => ItemGroupBlueprint[];
     getMeta?: (scope: ScopeType, items: RawItemType[]) => any;
@@ -148,6 +149,7 @@ export interface ItemInstance {
 
 export interface SectionInstance {
   id: string;
+  name: string;
   rootSectionId: string;
   itemIds: string[];
   groups: ItemGroupInstance[];

--- a/src/navsections/sectionBlueprintMiddleware.ts
+++ b/src/navsections/sectionBlueprintMiddleware.ts
@@ -288,6 +288,9 @@ const processSectionBlueprints = async (state: RootState, dispatch: AppDispatch)
           .value();
     const sectionInstance: SectionInstance = {
       id: sectionBlueprint.id,
+      name: sectionBuilder?.transformName
+        ? sectionBuilder.transformName(sectionBlueprint.name, sectionScope)
+        : sectionBlueprint.name,
       rootSectionId: sectionBlueprint.rootSectionId,
       itemIds: itemInstances?.map(i => i.id) || [],
       groups: sectionInstanceGroups,

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -7,9 +7,9 @@ import fs from 'fs';
 import log from 'loglevel';
 import path from 'path';
 import {v4 as uuidv4} from 'uuid';
-import {parseDocument} from 'yaml';
+import {parse, parseDocument} from 'yaml';
 
-import {CLUSTER_DIFF_PREFIX, PREVIEW_PREFIX, ROOT_FILE_ENTRY} from '@constants/constants';
+import {CLUSTER_DIFF_PREFIX, HELM_CHART_ENTRY_FILE, PREVIEW_PREFIX, ROOT_FILE_ENTRY} from '@constants/constants';
 
 import {AlertType} from '@models/alert';
 import {AppConfig} from '@models/appconfig';
@@ -288,31 +288,51 @@ export const mainSlice = createSlice({
             fs.writeFileSync(filePath, action.payload.content);
             fileEntry.timestamp = getFileTimestamp(filePath);
 
-            getResourcesForPath(fileEntry.filePath, state.resourceMap).forEach(r => {
-              deleteResource(r, state.resourceMap);
-            });
+            if (path.basename(fileEntry.filePath) === HELM_CHART_ENTRY_FILE) {
+              try {
+                const helmChart = Object.values(state.helmChartMap).find(
+                  chart => chart.filePath === fileEntry.filePath
+                );
+                if (!helmChart) {
+                  throw new Error(`Couldn't find the helm chart for path: ${fileEntry.filePath}`);
+                }
+                const fileContent = parse(action.payload.content);
+                if (typeof fileContent?.name !== 'string') {
+                  throw new Error(`Couldn't get the name property of the helm chart at path: ${fileEntry.filePath}`);
+                }
+                helmChart.name = fileContent.name;
+              } catch (e) {
+                if (e instanceof Error) {
+                  log.warn(`[updateFileEntry]: ${e.message}`);
+                }
+              }
+            } else {
+              getResourcesForPath(fileEntry.filePath, state.resourceMap).forEach(r => {
+                deleteResource(r, state.resourceMap);
+              });
 
-            const extractedResources = extractK8sResources(
-              action.payload.content,
-              filePath.substring(rootFolder.length)
-            );
+              const extractedResources = extractK8sResources(
+                action.payload.content,
+                filePath.substring(rootFolder.length)
+              );
 
-            let resourceIds: string[] = [];
+              let resourceIds: string[] = [];
 
-            // only recalculate refs for resources that already have refs
-            Object.values(state.resourceMap)
-              .filter(r => r.refs)
-              .forEach(r => resourceIds.push(r.id));
+              // only recalculate refs for resources that already have refs
+              Object.values(state.resourceMap)
+                .filter(r => r.refs)
+                .forEach(r => resourceIds.push(r.id));
 
-            Object.values(extractedResources).forEach(r => {
-              state.resourceMap[r.id] = r;
-              r.isHighlighted = true;
-              resourceIds.push(r.id);
-            });
+              Object.values(extractedResources).forEach(r => {
+                state.resourceMap[r.id] = r;
+                r.isHighlighted = true;
+                resourceIds.push(r.id);
+              });
 
-            reprocessResources(resourceIds, state.resourceMap, state.fileMap, state.resourceRefsProcessingOptions, {
-              resourceKinds: extractedResources.map(r => r.kind),
-            });
+              reprocessResources(resourceIds, state.resourceMap, state.fileMap, state.resourceRefsProcessingOptions, {
+                resourceKinds: extractedResources.map(r => r.kind),
+              });
+            }
           }
         } else {
           log.error(`Could not find FileEntry for ${action.payload.path}`);


### PR DESCRIPTION
This PR...

## Changes

- added new `transformName` method to the section blueprint builder

## Fixes

- reactivity of helm chart section name
- get helm chart name from the file
- update helm chart name when file is updated within Monokle or externally

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
