### PR TITLE
fix: add error message if preview configuration name is empty

### DIFF
--- a/src/components/organisms/PreviewConfigurationEditor/PreviewConfigurationEditor.tsx
+++ b/src/components/organisms/PreviewConfigurationEditor/PreviewConfigurationEditor.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {Button, Input, Select} from 'antd';
 
@@ -50,6 +50,7 @@ const PreviewConfigurationEditor = () => {
   });
 
   const [name, setName] = useState<string>(() => previewConfiguration?.name || '');
+  const [showNameError, setShowNameError] = useState(false);
 
   const [valuesFileItemMap, setValuesFileItemMap] = useState<Record<string, PreviewConfigValuesFileItem>>(() => {
     // get the existing items saved in the preview configuration
@@ -131,9 +132,19 @@ const PreviewConfigurationEditor = () => {
     dispatch(closePreviewConfigurationEditor());
   }, [dispatch]);
 
+  useEffect(() => {
+    if (name.trim().length) {
+      setShowNameError(false);
+    }
+  }, [name]);
+
   const onSave = useCallback(
     (shouldRunPreview?: boolean) => {
       if (!helmChart) {
+        return;
+      }
+      if (!name.trim().length) {
+        setShowNameError(true);
         return;
       }
       const input: HelmPreviewConfiguration = {
@@ -184,6 +195,7 @@ const PreviewConfigurationEditor = () => {
       <S.Field>
         <S.Label>Name your configuration:</S.Label>
         <Input value={name} onChange={e => setName(e.target.value)} placeholder="Enter the configuration name" />
+        {showNameError && <S.Error>You must enter a name for this Preview Configuration.</S.Error>}
       </S.Field>
       <S.Field>
         <S.Label style={{marginBottom: 0}}>Select which values files to use:</S.Label>

--- a/src/components/organisms/PreviewConfigurationEditor/styled.tsx
+++ b/src/components/organisms/PreviewConfigurationEditor/styled.tsx
@@ -27,3 +27,7 @@ export const ActionsContainer = styled.div`
   justify-content: flex-end;
   gap: 8px;
 `;
+
+export const Error = styled.p`
+  color: ${Colors.redError};
+`;


### PR DESCRIPTION
This PR...

## Changes

<img width="388" alt="image" src="https://user-images.githubusercontent.com/20538711/158191280-63a52609-2034-4ec8-b516-e46430d9e138.png">


## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
