### PR TITLE
Aggregate warnings on collapse nav section

### DIFF
--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -1,9 +1,10 @@
 import {useCallback, useMemo, useState} from 'react';
 
-import {SectionBlueprint, SectionInstance} from '@models/navigator';
+import {SectionBlueprint, SectionCustomComponent, SectionInstance} from '@models/navigator';
 
 import {useAppDispatch} from '@redux/hooks';
 
+import SectionHeaderDefaultNameCounter from './SectionHeaderDefaultNameCounter';
 import {useSectionCustomization} from './useSectionCustomization';
 
 import * as S from './styled';
@@ -39,6 +40,11 @@ function SectionHeader(props: SectionHeaderProps) {
     sectionBlueprint.customization
   );
 
+  const Counter: SectionCustomComponent = useMemo(
+    () => NameCounter.Component ?? SectionHeaderDefaultNameCounter,
+    [NameCounter]
+  );
+
   const toggleCollapse = useCallback(() => {
     if (isCollapsed) {
       expandSection();
@@ -46,20 +52,6 @@ function SectionHeader(props: SectionHeaderProps) {
       collapseSection();
     }
   }, [isCollapsed, expandSection, collapseSection]);
-
-  const counter = useMemo(() => {
-    const counterDisplayMode = sectionBlueprint.customization?.counterDisplayMode;
-    if (!counterDisplayMode || counterDisplayMode === 'descendants') {
-      return sectionInstance?.visibleDescendantItemIds?.length || 0;
-    }
-    if (counterDisplayMode === 'items') {
-      return sectionInstance?.visibleItemIds.length;
-    }
-    if (counterDisplayMode === 'subsections') {
-      return sectionInstance?.visibleChildSectionIds?.length || 0;
-    }
-    return undefined;
-  }, [sectionInstance, sectionBlueprint]);
 
   const onCheck = useCallback(() => {
     if (!sectionInstance.checkable || !sectionInstance.visibleDescendantItemIds) {
@@ -134,13 +126,7 @@ function SectionHeader(props: SectionHeaderProps) {
               {name}
             </S.Name>
 
-            {NameCounter.Component ? (
-              <NameCounter.Component sectionInstance={sectionInstance} onClick={toggleCollapse} />
-            ) : (
-              counter !== undefined && (
-                <S.Counter selected={sectionInstance.isSelected && isCollapsed}>{counter}</S.Counter>
-              )
-            )}
+            <Counter sectionInstance={sectionInstance} sectionBlueprint={sectionBlueprint} onClick={toggleCollapse} />
 
             <S.BlankSpace level={level} onClick={toggleCollapse} />
 

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -35,7 +35,9 @@ function SectionHeader(props: SectionHeaderProps) {
   const dispatch = useAppDispatch();
   const [isHovered, setIsHovered] = useState<boolean>(false);
 
-  const {NameDisplay, NamePrefix, NameSuffix, NameContext} = useSectionCustomization(sectionBlueprint.customization);
+  const {NameDisplay, NamePrefix, NameSuffix, NameContext, NameCounter} = useSectionCustomization(
+    sectionBlueprint.customization
+  );
 
   const toggleCollapse = useCallback(() => {
     if (isCollapsed) {
@@ -131,10 +133,17 @@ function SectionHeader(props: SectionHeaderProps) {
             >
               {name}
             </S.Name>
-            {counter !== undefined && (
-              <S.Counter selected={sectionInstance.isSelected && isCollapsed}>{counter}</S.Counter>
+
+            {NameCounter.Component ? (
+              <NameCounter.Component sectionInstance={sectionInstance} onClick={toggleCollapse} />
+            ) : (
+              counter !== undefined && (
+                <S.Counter selected={sectionInstance.isSelected && isCollapsed}>{counter}</S.Counter>
+              )
             )}
+
             <S.BlankSpace level={level} onClick={toggleCollapse} />
+
             {NameSuffix.Component && (NameSuffix.options?.isVisibleOnHover ? isHovered : true) && (
               <NameSuffix.Component sectionInstance={sectionInstance} onClick={toggleCollapse} />
             )}

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -126,7 +126,7 @@ function SectionHeader(props: SectionHeaderProps) {
               {name}
             </S.Name>
 
-            <Counter sectionInstance={sectionInstance} sectionBlueprint={sectionBlueprint} onClick={toggleCollapse} />
+            <Counter sectionInstance={sectionInstance} onClick={toggleCollapse} />
 
             <S.BlankSpace level={level} onClick={toggleCollapse} />
 

--- a/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
@@ -6,7 +6,7 @@ import {useAppSelector} from '@redux/hooks';
 
 import * as S from './styled';
 
-function SectionHeaderDefaultNameCounter({sectionInstance, sectionBlueprint}: SectionCustomComponentProps) {
+function SectionHeaderDefaultNameCounter({sectionInstance, sectionBlueprint, onClick}: SectionCustomComponentProps) {
   const {id, isSelected} = sectionInstance;
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
 
@@ -30,7 +30,7 @@ function SectionHeaderDefaultNameCounter({sectionInstance, sectionBlueprint}: Se
   }
 
   return (
-    <S.Counter selected={isSelected && isCollapsed}>
+    <S.Counter selected={isSelected && isCollapsed} onClick={onClick}>
       {resourceCount}
     </S.Counter>
   );

--- a/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
@@ -1,0 +1,39 @@
+import React, {useMemo} from 'react';
+
+import {SectionCustomComponentProps} from '@models/navigator';
+
+import {useAppSelector} from '@redux/hooks';
+
+import * as S from './styled';
+
+function SectionHeaderDefaultNameCounter({sectionInstance, sectionBlueprint}: SectionCustomComponentProps) {
+  const {id, isSelected} = sectionInstance;
+  const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
+
+  const resourceCount = useMemo(() => {
+    const counterDisplayMode = sectionBlueprint?.customization?.counterDisplayMode;
+
+    if (!counterDisplayMode || counterDisplayMode === 'descendants') {
+      return sectionInstance?.visibleDescendantItemIds?.length || 0;
+    }
+    if (counterDisplayMode === 'items') {
+      return sectionInstance?.visibleItemIds.length;
+    }
+    if (counterDisplayMode === 'subsections') {
+      return sectionInstance?.visibleChildSectionIds?.length || 0;
+    }
+    return undefined;
+  }, [sectionInstance, sectionBlueprint]);
+
+  if (resourceCount === undefined) {
+    return null;
+  }
+
+  return (
+    <S.Counter selected={isSelected && isCollapsed}>
+      {resourceCount}
+    </S.Counter>
+  );
+}
+
+export default SectionHeaderDefaultNameCounter;

--- a/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeaderDefaultNameCounter.tsx
@@ -4,10 +4,13 @@ import {SectionCustomComponentProps} from '@models/navigator';
 
 import {useAppSelector} from '@redux/hooks';
 
+import sectionBlueprintMap from '@src/navsections/sectionBlueprintMap';
+
 import * as S from './styled';
 
-function SectionHeaderDefaultNameCounter({sectionInstance, sectionBlueprint, onClick}: SectionCustomComponentProps) {
+function SectionHeaderDefaultNameCounter({sectionInstance, onClick}: SectionCustomComponentProps) {
   const {id, isSelected} = sectionInstance;
+  const sectionBlueprint = sectionBlueprintMap.getById(id);
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
 
   const resourceCount = useMemo(() => {

--- a/src/components/molecules/SectionRenderer/styled.tsx
+++ b/src/components/molecules/SectionRenderer/styled.tsx
@@ -142,6 +142,7 @@ export const Skeleton = styled(RawSkeleton)`
 export const Counter = styled.span<{selected: boolean}>`
   margin-left: 8px;
   font-size: 14px;
+  cursor: pointer;
   ${props => (props.selected ? `color: ${Colors.blackPure};` : `color: ${FontColors.grey};`)}
 `;
 

--- a/src/components/molecules/SectionRenderer/useSectionCustomization.ts
+++ b/src/components/molecules/SectionRenderer/useSectionCustomization.ts
@@ -23,5 +23,7 @@ export function useSectionCustomization(customization: SectionCustomization = {}
   );
   const NameContext = useMemo(() => ({Component: customization.nameContext?.component}), [customization.nameContext]);
 
-  return {NameDisplay, EmptyDisplay, NamePrefix, NameSuffix, NameContext};
+  const NameCounter = useMemo(() => ({Component: customization.nameCounter?.component}), [customization.nameCounter]);
+
+  return {NameDisplay, EmptyDisplay, NamePrefix, NameSuffix, NameContext, NameCounter};
 }

--- a/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
+++ b/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
@@ -49,6 +49,7 @@ export const StyledMenuItem = styled(Menu.Item)`
 export const WarningCountContainer = styled.span<{$type: 'warning' | 'error'}>`
   ${({$type}) => `color: ${$type === 'warning' ? Colors.yellowWarning : Colors.redError};`}
   margin-left: 8px;
+  cursor: pointer;
 `;
 
 export const WarningKindLabel = styled.span`

--- a/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
+++ b/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
@@ -13,6 +13,7 @@ import {filteredResourceSelector, isInPreviewModeSelector} from '@redux/selector
 import {Icon} from '@atoms';
 
 import {isDefined} from '@utils/filter';
+import {countResourceErrors, countResourceWarnings} from '@utils/resources';
 
 import * as S from './WarningAndErrorsDisplay.styled';
 
@@ -119,17 +120,8 @@ function WarningsAndErrorsDisplay() {
     return sortWarnings(errorsCollection);
   }, [resources]);
 
-  const warningsCount = useMemo(() => {
-    return resources.reduce<number>((acc, resource) => {
-      return acc + (resource.refs ? resource.refs.filter(ref => ref.type === ResourceRefType.Unsatisfied).length : 0);
-    }, 0);
-  }, [resources]);
-
-  const errorsCount = useMemo(() => {
-    return resources.reduce<number>((acc, resource) => {
-      return acc + (resource.validation && !resource.validation.isValid ? resource.validation.errors.length : 0);
-    }, 0);
-  }, [resources]);
+  const warningsCount = useMemo(() => countResourceWarnings(resources), [resources]);
+  const errorsCount = useMemo(() => countResourceErrors(resources), [resources]);
 
   return (
     <>

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -49,7 +49,6 @@ export interface ItemCustomization {
 
 export type SectionCustomComponentProps = {
   sectionInstance: SectionInstance;
-  sectionBlueprint?: SectionBlueprint<any>;
   onClick?: () => void;
 };
 

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -70,6 +70,9 @@ export interface SectionCustomization {
   nameContext?: {
     component: SectionCustomComponent;
   };
+  nameCounter?: {
+    component: SectionCustomComponent;
+  };
   namePrefix?: {
     component: SectionCustomComponent;
   };

--- a/src/models/navigator.ts
+++ b/src/models/navigator.ts
@@ -49,6 +49,7 @@ export interface ItemCustomization {
 
 export type SectionCustomComponentProps = {
   sectionInstance: SectionInstance;
+  sectionBlueprint?: SectionBlueprint<any>;
   onClick?: () => void;
 };
 

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
@@ -22,6 +22,7 @@ import {resourceMatchesKindHandler} from '@src/kindhandlers';
 import ResourceKindContextMenu from './ResourceKindContextMenu';
 import ResourceKindContextMenuWrapper from './ResourceKindContextMenuWrapper';
 import ResourceKindPrefix from './ResourceKindPrefix';
+import ResourceKindSectionNameCounter from './ResourceKindSectionNameCounter';
 import ResourceKindSectionNameSuffix from './ResourceKindSectionNameSuffix';
 import ResourceKindSuffix from './ResourceKindSuffix';
 
@@ -89,6 +90,9 @@ export function makeResourceKindNavSection(
         options: {
           isVisibleOnHover: true,
         },
+      },
+      nameCounter: {
+        component: ResourceKindSectionNameCounter,
       },
       isCheckVisibleOnHover: true,
     },

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.styled.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.styled.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+import Colors, {FontColors} from '@styles/Colors';
+
+export const Counter = styled.span<{selected: boolean}>`
+  margin-left: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  ${props => (props.selected ? `color: ${Colors.blackPure};` : `color: ${FontColors.grey};`)}
+`;
+
+export const WarningCountContainer = styled.span<{selected: boolean; $type: 'warning' | 'error'}>`
+  ${({selected, $type}) =>
+    `color: ${selected ? Colors.blackPure : $type === 'warning' ? Colors.yellowWarning : Colors.redError};`}
+  margin-left: 8px;
+  cursor: pointer;
+`;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
@@ -1,0 +1,41 @@
+import React, {useMemo} from 'react';
+
+import {SectionCustomComponentProps} from '@models/navigator';
+
+import {useAppSelector} from '@redux/hooks';
+
+import {countResourceErrors, countResourceWarnings} from '@utils/resources';
+
+import * as S from '../../components/molecules/SectionRenderer/styled';
+import * as WarningStyle from '../../components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled';
+
+function ResourceKindSectionCounter({sectionInstance}: SectionCustomComponentProps) {
+  const {id, isSelected, itemIds} = sectionInstance;
+  const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
+  const resourceMap = useAppSelector(state => state.main.resourceMap);
+  const resources = useMemo(() => itemIds.map(itemId => resourceMap[itemId]), [itemIds, resourceMap]);
+
+  const resourceCount = resources.length;
+  const warningCount = useMemo(() => countResourceWarnings(resources), [resources]);
+  const errorCount = useMemo(() => countResourceErrors(resources), [resources]);
+
+  return (
+    <>
+      <S.Counter selected={isSelected && isCollapsed}>{resourceCount}</S.Counter>
+
+      {isCollapsed && warningCount > 0 ? (
+        <WarningStyle.WarningCountContainer $type="warning">
+          <WarningStyle.Icon $type="warning" name="warning" /> {warningCount}
+        </WarningStyle.WarningCountContainer>
+      ) : undefined}
+
+      {isCollapsed && errorCount > 0 ? (
+        <WarningStyle.WarningCountContainer $type="error">
+          <WarningStyle.Icon $type="error" name="error" /> {errorCount}
+        </WarningStyle.WarningCountContainer>
+      ) : undefined}
+    </>
+  );
+}
+
+export default ResourceKindSectionCounter;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
@@ -4,6 +4,7 @@ import {SectionCustomComponentProps} from '@models/navigator';
 
 import {useAppSelector} from '@redux/hooks';
 
+import {isDefined} from '@utils/filter';
 import {countResourceErrors, countResourceWarnings} from '@utils/resources';
 
 import * as S from '../../components/molecules/SectionRenderer/styled';
@@ -12,8 +13,7 @@ import * as WarningStyle from '../../components/organisms/NavigatorPane/WarningA
 function ResourceKindSectionCounter({sectionInstance, onClick}: SectionCustomComponentProps) {
   const {id, isSelected, itemIds} = sectionInstance;
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
-  const resourceMap = useAppSelector(state => state.main.resourceMap);
-  const resources = useMemo(() => itemIds.map(itemId => resourceMap[itemId]), [itemIds, resourceMap]);
+  const resources = useAppSelector(state => itemIds.map(itemId => state.main.resourceMap[itemId]).filter(isDefined));
 
   const resourceCount = resources.length;
   const warningCount = useMemo(() => countResourceWarnings(resources), [resources]);

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
@@ -9,7 +9,7 @@ import {countResourceErrors, countResourceWarnings} from '@utils/resources';
 import * as S from '../../components/molecules/SectionRenderer/styled';
 import * as WarningStyle from '../../components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled';
 
-function ResourceKindSectionCounter({sectionInstance}: SectionCustomComponentProps) {
+function ResourceKindSectionCounter({sectionInstance, onClick}: SectionCustomComponentProps) {
   const {id, isSelected, itemIds} = sectionInstance;
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
   const resourceMap = useAppSelector(state => state.main.resourceMap);
@@ -21,16 +21,18 @@ function ResourceKindSectionCounter({sectionInstance}: SectionCustomComponentPro
 
   return (
     <>
-      <S.Counter selected={isSelected && isCollapsed}>{resourceCount}</S.Counter>
+      <S.Counter selected={isSelected && isCollapsed} onClick={onClick}>
+        {resourceCount}
+      </S.Counter>
 
       {isCollapsed && warningCount > 0 ? (
-        <WarningStyle.WarningCountContainer $type="warning">
+        <WarningStyle.WarningCountContainer $type="warning" onClick={onClick}>
           <WarningStyle.Icon $type="warning" name="warning" /> {warningCount}
         </WarningStyle.WarningCountContainer>
       ) : undefined}
 
       {isCollapsed && errorCount > 0 ? (
-        <WarningStyle.WarningCountContainer $type="error">
+        <WarningStyle.WarningCountContainer $type="error" onClick={onClick}>
           <WarningStyle.Icon $type="error" name="error" /> {errorCount}
         </WarningStyle.WarningCountContainer>
       ) : undefined}

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
@@ -4,16 +4,18 @@ import {SectionCustomComponentProps} from '@models/navigator';
 
 import {useAppSelector} from '@redux/hooks';
 
+import {Icon} from '@components/atoms';
+
 import {isDefined} from '@utils/filter';
 import {countResourceErrors, countResourceWarnings} from '@utils/resources';
 
-import * as S from '../../components/molecules/SectionRenderer/styled';
-import * as WarningStyle from '../../components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled';
+import * as S from './ResourceKindSectionNameCounter.styled';
 
 function ResourceKindSectionCounter({sectionInstance, onClick}: SectionCustomComponentProps) {
   const {id, isSelected, itemIds} = sectionInstance;
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
   const resources = useAppSelector(state => itemIds.map(itemId => state.main.resourceMap[itemId]).filter(isDefined));
+  const selected = isSelected && isCollapsed;
 
   const resourceCount = resources.length;
   const warningCount = useMemo(() => countResourceWarnings(resources), [resources]);
@@ -21,20 +23,20 @@ function ResourceKindSectionCounter({sectionInstance, onClick}: SectionCustomCom
 
   return (
     <>
-      <S.Counter selected={isSelected && isCollapsed} onClick={onClick}>
+      <S.Counter selected={selected} onClick={onClick}>
         {resourceCount}
       </S.Counter>
 
       {isCollapsed && warningCount > 0 ? (
-        <WarningStyle.WarningCountContainer $type="warning" onClick={onClick}>
-          <WarningStyle.Icon $type="warning" name="warning" /> {warningCount}
-        </WarningStyle.WarningCountContainer>
+        <S.WarningCountContainer selected={selected} $type="warning" onClick={onClick}>
+          <Icon name="warning" /> {warningCount}
+        </S.WarningCountContainer>
       ) : undefined}
 
       {isCollapsed && errorCount > 0 ? (
-        <WarningStyle.WarningCountContainer $type="error" onClick={onClick}>
-          <WarningStyle.Icon $type="error" name="error" /> {errorCount}
-        </WarningStyle.WarningCountContainer>
+        <S.WarningCountContainer selected={selected} $type="error" onClick={onClick}>
+          <Icon name="error" /> {errorCount}
+        </S.WarningCountContainer>
       ) : undefined}
     </>
   );

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import {CLUSTER_RESOURCE_IGNORED_PATHS} from '@constants/clusterResource';
 
 import {ResourceFilterType} from '@models/appstate';
-import {K8sResource} from '@models/k8sresource';
+import {K8sResource, ResourceRefType} from '@models/k8sresource';
 
 import {isPassingKeyValueFilter} from '@utils/filter';
 import {removeNestedEmptyObjects} from '@utils/objects';
@@ -133,4 +133,16 @@ export function getDefaultNamespaceForApply(
   }
 
   return {defaultNamespace: namespace};
+}
+
+export function countResourceWarnings(resources: K8sResource[]): number {
+  return resources.reduce<number>((acc, resource) => {
+    return acc + (resource.refs ? resource.refs.filter(ref => ref.type === ResourceRefType.Unsatisfied).length : 0);
+  }, 0);
+}
+
+export function countResourceErrors(resources: K8sResource[]): number {
+  return resources.reduce<number>((acc, resource) => {
+    return acc + (resource.validation && !resource.validation.isValid ? resource.validation.errors.length : 0);
+  }, 0);
 }


### PR DESCRIPTION
This PR closes https://github.com/kubeshop/monokle/issues/1495

## Changes

- Aggregates warnings on collapsing a navigation section.

## How to test it

- Open a project with warnings or errors
- Collapse a nav section with said warnings
- Validate that warnings are aggregated.

## Screenshots

https://user-images.githubusercontent.com/7761005/161929246-c4be3314-8a17-4e89-945c-5daf87d1d961.mov

## Checklist

- [x ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
