### PR TITLE
fix: cluster namespaces list if no kubeConfig set

### DIFF
--- a/src/hooks/useTargetClusterNamespaces.ts
+++ b/src/hooks/useTargetClusterNamespaces.ts
@@ -16,6 +16,11 @@ export function useTargetClusterNamespaces(): [string[], Dispatch<SetStateAction
 
   useEffect(() => {
     const setClusterNamespaces = async () => {
+      if (!kubeConfigPath.trim().length) {
+        setNamespaces([]);
+        return;
+      }
+
       let clusterNamespaces = await getTargetClusterNamespaces(kubeConfigPath, kubeConfigContext, clusterAccess);
       clusterNamespaces.sort((a, b) => {
         if (a === 'default') {


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
