### PR TITLE
fix: fix collapsed nav section warning count

### DIFF
--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionNameCounter.tsx
@@ -3,6 +3,7 @@ import React, {useMemo} from 'react';
 import {SectionCustomComponentProps} from '@models/navigator';
 
 import {useAppSelector} from '@redux/hooks';
+import {filteredResourceMapSelector} from '@redux/selectors';
 
 import {Icon} from '@components/atoms';
 
@@ -14,9 +15,12 @@ import * as S from './ResourceKindSectionNameCounter.styled';
 function ResourceKindSectionCounter({sectionInstance, onClick}: SectionCustomComponentProps) {
   const {id, isSelected, itemIds} = sectionInstance;
   const isCollapsed = useAppSelector(state => state.navigator.collapsedSectionIds.includes(id));
-  const resources = useAppSelector(state => itemIds.map(itemId => state.main.resourceMap[itemId]).filter(isDefined));
+  const filteredResourceMap = useAppSelector(filteredResourceMapSelector);
   const selected = isSelected && isCollapsed;
 
+  const resources = useMemo(() => {
+    return itemIds.map(itemId => filteredResourceMap[itemId]).filter(isDefined);
+  }, [itemIds, filteredResourceMap]);
   const resourceCount = resources.length;
   const warningCount = useMemo(() => countResourceWarnings(resources), [resources]);
   const errorCount = useMemo(() => countResourceErrors(resources), [resources]);

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -71,6 +71,16 @@ export const filteredResourceSelector = createSelector(
   (resourceMap, filter) => Object.values(resourceMap).filter(resource => isResourcePassingFilter(resource, filter))
 );
 
+export const filteredResourceMapSelector = createSelector(
+  (state: RootState) => state.main.resourceMap,
+  (state: RootState) => state.main.resourceFilter,
+  (resourceMap, filter) =>
+    _.keyBy(
+      Object.values(resourceMap).filter(resource => isResourcePassingFilter(resource, filter)),
+      'id'
+    )
+);
+
 export const kustomizationsSelector = createSelector(allResourcesSelector, resources =>
   resources.filter((r: K8sResource) => isKustomizationResource(r))
 );


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle/issues/1593

## Fixes

- Properly use filtered resources.

## How to test it

- Open a project with a section that has multiple errors.
- Add a filter which removes one of the many errors.
- Collapse the section.
- Validate that the count is correct.

## Screenshots


https://user-images.githubusercontent.com/7761005/162968306-f69ff571-00e1-4b9c-be0a-1f20a8e5b5ab.mov



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
