### PR TITLE
fix: absolute path for plugin/template icons

### DIFF
--- a/electron/app/services/pluginService.ts
+++ b/electron/app/services/pluginService.ts
@@ -23,6 +23,10 @@ function transformPackageJsonToAnyPlugin(packageJson: PluginPackageJson, folderP
   const {repositoryOwner, repositoryName, repositoryBranch} = extractRepositoryOwnerAndNameFromUrl(
     packageJson.repository
   );
+  let icon = packageJson.monoklePlugin.icon;
+  if (icon && !icon.includes('http')) {
+    icon = path.join(folderPath, icon);
+  }
   const plugin: AnyPlugin = {
     id: packageJson.monoklePlugin.id,
     name: packageJson.name,
@@ -35,6 +39,7 @@ function transformPackageJsonToAnyPlugin(packageJson: PluginPackageJson, folderP
       name: repositoryName,
       branch: repositoryBranch,
     },
+    icon,
     modules: packageJson.monoklePlugin.modules.map(module => {
       if (isTemplatePluginModule(module)) {
         return {

--- a/electron/app/services/templateService.ts
+++ b/electron/app/services/templateService.ts
@@ -25,8 +25,13 @@ const TEMPLATE_PACK_ENTRY_FILE_NAME = 'monokle-template-pack.json';
 const TEMPLATE_ENTRY_FILE_NAME = 'monokle-template.json';
 
 const parseTemplate = (template: AnyTemplate, templateFolderPath: string): AnyTemplate => {
-  const updatedTemplate = {
+  let icon = template.icon;
+  if (icon && !icon.includes('http')) {
+    icon = path.join(templateFolderPath, icon);
+  }
+  const updatedTemplate: AnyTemplate = {
     ...template,
+    icon,
     forms: template.forms.map(form => {
       return {
         ...form,


### PR DESCRIPTION
This PR...

## Changes

- if the `icon` field on plugins or templates is not a URL, populate it with the full folder path

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
