### PR TITLE
fix: Nucleus initialization

### DIFF
--- a/electron/app/createWindow.ts
+++ b/electron/app/createWindow.ts
@@ -141,8 +141,6 @@ export const createWindow = (givenPath?: string) => {
   win.webContents.on('dom-ready', async () => {
     const dispatch = createDispatchForWindow(win);
 
-    Nucleus.appStarted();
-
     subscribeToStoreStateChanges(win.webContents, storeState => {
       createMenu(storeState, dispatch);
       let projectName = activeProjectSelector(storeState)?.name;

--- a/electron/app/index.ts
+++ b/electron/app/index.ts
@@ -20,6 +20,9 @@ const isDev = process.env.NODE_ENV === 'development';
 const userHomeDir = app.getPath('home');
 const userDataDir = app.getPath('userData');
 
+// This has to run before everything else related to Nucleus.
+Nucleus.appStarted();
+
 let {disableErrorReports} = initNucleus(isDev, app);
 unhandled({
   logger: error => {


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- the `appStarted` call should happen before any other call related to Nucleus, as per the discussion we had with their support team 

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
