### PR TITLE
refactor: improve create project from template

### DIFF
--- a/src/components/organisms/CreateProjectModal/CreateProjectModal.tsx
+++ b/src/components/organisms/CreateProjectModal/CreateProjectModal.tsx
@@ -196,15 +196,19 @@ const CreateProjectModal: React.FC = () => {
             Back
           </Button>
         ),
-        <Button
-          id="empty-project-save"
-          key="submit"
-          type="primary"
-          disabled={!isSubmitEnabled}
-          onClick={() => createProjectForm.submit()}
-        >
-          {uiState.fromTemplate && formStep === FormSteps.STEP_ONE ? 'Next: Select a Template' : 'Create Project'}
-        </Button>,
+        <>
+          {formStep !== FormSteps.STEP_TWO && (
+            <Button
+              id="empty-project-save"
+              key="submit"
+              type="primary"
+              disabled={!isSubmitEnabled}
+              onClick={() => createProjectForm.submit()}
+            >
+              {uiState.fromTemplate && formStep === FormSteps.STEP_ONE ? 'Next: Select a Template' : 'Create Project'}
+            </Button>
+          )}
+        </>,
       ]}
     >
       {formStep === FormSteps.STEP_ONE ? (
@@ -277,6 +281,8 @@ const CreateProjectModal: React.FC = () => {
               <TemplateInformation
                 key={template.id}
                 template={template}
+                actionType="button"
+                actionLabel="Use this Template"
                 onClickOpenTemplate={() => onClickOpenTemplate(template)}
               />
             ))}

--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.styled.tsx
@@ -78,9 +78,9 @@ export const FormOutlined = styled(RawFormOutlined)`
   font-size: 30px;
 `;
 
-export const OpenButton = styled(Button)`
+export const OpenButton = styled(Button)<{$noPadding: boolean}>`
   width: max-content;
-  padding: 0px;
+  ${props => props.$noPadding && 'padding: 0px;'}
 `;
 
 export const Footer = styled.div`

--- a/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
+++ b/src/components/organisms/TemplateManagerPane/TemplateInformation.tsx
@@ -20,11 +20,13 @@ import * as S from './TemplateInformation.styled';
 interface IProps {
   template: AnyTemplate;
   onClickOpenTemplate: () => void;
+  actionType?: 'link' | 'button';
+  actionLabel?: string;
   disabled?: boolean;
 }
 
 const TemplateInformation: React.FC<IProps> = props => {
-  const {template, onClickOpenTemplate, disabled} = props;
+  const {template, onClickOpenTemplate, actionType = 'link', actionLabel, disabled} = props;
   const dispatch = useAppDispatch();
   const favoriteTemplates = useAppSelector(state => state.config.favoriteTemplates);
 
@@ -43,15 +45,15 @@ const TemplateInformation: React.FC<IProps> = props => {
               <Icon name="helm" />
             </Tooltip>
           )}
-            {favoriteTemplates.includes(template.id) ? (
-              <S.UnPinTemplateButton onClick={onClickPinTemplate}>
-                <DeliveredProcedureOutlined />
-              </S.UnPinTemplateButton>
-            ) : (
-              <S.PinTemplateButton onClick={onClickPinTemplate}>
-                <Icon name="helm" />
-              </S.PinTemplateButton>
-            )}
+          {favoriteTemplates.includes(template.id) ? (
+            <S.UnPinTemplateButton onClick={onClickPinTemplate}>
+              <DeliveredProcedureOutlined />
+            </S.UnPinTemplateButton>
+          ) : (
+            <S.PinTemplateButton onClick={onClickPinTemplate}>
+              <Icon name="helm" />
+            </S.PinTemplateButton>
+          )}
         </S.NameContainer>
         <S.Description>{_.truncate(template.description, {length: 140})}</S.Description>
 
@@ -64,11 +66,12 @@ const TemplateInformation: React.FC<IProps> = props => {
           <S.OpenButton
             disabled={disabled}
             icon={<DeliveredProcedureOutlined />}
-            type="link"
-            size="small"
+            $noPadding={actionType === 'link'}
+            type={actionType === 'button' ? 'primary' : 'link'}
+            size={actionType === 'button' ? 'middle' : 'small'}
             onClick={onClickOpenTemplate}
           >
-            Use Template
+            {actionLabel || 'Use Template'}
           </S.OpenButton>
         </S.Footer>
       </S.InfoContainer>


### PR DESCRIPTION
This PR...

## Changes

- removed the "Create Project" button from top right when creating a project from a template
- change the style of the Use Template button

<img width="533" alt="image" src="https://user-images.githubusercontent.com/20538711/158184241-84e83a8d-ac1c-4203-8b30-12cf51913dd2.png">


## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
