### PR TITLE
fix: use immer in thunks to create next main state

### DIFF
--- a/src/redux/thunks/multiplePathsChanged.ts
+++ b/src/redux/thunks/multiplePathsChanged.ts
@@ -1,4 +1,4 @@
-import {createAsyncThunk} from '@reduxjs/toolkit';
+import {createAsyncThunk, createNextState} from '@reduxjs/toolkit';
 
 import micromatch from 'micromatch';
 
@@ -14,13 +14,17 @@ export const multiplePathsChanged = createAsyncThunk(
     const projectConfig = currentConfigSelector(state);
     const userDataDir = String(state.config.userDataDir);
 
-    filePaths.forEach((filePath: string) => {
-      let fileEntry = getFileEntryForAbsolutePath(filePath, state.main.fileMap);
-      if (fileEntry) {
-        reloadFile(filePath, fileEntry, state.main, projectConfig, userDataDir);
-      } else if (!projectConfig.scanExcludes || !micromatch.any(filePath, projectConfig.scanExcludes)) {
-        addPath(filePath, state.main, projectConfig, userDataDir);
-      }
+    const nextMainState = createNextState(state.main, mainState => {
+      filePaths.forEach((filePath: string) => {
+        let fileEntry = getFileEntryForAbsolutePath(filePath, mainState.fileMap);
+        if (fileEntry) {
+          reloadFile(filePath, fileEntry, mainState, projectConfig, userDataDir);
+        } else if (!projectConfig.scanExcludes || !micromatch.any(filePath, projectConfig.scanExcludes)) {
+          addPath(filePath, mainState, projectConfig, userDataDir);
+        }
+      });
     });
+
+    return nextMainState;
   }
 );

--- a/src/redux/thunks/updateFileEntry.ts
+++ b/src/redux/thunks/updateFileEntry.ts
@@ -1,4 +1,4 @@
-import {createAsyncThunk, original} from '@reduxjs/toolkit';
+import {createAsyncThunk, createNextState, original} from '@reduxjs/toolkit';
 
 import fs from 'fs';
 import log from 'loglevel';
@@ -25,74 +25,78 @@ export const updateFileEntry = createAsyncThunk(
     const schemaVersion = getK8sVersion(projectConfig);
     const userDataDir = String(state.config.userDataDir);
 
-    try {
-      const fileEntry = state.main.fileMap[payload.path];
-      if (!fileEntry) {
-        log.error(`Could not find FileEntry for ${payload.path}`);
-        return;
-      }
-
-      let rootFolder = state.main.fileMap[ROOT_FILE_ENTRY].filePath;
-      const filePath = path.join(rootFolder, payload.path);
-
-      if (getFileStats(filePath)?.isDirectory() === false) {
-        fs.writeFileSync(filePath, payload.content);
-        fileEntry.timestamp = getFileTimestamp(filePath);
-
-        if (path.basename(fileEntry.filePath) === HELM_CHART_ENTRY_FILE) {
-          try {
-            const helmChart = Object.values(state.main.helmChartMap).find(
-              chart => chart.filePath === fileEntry.filePath
-            );
-            if (!helmChart) {
-              throw new Error(`Couldn't find the helm chart for path: ${fileEntry.filePath}`);
-            }
-            const fileContent = parse(payload.content);
-            if (typeof fileContent?.name !== 'string') {
-              throw new Error(`Couldn't get the name property of the helm chart at path: ${fileEntry.filePath}`);
-            }
-            helmChart.name = fileContent.name;
-          } catch (e) {
-            if (e instanceof Error) {
-              log.warn(`[updateFileEntry]: ${e.message}`);
-            }
-          }
-        } else {
-          getResourcesForPath(fileEntry.filePath, state.main.resourceMap).forEach(r => {
-            deleteResource(r, state.main.resourceMap);
-          });
-
-          const extractedResources = extractK8sResources(payload.content, filePath.substring(rootFolder.length));
-
-          let resourceIds: string[] = [];
-
-          // only recalculate refs for resources that already have refs
-          Object.values(state.main.resourceMap)
-            .filter(r => r.refs)
-            .forEach(r => resourceIds.push(r.id));
-
-          Object.values(extractedResources).forEach(r => {
-            state.main.resourceMap[r.id] = r;
-            r.isHighlighted = true;
-            resourceIds.push(r.id);
-          });
-
-          reprocessResources(
-            schemaVersion,
-            userDataDir,
-            resourceIds,
-            state.main.resourceMap,
-            state.main.fileMap,
-            state.main.resourceRefsProcessingOptions,
-            {
-              resourceKinds: extractedResources.map(r => r.kind),
-            }
-          );
+    const nextMainState = createNextState(state.main, mainState => {
+      try {
+        const fileEntry = mainState.fileMap[payload.path];
+        if (!fileEntry) {
+          log.error(`Could not find FileEntry for ${payload.path}`);
+          return;
         }
+
+        let rootFolder = mainState.fileMap[ROOT_FILE_ENTRY].filePath;
+        const filePath = path.join(rootFolder, payload.path);
+
+        if (getFileStats(filePath)?.isDirectory() === false) {
+          fs.writeFileSync(filePath, payload.content);
+          fileEntry.timestamp = getFileTimestamp(filePath);
+
+          if (path.basename(fileEntry.filePath) === HELM_CHART_ENTRY_FILE) {
+            try {
+              const helmChart = Object.values(mainState.helmChartMap).find(
+                chart => chart.filePath === fileEntry.filePath
+              );
+              if (!helmChart) {
+                throw new Error(`Couldn't find the helm chart for path: ${fileEntry.filePath}`);
+              }
+              const fileContent = parse(payload.content);
+              if (typeof fileContent?.name !== 'string') {
+                throw new Error(`Couldn't get the name property of the helm chart at path: ${fileEntry.filePath}`);
+              }
+              helmChart.name = fileContent.name;
+            } catch (e) {
+              if (e instanceof Error) {
+                log.warn(`[updateFileEntry]: ${e.message}`);
+              }
+            }
+          } else {
+            getResourcesForPath(fileEntry.filePath, mainState.resourceMap).forEach(r => {
+              deleteResource(r, mainState.resourceMap);
+            });
+
+            const extractedResources = extractK8sResources(payload.content, filePath.substring(rootFolder.length));
+
+            let resourceIds: string[] = [];
+
+            // only recalculate refs for resources that already have refs
+            Object.values(mainState.resourceMap)
+              .filter(r => r.refs)
+              .forEach(r => resourceIds.push(r.id));
+
+            Object.values(extractedResources).forEach(r => {
+              mainState.resourceMap[r.id] = r;
+              r.isHighlighted = true;
+              resourceIds.push(r.id);
+            });
+
+            reprocessResources(
+              schemaVersion,
+              userDataDir,
+              resourceIds,
+              mainState.resourceMap,
+              mainState.fileMap,
+              mainState.resourceRefsProcessingOptions,
+              {
+                resourceKinds: extractedResources.map(r => r.kind),
+              }
+            );
+          }
+        }
+      } catch (e) {
+        log.error(e);
+        return original(mainState);
       }
-    } catch (e) {
-      log.error(e);
-      return original(state);
-    }
+    });
+
+    return nextMainState;
   }
 );

--- a/src/redux/thunks/updateManyResources.ts
+++ b/src/redux/thunks/updateManyResources.ts
@@ -1,4 +1,4 @@
-import {createAsyncThunk, original} from '@reduxjs/toolkit';
+import {createAsyncThunk, createNextState, original} from '@reduxjs/toolkit';
 
 import log from 'loglevel';
 
@@ -18,34 +18,38 @@ export const updateManyResources = createAsyncThunk(
     const schemaVersion = getK8sVersion(projectConfig);
     const userDataDir = String(state.config.userDataDir);
 
-    try {
-      let resourceIdsToReprocess: string[] = [];
-      const activeResources = getActiveResourceMap(state.main);
+    const nextMainState = createNextState(state.main, mainState => {
+      try {
+        let resourceIdsToReprocess: string[] = [];
+        const activeResources = getActiveResourceMap(mainState);
 
-      payload.forEach(({resourceId, content}) => {
-        const resource = activeResources[resourceId];
-        if (resource) {
-          performResourceContentUpdate(resource, content, state.main.fileMap, state.main.resourceMap);
-          let resourceIds = findResourcesToReprocess(resource, state.main.resourceMap);
-          resourceIdsToReprocess = [...new Set(resourceIdsToReprocess.concat(...resourceIds))];
+        payload.forEach(({resourceId, content}) => {
+          const resource = activeResources[resourceId];
+          if (resource) {
+            performResourceContentUpdate(resource, content, mainState.fileMap, mainState.resourceMap);
+            let resourceIds = findResourcesToReprocess(resource, mainState.resourceMap);
+            resourceIdsToReprocess = [...new Set(resourceIdsToReprocess.concat(...resourceIds))];
+          }
+        });
+        reprocessResources(
+          schemaVersion,
+          userDataDir,
+          resourceIdsToReprocess,
+          activeResources,
+          mainState.fileMap,
+          mainState.resourceRefsProcessingOptions
+        );
+
+        // relaod cluster diff if that's where we are
+        if (state.ui.isClusterDiffVisible) {
+          mainState.clusterDiff.shouldReload = true;
         }
-      });
-      reprocessResources(
-        schemaVersion,
-        userDataDir,
-        resourceIdsToReprocess,
-        activeResources,
-        state.main.fileMap,
-        state.main.resourceRefsProcessingOptions
-      );
-
-      // relaod cluster diff if that's where we are
-      if (state.ui.isClusterDiffVisible) {
-        state.main.clusterDiff.shouldReload = true;
+      } catch (e) {
+        log.error(e);
+        return original(mainState);
       }
-    } catch (e) {
-      log.error(e);
-      return original(state);
-    }
+    });
+
+    return nextMainState;
   }
 );

--- a/src/redux/thunks/updateResource.ts
+++ b/src/redux/thunks/updateResource.ts
@@ -1,10 +1,21 @@
-import {createAsyncThunk, original} from '@reduxjs/toolkit';
+import {createAsyncThunk, createNextState, original} from '@reduxjs/toolkit';
+
+import log from 'loglevel';
 
 import {RootState} from '@models/rootstate';
 
-import {UpdateResourcePayload, mainSlice} from '@redux/reducers/main';
+import {
+  UpdateResourcePayload,
+  getActiveResourceMap,
+  getLocalResourceMap,
+  performResourceContentUpdate,
+} from '@redux/reducers/main';
 import {currentConfigSelector} from '@redux/selectors';
+import {isKustomizationPatch, isKustomizationResource, processKustomizations} from '@redux/services/kustomize';
 import {getK8sVersion} from '@redux/services/projectConfig';
+import {reprocessResources} from '@redux/services/resource';
+import {findResourcesToReprocess} from '@redux/services/resourceRefs';
+import {updateSelectionAndHighlights} from '@redux/services/selection';
 
 export const updateResource = createAsyncThunk(
   'main/updateResource',
@@ -14,12 +25,51 @@ export const updateResource = createAsyncThunk(
     const schemaVersion = getK8sVersion(projectConfig);
     const userDataDir = String(state.config.userDataDir);
 
-    try {
-      thunkAPI.dispatch(
-        mainSlice.actions.updateResourceSubAction({userDataDir, schemaVersion, parentPayload: payload})
-      );
-    } catch (error) {
-      return original(error);
-    }
+    const {isInClusterMode, resourceId, content, preventSelectionAndHighlightsUpdate} = payload;
+
+    const nextMainState = createNextState(state.main, mainState => {
+      try {
+        const currentResourceMap = isInClusterMode ? getLocalResourceMap(mainState) : getActiveResourceMap(mainState);
+        const resourceMap = mainState.resourceMap;
+        const resource = isInClusterMode ? resourceMap[resourceId] : currentResourceMap[resourceId];
+
+        const fileMap = mainState.fileMap;
+        if (resource) {
+          performResourceContentUpdate(resource, content, fileMap, resourceMap);
+          let resourceIds = findResourcesToReprocess(resource, currentResourceMap);
+          reprocessResources(
+            schemaVersion,
+            userDataDir,
+            resourceIds,
+            currentResourceMap,
+            fileMap,
+            mainState.resourceRefsProcessingOptions
+          );
+          if (!preventSelectionAndHighlightsUpdate) {
+            resource.isSelected = false;
+            updateSelectionAndHighlights(mainState, resource);
+          }
+        } else {
+          const r = resourceMap[resourceId];
+          // check if this was a kustomization resource updated during a kustomize preview
+          if (
+            r &&
+            (isKustomizationResource(r) || isKustomizationPatch(r)) &&
+            mainState.previewResourceId &&
+            isKustomizationResource(resourceMap[mainState.previewResourceId])
+          ) {
+            performResourceContentUpdate(r, content, fileMap, resourceMap);
+            processKustomizations(resourceMap, fileMap);
+          } else {
+            log.warn('Failed to find updated resource during preview', resourceId);
+          }
+        }
+      } catch (e) {
+        log.error(e);
+        return original(mainState);
+      }
+    });
+
+    return nextMainState;
   }
 );


### PR DESCRIPTION
This PR...

## Changes

- used the `createNextState` method from redux toolkit which is a copy of the `produce` method from `immer` in order to be able to mutate the main state in thunks and then replace it via returning it in the `.fulfilled` action

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
