### PR TITLE
Now we can trigger contextmenu on file explorer section by right-clicking on tree items

### DIFF
--- a/src/components/molecules/ContextMenu/ContextMenu.tsx
+++ b/src/components/molecules/ContextMenu/ContextMenu.tsx
@@ -2,13 +2,14 @@ import {Dropdown} from 'antd';
 
 interface ContextMenuProps {
   overlay: React.ReactElement;
+  triggerOnRightClick?: boolean;
 }
 
 const ContextMenu: React.FC<ContextMenuProps> = props => {
-  const {overlay, children} = props;
+  const {overlay, children, triggerOnRightClick = false} = props;
 
   return (
-    <Dropdown overlay={overlay} trigger={['click']} placement="bottomCenter">
+    <Dropdown overlay={overlay} trigger={triggerOnRightClick ? ['contextMenu'] : ['click']} placement="bottomCenter">
       {children}
     </Dropdown>
   );

--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -250,41 +250,45 @@ const TreeItem: React.FC<TreeItemProps> = props => {
   );
 
   return (
-    <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
-      <S.TitleWrapper>
-        <S.TreeTitleText>{title}</S.TreeTitleText>
-        {canPreview(relativePath) && <EyeOutlined style={{color: isFileSelected ? Colors.blackPure : Colors.grey7}} />}
-      </S.TitleWrapper>
-      {processingEntity.processingEntityID === treeKey && processingEntity.processingType === 'delete' && (
-        <S.SpinnerWrapper>
-          <Spinner />
-        </S.SpinnerWrapper>
-      )}
-      {isTitleHovered && !processingEntity.processingType ? (
-        <S.ActionsWrapper>
+    <ContextMenu overlay={menu} triggerOnRightClick>
+      <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
+        <S.TitleWrapper>
+          <S.TreeTitleText>{title}</S.TreeTitleText>
           {canPreview(relativePath) && (
-            <S.PreviewButton
-              type="text"
-              size="small"
-              disabled={isInPreviewMode}
-              $isItemSelected={isFileSelected}
-              onClick={handlePreview}
-            >
-              Preview
-            </S.PreviewButton>
+            <EyeOutlined style={{color: isFileSelected ? Colors.blackPure : Colors.grey7}} />
           )}
-          <ContextMenu overlay={menu}>
-            <div
-              onClick={e => {
-                e.stopPropagation();
-              }}
-            >
-              <Dots color={isFileSelected ? Colors.blackPure : undefined} />
-            </div>
-          </ContextMenu>
-        </S.ActionsWrapper>
-      ) : null}
-    </S.TreeTitleWrapper>
+        </S.TitleWrapper>
+        {processingEntity.processingEntityID === treeKey && processingEntity.processingType === 'delete' && (
+          <S.SpinnerWrapper>
+            <Spinner />
+          </S.SpinnerWrapper>
+        )}
+        {isTitleHovered && !processingEntity.processingType ? (
+          <S.ActionsWrapper>
+            {canPreview(relativePath) && (
+              <S.PreviewButton
+                type="text"
+                size="small"
+                disabled={isInPreviewMode}
+                $isItemSelected={isFileSelected}
+                onClick={handlePreview}
+              >
+                Preview
+              </S.PreviewButton>
+            )}
+            <ContextMenu overlay={menu}>
+              <div
+                onClick={e => {
+                  e.stopPropagation();
+                }}
+              >
+                <Dots color={isFileSelected ? Colors.blackPure : undefined} />
+              </div>
+            </ContextMenu>
+          </S.ActionsWrapper>
+        ) : null}
+      </S.TreeTitleWrapper>
+    </ContextMenu>
   );
 };
 


### PR DESCRIPTION

This PR...

## Changes

-

## Fixes

-

## How to test it
Right-click items that listed in file explorer.
-

## Screenshots
<img src="https://cdn.discordapp.com/attachments/946537793071497256/946542156624064532/unknown.png" />
-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
