### PR TITLE
fix: handle plugin import model error message cache problem

### DIFF
--- a/electron/extensions/downloadExtension.ts
+++ b/electron/extensions/downloadExtension.ts
@@ -1,4 +1,5 @@
 import {readFileSync} from 'fs';
+import log from 'loglevel';
 import path from 'path';
 import tar from 'tar';
 
@@ -39,6 +40,7 @@ async function downloadExtension<ExtensionEntryType, ExtensionType>(
 
   const tarballFilePath = `${extensionFolderPath}.tgz`;
   const doesTarballFileExist = await doesPathExist(tarballFilePath);
+
   if (doesTarballFileExist) {
     await deleteFile(tarballFilePath);
   }
@@ -71,6 +73,7 @@ export const checkAllJSONFilesOfExtensionAreValid = (folderPath: string) => {
   } catch (error: any) {
     deleteFolder(folderPath);
     const paths: Array<string> = currentFile.split(path.sep);
+    log.warn(`[${paths[paths.length - 1]}]: ${error.message} `);
     throw new Error(`[${paths[paths.length - 1]}]: ${error.message}`);
   }
 };

--- a/src/components/organisms/PluginManager/PluginInstallModal.tsx
+++ b/src/components/organisms/PluginManager/PluginInstallModal.tsx
@@ -47,6 +47,7 @@ function PluginInstallModal(props: {isVisible: boolean; onClose: () => void}) {
   const download = async (pluginUrl: string) => {
     try {
       setIsDownloading(true);
+      setErrorMessage('');
       const downloadPluginResult = await downloadPlugin(pluginUrl);
       const {pluginExtension, templateExtensions} = downloadPluginResult;
       dispatch(addPlugin(pluginExtension));


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- handle not showing the same error message for the continues attempts

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
