### PR TITLE
fix: remove unused execSync

### DIFF
--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -1,6 +1,5 @@
 import {Draft, PayloadAction, createAsyncThunk, createSlice} from '@reduxjs/toolkit';
 
-import {execSync} from 'child_process';
 import flatten from 'flat';
 import {existsSync, mkdirSync} from 'fs';
 import _ from 'lodash';


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- Remove unused execSync import

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
