### PR TITLE
fix: update values files in preview configurations

### DIFF
--- a/src/components/atoms/OrderedList/index.ts
+++ b/src/components/atoms/OrderedList/index.ts
@@ -1,2 +1,1 @@
 export {default} from './OrderedList';
-export type {OrderedListItem} from './OrderedList';

--- a/src/components/molecules/PreviewConfigurationDetails/PreviewConfigurationDetails.tsx
+++ b/src/components/molecules/PreviewConfigurationDetails/PreviewConfigurationDetails.tsx
@@ -2,9 +2,12 @@ import {useMemo} from 'react';
 
 import {Breadcrumb, Typography} from 'antd';
 
+import {sortBy} from 'lodash';
 import styled from 'styled-components';
 
 import {ROOT_FILE_ENTRY} from '@constants/constants';
+
+import {PreviewConfigValuesFileItem, PreviewConfigValuesFileItemPropsDefinition} from '@models/appconfig';
 
 import {useAppSelector} from '@redux/hooks';
 import {kubeConfigContextSelector} from '@redux/selectors';
@@ -41,19 +44,33 @@ const PreviwConfigurationDetails: React.FC = () => {
     );
   });
 
+  const orderedValuesFilePaths = useMemo(
+    () =>
+      previewConfiguration
+        ? sortBy(
+            Object.values(previewConfiguration.valuesFileItemMap).filter(
+              (item): item is PreviewConfigValuesFileItem => item != null
+            ),
+            [PreviewConfigValuesFileItemPropsDefinition.orderPropName]
+          ).map(i => i.filePath)
+        : [],
+    [previewConfiguration]
+  );
+
   const builtCommand = useMemo(() => {
     if (!previewConfiguration || !helmChart) {
       return [''];
     }
+
     return buildHelmCommand(
       helmChart,
-      previewConfiguration.orderedValuesFilePaths,
+      orderedValuesFilePaths,
       previewConfiguration.command,
       previewConfiguration.options,
       rootFolderPath,
       currentContext
     );
-  }, [previewConfiguration, helmChart, currentContext, rootFolderPath]);
+  }, [previewConfiguration, helmChart, currentContext, rootFolderPath, orderedValuesFilePaths]);
 
   if (!previewConfiguration || !helmChart) {
     return (

--- a/src/models/appconfig.ts
+++ b/src/models/appconfig.ts
@@ -62,12 +62,27 @@ export type Project = {
   lastOpened?: string;
 };
 
+export const PreviewConfigValuesFileItemPropsDefinition = {
+  idPropName: 'id',
+  orderPropName: 'order',
+  checkedPropName: 'isChecked',
+  textPropName: 'name',
+} as const;
+
+export type PreviewConfigValuesFileItem = {
+  filePath: string;
+  [PreviewConfigValuesFileItemPropsDefinition.idPropName]: string;
+  [PreviewConfigValuesFileItemPropsDefinition.orderPropName]: number;
+  [PreviewConfigValuesFileItemPropsDefinition.checkedPropName]: boolean;
+  [PreviewConfigValuesFileItemPropsDefinition.textPropName]: string;
+};
+
 export type HelmPreviewConfiguration = {
   id: string;
   name: string;
   helmChartFilePath: string;
-  orderedValuesFilePaths: string[];
   command: 'install' | 'template';
+  valuesFileItemMap: Record<string, PreviewConfigValuesFileItem | null>;
   options: Record<string, string | null>;
 };
 


### PR DESCRIPTION
This PR...

## Changes

- I might've complicated the `OrderedList` component by allowing to specify the property names of the items but I wanted it to be reusable and other solutions were throwing lots of typescript errors

## Fixes

- the order and the isChecked properties of values files from Preview Configurations were not being updated correctly, this PR fixes it 

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
