### PR TITLE
fix: ui updates colors and borders

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
@@ -100,7 +100,7 @@ export const ClusterOutlined = styled(RawClusterOutlined)`
 export const ClusterStatus = styled.div`
   display: flex;
   align-items: center;
-  border: 1px solid ${Colors.grey3};
+  border: 1px solid ${Colors.grey5};
   border-radius: 4px;
   padding: 0px 8px;
 `;

--- a/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
@@ -81,7 +81,7 @@ export const ProjectFolderOpenOutlined = styled(RawFolderOpenOutlined)`
 export const ProjectContainer = styled.div`
   display: flex;
   align-items: center;
-  border: 1px solid ${Colors.grey3};
+  border: 1px solid ${Colors.grey5};
   border-radius: 4px;
   margin-right: 10px;
   padding: 0px 10px;

--- a/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
@@ -41,7 +41,7 @@ const MenuButton: React.FC<IMenuButtonProps> = props => {
     return Object.values(sectionInstanceByName).some(sectionInstance => sectionInstance.isSelected);
   }, [sectionInstanceByName]);
 
-  const style: React.CSSProperties = {width: '100%'};
+  const style: React.CSSProperties = {width: '100%', borderRadius: '0px'};
 
   const hasGradientBackground = useMemo(() => {
     return Boolean(

--- a/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
@@ -45,6 +45,7 @@ const MenuButton: React.FC<IMenuButtonProps> = props => {
     width: '100%',
     borderRadius: '0px',
     background: !isSelected || !isActive ? 'transparent' : PanelColors.toolBar,
+    height: '45px',
   };
 
   const hasGradientBackground = useMemo(() => {

--- a/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
+++ b/src/components/organisms/PaneManager/MenuButton/MenuButton.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 
 import {useAppSelector} from '@redux/hooks';
 
-import Colors from '@styles/Colors';
+import Colors, {PanelColors} from '@styles/Colors';
 
 import * as S from './styled';
 
@@ -41,7 +41,11 @@ const MenuButton: React.FC<IMenuButtonProps> = props => {
     return Object.values(sectionInstanceByName).some(sectionInstance => sectionInstance.isSelected);
   }, [sectionInstanceByName]);
 
-  const style: React.CSSProperties = {width: '100%', borderRadius: '0px'};
+  const style: React.CSSProperties = {
+    width: '100%',
+    borderRadius: '0px',
+    background: !isSelected || !isActive ? 'transparent' : PanelColors.toolBar,
+  };
 
   const hasGradientBackground = useMemo(() => {
     return Boolean(

--- a/src/components/organisms/PaneManager/MenuButton/styled.ts
+++ b/src/components/organisms/PaneManager/MenuButton/styled.ts
@@ -2,7 +2,7 @@ import {Button} from 'antd';
 
 import styled from 'styled-components';
 
-import Colors, {PanelColors} from '@styles/Colors';
+import Colors from '@styles/Colors';
 
 export const StyledButton = styled(Button)<{$hasGradientBackground: boolean; $showOpenArrow: boolean}>`
   display: flex;
