### PR TITLE
fix: split updateResource thunk into reducer

### DIFF
--- a/src/redux/thunks/updateResource.ts
+++ b/src/redux/thunks/updateResource.ts
@@ -1,21 +1,10 @@
 import {createAsyncThunk, original} from '@reduxjs/toolkit';
 
-import log from 'loglevel';
-
 import {RootState} from '@models/rootstate';
 
-import {
-  UpdateResourcePayload,
-  getActiveResourceMap,
-  getLocalResourceMap,
-  performResourceContentUpdate,
-} from '@redux/reducers/main';
+import {UpdateResourcePayload, mainSlice} from '@redux/reducers/main';
 import {currentConfigSelector} from '@redux/selectors';
-import {isKustomizationPatch, isKustomizationResource, processKustomizations} from '@redux/services/kustomize';
 import {getK8sVersion} from '@redux/services/projectConfig';
-import {reprocessResources} from '@redux/services/resource';
-import {findResourcesToReprocess} from '@redux/services/resourceRefs';
-import {updateSelectionAndHighlights} from '@redux/services/selection';
 
 export const updateResource = createAsyncThunk(
   'main/updateResource',
@@ -26,45 +15,11 @@ export const updateResource = createAsyncThunk(
     const userDataDir = String(state.config.userDataDir);
 
     try {
-      const isInClusterMode = payload.isInClusterMode;
-      const currentResourceMap = isInClusterMode ? getLocalResourceMap(state.main) : getActiveResourceMap(state.main);
-      const resourceMap = state.main.resourceMap;
-      const resource = isInClusterMode ? resourceMap[payload.resourceId] : currentResourceMap[payload.resourceId];
-
-      const fileMap = state.main.fileMap;
-      if (resource) {
-        performResourceContentUpdate(resource, payload.content, fileMap, resourceMap);
-        let resourceIds = findResourcesToReprocess(resource, currentResourceMap);
-        reprocessResources(
-          schemaVersion,
-          userDataDir,
-          resourceIds,
-          currentResourceMap,
-          fileMap,
-          state.main.resourceRefsProcessingOptions
-        );
-        if (!payload.preventSelectionAndHighlightsUpdate) {
-          resource.isSelected = false;
-          updateSelectionAndHighlights(state.main, resource);
-        }
-      } else {
-        const r = resourceMap[payload.resourceId];
-        // check if this was a kustomization resource updated during a kustomize preview
-        if (
-          r &&
-          (isKustomizationResource(r) || isKustomizationPatch(r)) &&
-          state.main.previewResourceId &&
-          isKustomizationResource(resourceMap[state.main.previewResourceId])
-        ) {
-          performResourceContentUpdate(r, payload.content, fileMap, resourceMap);
-          processKustomizations(resourceMap, fileMap);
-        } else {
-          log.warn('Failed to find updated resource during preview', payload.resourceId);
-        }
-      }
-    } catch (e) {
-      log.error(e);
-      return original(state);
+      thunkAPI.dispatch(
+        mainSlice.actions.updateResourceSubAction({userDataDir, schemaVersion, parentPayload: payload})
+      );
+    } catch (error) {
+      throw original(error);
     }
   }
 );

--- a/src/redux/thunks/updateResource.ts
+++ b/src/redux/thunks/updateResource.ts
@@ -19,7 +19,7 @@ export const updateResource = createAsyncThunk(
         mainSlice.actions.updateResourceSubAction({userDataDir, schemaVersion, parentPayload: payload})
       );
     } catch (error) {
-      throw original(error);
+      return original(error);
     }
   }
 );


### PR DESCRIPTION
This PR...

## Changes

- Splits updateResource thunk into reducer

## Fixes

- https://github.com/kubeshop/monokle/issues/1472

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
