### PR TITLE
feat: file explorer: trancate names and add path for files

### DIFF
--- a/src/components/organisms/FileTreePane/Styled.tsx
+++ b/src/components/organisms/FileTreePane/Styled.tsx
@@ -245,6 +245,7 @@ export const TitleWrapper = styled.div`
   display: flex;
   justify-content: space-around;
   align-items: center;
+  max-width: 80%;
 `;
 
 export const ActionsWrapper = styled.div`

--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -1,13 +1,13 @@
 import React, {useCallback, useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import {Menu, Modal} from 'antd';
+import {Menu, Modal, Tooltip} from 'antd';
 
 import {ExclamationCircleOutlined, EyeOutlined} from '@ant-design/icons';
 
 import path from 'path';
 
-import {ROOT_FILE_ENTRY} from '@constants/constants';
+import {ROOT_FILE_ENTRY, TOOLTIP_DELAY} from '@constants/constants';
 
 import {useAppSelector} from '@redux/hooks';
 import {isInPreviewModeSelector} from '@redux/selectors';
@@ -252,12 +252,14 @@ const TreeItem: React.FC<TreeItemProps> = props => {
   return (
     <ContextMenu overlay={menu} triggerOnRightClick>
       <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
-        <S.TitleWrapper>
-          <S.TreeTitleText>{title}</S.TreeTitleText>
-          {canPreview(relativePath) && (
-            <EyeOutlined style={{color: isFileSelected ? Colors.blackPure : Colors.grey7}} />
-          )}
-        </S.TitleWrapper>
+        <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={absolutePath} placement="bottom">
+          <S.TitleWrapper>
+            <S.TreeTitleText>{title}</S.TreeTitleText>
+            {canPreview(relativePath) && (
+              <EyeOutlined style={{color: isFileSelected ? Colors.blackPure : Colors.grey7}} />
+            )}
+          </S.TitleWrapper>
+        </Tooltip>
         {processingEntity.processingEntityID === treeKey && processingEntity.processingType === 'delete' && (
           <S.SpinnerWrapper>
             <Spinner />


### PR DESCRIPTION
This PR...

## Changes
Truncates file names in file explorer (UI affected)
-

## Fixes

-

## How to test it

- Open the Monokle and have a look on the File explorer files with long names or deep nesting.
- Hover over the filename.


## Screenshots
<img width="622" alt="image" src="https://user-images.githubusercontent.com/22424626/160154713-5a05b6df-3f44-44ef-814f-5ff31ffc6427.png">

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