@@ -10,14 +10,14 @@ export const StyledButton = styled(Button)<{$hasGradientBackground: boolean; $sh
   justify-content: center;
   position: relative;
   border-radius: 0px;
+  transition: none;
 
   ${props => {
-    if (!props.$showOpenArrow) {
-      return ` background-color: ${PanelColors.toolBar} !important;
-            `;
-    }
     if (props.$showOpenArrow) {
       return `
+      &:hover, &:active, &:focus {
+        background-color: transparent;
+      }
       &:hover {
         &: after {
           position: absolute;
@@ -41,10 +41,6 @@ export const StyledButton = styled(Button)<{$hasGradientBackground: boolean; $sh
       }`;
     }
   }}
-
-  & .anticon {
-    transition: all 0.2s ease-in;
-  }
 
   ${props => `
     &:hover {

--- a/src/components/organisms/PaneManager/MenuButton/styled.ts
+++ b/src/components/organisms/PaneManager/MenuButton/styled.ts
@@ -9,6 +9,7 @@ export const StyledButton = styled(Button)<{$hasGradientBackground: boolean; $sh
   align-items: center;
   justify-content: center;
   position: relative;
+  border-radius: 0px;
 
   ${props => {
     if (!props.$showOpenArrow) {

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -1,10 +1,8 @@
 import {useEffect, useMemo, useState} from 'react';
 
-import {Tooltip} from 'antd';
-
 import {FolderOpenOutlined, FolderOutlined, FormatPainterOutlined} from '@ant-design/icons';
 
-import {ROOT_FILE_ENTRY, TOOLTIP_DELAY} from '@constants/constants';
+import {ROOT_FILE_ENTRY} from '@constants/constants';
 
 import {LeftMenuSelectionType} from '@models/ui';
 
@@ -25,6 +23,7 @@ import {KUSTOMIZE_PATCH_SECTION_NAME} from '@src/navsections/KustomizePatchSecti
 import MenuButton from './MenuButton';
 import MenuIcon from './MenuIcon';
 import * as S from './PaneManagerLeftMenu.styled';
+import PaneTooltip from './PaneTooltip';
 
 const PaneManagerLeftMenu: React.FC = () => {
   const dispatch = useAppDispatch();
@@ -79,9 +78,9 @@ const PaneManagerLeftMenu: React.FC = () => {
 
   return (
     <S.Container id="LeftToolbar" isLeftActive={leftActive}>
-      <Tooltip
-        mouseEnterDelay={TOOLTIP_DELAY}
-        title={leftMenuSelection === 'file-explorer' && leftActive ? 'Hide File Explorer' : 'View File Explorer'}
+      <PaneTooltip
+        show={!leftActive || !(leftMenuSelection === 'file-explorer')}
+        title="View File Explorer"
         placement="right"
       >
         <MenuButton
@@ -99,11 +98,11 @@ const PaneManagerLeftMenu: React.FC = () => {
             isSelected={Boolean(activeProject) && leftMenuSelection === 'file-explorer'}
           />
         </MenuButton>
-      </Tooltip>
+      </PaneTooltip>
 
-      <Tooltip
-        mouseEnterDelay={TOOLTIP_DELAY}
-        title={leftMenuSelection === 'kustomize-pane' && leftActive ? 'Hide Kustomizations' : 'View Kustomizations'}
+      <PaneTooltip
+        show={!leftActive || !(leftMenuSelection === 'kustomize-pane')}
+        title="View Kustomizations"
         placement="right"
       >
         <MenuButton
@@ -127,11 +126,11 @@ const PaneManagerLeftMenu: React.FC = () => {
             />
           </S.Badge>
         </MenuButton>
-      </Tooltip>
+      </PaneTooltip>
 
-      <Tooltip
-        mouseEnterDelay={TOOLTIP_DELAY}
-        title={leftMenuSelection === 'helm-pane' && leftActive ? 'Hide Helm Charts' : 'View Helm Charts'}
+      <PaneTooltip
+        show={!leftActive || !(leftMenuSelection === 'helm-pane')}
+        title="View Helm Charts"
         placement="right"
       >
         <WalkThrough placement="rightTop" step="kustomizeHelm">
@@ -157,11 +156,11 @@ const PaneManagerLeftMenu: React.FC = () => {
             </S.Badge>
           </MenuButton>
         </WalkThrough>
-      </Tooltip>
+      </PaneTooltip>
 
-      <Tooltip
-        mouseEnterDelay={TOOLTIP_DELAY}
-        title={leftMenuSelection === 'templates-pane' && leftActive ? 'Hide Templates' : 'View Templates'}
+      <PaneTooltip
+        show={!leftActive || !(leftMenuSelection === 'templates-pane')}
+        title="View Templates"
         placement="right"
       >
         <MenuButton
@@ -178,7 +177,7 @@ const PaneManagerLeftMenu: React.FC = () => {
             isSelected={Boolean(activeProject) && leftMenuSelection === 'templates-pane'}
           />
         </MenuButton>
-      </Tooltip>
+      </PaneTooltip>
     </S.Container>
   );
 };

--- a/src/components/organisms/PaneManager/PaneManagerSplitView.styled.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerSplitView.styled.tsx
@@ -17,14 +17,14 @@ export const EditorPaneContainer = styled.div`
 `;
 
 export const LeftPaneContainer = styled.div`
-  height: 100%;
-  border-right: ${AppBorders.sectionDivider};
   position: relative;
+  height: 100%;
+  background: ${PanelColors.toolBar};
+  border-right: ${AppBorders.sectionDivider};
 
   & .custom-modal-handle {
     right: -3px;
   }
-  background: ${PanelColors.toolBar};
 `;
 
 export const Pane = styled.div<{$height?: number}>`

--- a/src/components/organisms/PaneManager/PaneTooltip/PaneTooltip.tsx
+++ b/src/components/organisms/PaneManager/PaneTooltip/PaneTooltip.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import {Tooltip, TooltipProps} from 'antd';
+
+import {TOOLTIP_DELAY} from '@constants/constants';
+
+type PaneTooltipProps = {
+  show: boolean;
+  mouseEnterDelay?: number;
+  title: string;
+  placement: TooltipProps['placement'];
+  children: React.ReactNode;
+};
+
+const PaneTooltip = ({show, mouseEnterDelay = TOOLTIP_DELAY, title, placement, children}: PaneTooltipProps) => {
+  return (
+    <>
+      {show ? (
+        <Tooltip mouseEnterDelay={mouseEnterDelay} title={title} placement={placement}>
+          {children}
+        </Tooltip>
+      ) : (
+        <>{children}</>
+      )}
+    </>
+  );
+};
+
+export default PaneTooltip;

--- a/src/components/organisms/PaneManager/PaneTooltip/index.ts
+++ b/src/components/organisms/PaneManager/PaneTooltip/index.ts
@@ -1,0 +1,1 @@
+export {default} from './PaneTooltip';

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -10,8 +10,8 @@ enum Colors {
   grey400 = '#DBE0DE',
   grey200 = '#F3F5F4',
   grey100 = '#F9FAFA',
-  grey11 = '#141718',
-  grey10 = '#242C2F',
+  grey11 = '#101314',
+  grey10 = '#191F21',
   grey9 = '#DBDBDB', // gray, grey 9
   grey8 = '#ACACAC', // gray, gray 8
   grey7 = '#7D7D7D', // gray, gray 7 https://www.figma.com/file/3UVW3KVNob7QjgvH62blGU/add-left-and-right-toolbars?node-id=3%3A5926


### PR DESCRIPTION
This PR...

## Changes
Updated according to Julio Comments:
please change colors to:
- top: #101314
- left: #191F21
- the border colors of drop-downs in the top, which are gray-4, have them to gray-5
- the left tab, when highlighted, looks like it have a 2px radio. we need to take that out
- first time, when file explorer is open, the tab on the left does not appear highlighted. We need to highlight it so the tab look is there from scratch

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
