### PR TITLE
Change "ConfigMap Properties Form" to generic "Kubernetes Resources Properties Form"

### DIFF
--- a/docs/form-editor.md
+++ b/docs/form-editor.md
@@ -1,12 +1,12 @@
 # Using the Form Editor
 
-## **Using the Resources Properties Form**
+## **Edit Resources Properties via Form**
 
-Monokle shows properties for Kubernetes resources:
+Monokle shows properties for diverse Kubernetes resources. These resources are identified according to the official Kubernetes API definitions. If it's defined here, Monokle will find it, and allow you to edit it.
 
 ![Form Editor](img/form-editor-1.5.0.png)
 
-For example, clicking "ConfigMap" at the top of the Editor opens the  form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
+For example, clicking on "Form" at the top of the Editor, opens the form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
 are written back to the underlying YAML. 
 
 ## **Using the Object Metadata Editor**

--- a/docs/form-editor.md
+++ b/docs/form-editor.md
@@ -6,7 +6,7 @@ Monokle shows properties for diverse Kubernetes resources. These resources are i
 
 ![Form Editor](img/form-editor-1.5.0.png)
 
-For example, clicking on "Form" at the top of the Editor, opens the form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
+For example in the case of a ConfigMap Kubernetes resource, clicking on "Form" at the top of the Editor, opens the form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
 are written back to the underlying YAML. 
 
 ## **Using the Object Metadata Editor**

--- a/docs/form-editor.md
+++ b/docs/form-editor.md
@@ -1,12 +1,12 @@
 # Using the Form Editor
 
-## **Using the ConfigMap Properties Form**
+## **Using the Resources Properties Form**
 
-Monokle shows properties for ConfigMap resources:
+Monokle shows properties for Kubernetes resources:
 
 ![Form Editor](img/form-editor-1.5.0.png)
 
-Clicking "ConfigMap" at the top of the Editor opens the  form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
+For example, clicking "ConfigMap" at the top of the Editor opens the  form fields editor for key ConfigMap properties, allowing you to edit/discover all available properties without having to learn or lookup the corresponding YAML/resource documentation. Any changes made and saved (with the Save button on the top right)
 are written back to the underlying YAML. 
 
 ## **Using the Object Metadata Editor**

--- a/docs/form-editor.md
+++ b/docs/form-editor.md
@@ -2,7 +2,7 @@
 
 ## **Edit Resources Properties via Form**
 
-Monokle shows properties for diverse Kubernetes resources. These resources are identified according to the official Kubernetes API definitions. If it's defined here, Monokle will find it, and allow you to edit it.
+Monokle shows form editors for diverse Kubernetes resources which allows you to interactively change the specification of your resources using visual controls/inputs.
 
 ![Form Editor](img/form-editor-1.5.0.png)
 

--- a/docs/form-editor.md
+++ b/docs/form-editor.md
@@ -18,4 +18,4 @@ To launch the Metadata Editor, click on the **Metadata** button.
 For editing object metadata, you need to provide a specific name, namespace, annotations, labels, cluster name, generate name, and finalizers to uniquely identify the object.  
 
 **Check out [this tutorial](tutorials/how-to-create-and-edit-configmap.md) for more details 
-on how to use the Form Editor for ConfigMaps and Metadata.**
+on how to use the Form Editor and Metadata.**

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -494,12 +494,7 @@ const ActionsPane: React.FC<IProps> = props => {
 
           {schemaForSelectedPath ||
           (selectedResource && (isKustomization || resourceKindHandler?.formEditorOptions?.editorSchema)) ? (
-            <TabPane
-              key="form"
-              tab={
-                <TabHeader icon={<ContainerOutlined />}>{selectedResource ? selectedResource.kind : 'Form'}</TabHeader>
-              }
-            >
+            <TabPane key="form" tab={<TabHeader icon={<ContainerOutlined />}>Form</TabHeader>}>
               {isFolderLoading || previewLoader.isLoading ? (
                 <S.Skeleton active />
               ) : activeTabKey === 'form' ? (


### PR DESCRIPTION
This PR...

## Changes

Updated to read Kubernetes resources instead of a dedicated ConfigMap's resource editor form.
## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
