### PR TITLE
fix: panes overflow ( moving towards right )

### DIFF
--- a/src/components/organisms/FileTreePane/FileTreePane.tsx
+++ b/src/components/organisms/FileTreePane/FileTreePane.tsx
@@ -498,7 +498,7 @@ const FileTreePane = () => {
       ) : tree ? (
         <S.TreeContainer>
           <S.RootFolderText>
-            <div id="file-explorer-project-name">{fileMap[ROOT_FILE_ENTRY].filePath}</div>
+            <S.FilePathLabel id="file-explorer-project-name">{fileMap[ROOT_FILE_ENTRY].filePath}</S.FilePathLabel>
             <div id="file-explorer-count">{Object.values(fileMap).filter(f => !f.children).length} files</div>
           </S.RootFolderText>
           <S.TreeDirectoryTree

--- a/src/components/organisms/FileTreePane/Styled.tsx
+++ b/src/components/organisms/FileTreePane/Styled.tsx
@@ -112,6 +112,12 @@ export const ContextMenuDivider = styled.div`
   border-bottom: 1px solid rgba(255, 255, 255, 0.25);
 `;
 
+export const FilePathLabel = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 export const NoFilesContainer = styled.div`
   margin-left: 16px;
   margin-top: 10px;
@@ -152,9 +158,6 @@ export const RootFolderText = styled.div`
   line-height: 22px;
   color: ${Colors.grey7};
   margin-left: 14px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 
 export const Skeleton = styled(RawSkeleton)`

--- a/src/components/organisms/PaneManager/PaneMangerSplitView.tsx
+++ b/src/components/organisms/PaneManager/PaneMangerSplitView.tsx
@@ -83,7 +83,8 @@ const PaneManagerSplitView: React.FC = () => {
   useEffect(() => {
     if (
       leftActive &&
-      navPaneWidth + splitViewContainerWidth * leftWidth + splitViewContainerWidth * editWidth > splitViewContainerWidth
+      navWidth * splitViewContainerWidth + splitViewContainerWidth * leftWidth + splitViewContainerWidth * editWidth >
+        splitViewContainerWidth
     ) {
       const newEditPaneWidthPercentage = 1 - leftWidth - navWidth;
 
@@ -91,7 +92,7 @@ const PaneManagerSplitView: React.FC = () => {
     }
 
     if (!leftActive) {
-      dispatch(setPaneConfiguration({...paneConfiguration, navWidth: navPaneWidth / (splitViewContainerWidth || 1)}));
+      dispatch(setPaneConfiguration({...paneConfiguration, navWidth: navPaneWidth / splitViewContainerWidth}));
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/organisms/PaneManager/PaneMangerSplitView.tsx
+++ b/src/components/organisms/PaneManager/PaneMangerSplitView.tsx
@@ -81,11 +81,7 @@ const PaneManagerSplitView: React.FC = () => {
   }, [leftActive]);
 
   useEffect(() => {
-    if (
-      leftActive &&
-      navWidth * splitViewContainerWidth + splitViewContainerWidth * leftWidth + splitViewContainerWidth * editWidth >
-        splitViewContainerWidth
-    ) {
+    if (leftActive && splitViewContainerWidth * (navWidth + leftWidth + editWidth) > splitViewContainerWidth) {
       const newEditPaneWidthPercentage = 1 - leftWidth - navWidth;
 
       dispatch(setPaneConfiguration({...paneConfiguration, editWidth: newEditPaneWidthPercentage}));


### PR DESCRIPTION
## Fixes

- Panes having an overflow and moving infinitely to the right
- File explorer file path overflow ellipsis

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/159956809-60b439d1-cc5f-4e31-b74d-1500ec7e13ea.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
