### PR TITLE
fix: paneConfiguration initial state and electronStore.onDidChange listener

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,11 +186,13 @@ const App = () => {
   useEffect(() => {
     globalElectronStoreChanges.forEach(globalElectronStoreChange => {
       electronStore.onDidChange(globalElectronStoreChange.keyName, (newData: any, oldData: any) => {
+        if (!newData || !oldData) {
+          return;
+        }
         const {shouldTriggerAcrossWindows, eventData} = globalElectronStoreChange.action(newData, oldData);
         if (!shouldTriggerAcrossWindows || !eventData) {
           return;
         }
-
         ipcRenderer.send('global-electron-store-update', eventData);
       });
     });

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -164,7 +164,14 @@ const initialUiState: UiState = {
   navPane: {
     collapsedNavSectionNames: [],
   },
-  paneConfiguration: electronStore.get('ui.paneConfiguration'),
+  paneConfiguration: electronStore.get('ui.paneConfiguration') || {
+    leftWidth: 0.3333,
+    navWidth: 0.3333,
+    editWidth: 0.3333,
+    rightWidth: 0,
+    actionsPaneFooterExpandedHeight: 0,
+    recentProjectsPaneWidth: 300,
+  },
   layoutSize: {
     footer: 0,
     header: 0,

--- a/src/utils/global-electron-store.ts
+++ b/src/utils/global-electron-store.ts
@@ -28,13 +28,12 @@ const projectNameChange: ElectronStoreChangePropagate<Project[], ProjectNameChan
   action: (newProjects, oldProjects) => {
     // means that a new project has been created and we should not update that
     if (newProjects.length > oldProjects.length) {
-      return { shouldTriggerAcrossWindows: false };
+      return {shouldTriggerAcrossWindows: false};
     }
 
-    const triggeredForProject = newProjects
-      .find((project, index) => project.name !== oldProjects[index].name);
+    const triggeredForProject = newProjects.find((project, index) => project.name !== oldProjects[index].name);
     if (!triggeredForProject) {
-      return { shouldTriggerAcrossWindows: false };
+      return {shouldTriggerAcrossWindows: false};
     }
 
     return {
@@ -49,6 +48,4 @@ const projectNameChange: ElectronStoreChangePropagate<Project[], ProjectNameChan
   },
 };
 
-export const globalElectronStoreChanges: ElectronStoreChangePropagate<any, any>[] = [
-  projectNameChange,
-];
+export const globalElectronStoreChanges: ElectronStoreChangePropagate<any, any>[] = [projectNameChange];


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- making sure `paneConfiguration` has an intial state if `config.json` is deleted
- fix error from watching the electronStore onDidChange

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
