### PR TITLE
Helm Charts fixes and improvements

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -11,6 +11,7 @@ import {ArrowLeftOutlined, ArrowRightOutlined, BookOutlined, CodeOutlined, Conta
 import {
   ACTIONS_PANE_FOOTER_DEFAULT_HEIGHT,
   ACTIONS_PANE_FOOTER_EXPANDED_DEFAULT_HEIGHT,
+  HELM_CHART_ENTRY_FILE,
   HELM_CHART_HELP_URL,
   KUSTOMIZE_HELP_URL,
   TOOLTIP_DELAY,
@@ -44,7 +45,7 @@ import {
   kubeConfigPathSelector,
 } from '@redux/selectors';
 import {getResourcesForPath} from '@redux/services/fileEntry';
-import {isHelmChartFile, isHelmValuesFile} from '@redux/services/helm';
+import {isHelmChartFile, isHelmTemplateFile, isHelmValuesFile} from '@redux/services/helm';
 import {isKustomizationPatch, isKustomizationResource} from '@redux/services/kustomize';
 import {startPreview} from '@redux/services/preview';
 import {isUnsavedResource} from '@redux/services/resource';
@@ -395,6 +396,8 @@ const ActionsPane: React.FC<IProps> = props => {
   const isDeployButtonDisabled = useMemo(() => {
     return (
       (!selectedResourceId && !selectedPath) ||
+      (selectedPath && selectedPath.endsWith(HELM_CHART_ENTRY_FILE)) ||
+      (selectedPath && isHelmTemplateFile(selectedPath)) ||
       (selectedResource &&
         !isKustomizationResource(selectedResource) &&
         (isKustomizationPatch(selectedResource) || !knownResourceKinds.includes(selectedResource.kind)))

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -64,19 +64,25 @@ const RootHelmChartsSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmC
 sectionBlueprintMap.register(RootHelmChartsSectionBlueprint);
 
 HelmChartEventEmitter.on('create', helmChart => {
-  const {valuesFilesSectionBlueprint, helmChartSectionBlueprint, previewConfigurationsSectionBlueprint} =
-    makeHelmChartSectionBlueprint(helmChart);
+  const {
+    valuesFilesSectionBlueprint,
+    helmChartSectionBlueprint,
+    previewConfigurationsSectionBlueprint,
+    templateFilesSectionBlueprint,
+  } = makeHelmChartSectionBlueprint(helmChart);
   if (RootHelmChartsSectionBlueprint.childSectionIds) {
     RootHelmChartsSectionBlueprint.childSectionIds?.push(helmChartSectionBlueprint.id);
   } else {
     RootHelmChartsSectionBlueprint.childSectionIds = [helmChartSectionBlueprint.id];
   }
+  sectionBlueprintMap.register(templateFilesSectionBlueprint);
   sectionBlueprintMap.register(previewConfigurationsSectionBlueprint);
   sectionBlueprintMap.register(valuesFilesSectionBlueprint);
   sectionBlueprintMap.register(helmChartSectionBlueprint);
 });
 
 HelmChartEventEmitter.on('remove', helmChartId => {
+  sectionBlueprintMap.remove(`${helmChartId}-templates`, [RootHelmChartsSectionBlueprint.id, helmChartId]);
   sectionBlueprintMap.remove(`${helmChartId}-configurations`, [RootHelmChartsSectionBlueprint.id, helmChartId]);
   sectionBlueprintMap.remove(`${helmChartId}-values`, [RootHelmChartsSectionBlueprint.id, helmChartId]);
   sectionBlueprintMap.remove(helmChartId, [RootHelmChartsSectionBlueprint.id]);

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -21,6 +21,7 @@ import {
   getHelmValuesFile,
   isHelmChartFile,
   isHelmChartFolder,
+  isHelmTemplateFile,
   isHelmValuesFile,
   processHelmChartFolder,
 } from '@redux/services/helm';
@@ -189,10 +190,9 @@ export function readFiles(
       const filePath = path.join(folder, file);
       const fileEntryPath = filePath.substring(rootFolder.length);
       const fileEntry = createFileEntry({fileEntryPath, fileMap, helmChartId: helmChart?.id});
-      if (helmChart) {
+      if (helmChart && isHelmTemplateFile(fileEntry.filePath)) {
         helmChart.templateFilePaths.push(fileEntryPath);
       }
-
       if (fileIsExcluded(fileEntry, projectConfig)) {
         fileEntry.isExcluded = true;
       } else if (getFileStats(filePath)?.isDirectory()) {

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -50,6 +50,16 @@ export function isHelmValuesFile(filePath: string): boolean {
 }
 
 /**
+ * Checks if the specified path is a helm chart template
+ */
+export function isHelmTemplateFile(filePath: string): boolean {
+  return (
+    filePath.includes('templates') &&
+    ['*.yaml', '*.yml'].some(ext => micromatch.isMatch(path.basename(filePath).toLowerCase(), ext))
+  );
+}
+
+/**
  * Checks if the specified path is a helm chart file
  */
 
@@ -73,7 +83,7 @@ export function createHelmValuesFile(fileEntry: FileEntry, helmChart: HelmChart,
   const helmValues: HelmValuesFile = {
     id: uuidv4(),
     filePath: fileEntry.filePath,
-    name: fileEntry.filePath.substring(path.dirname(helmChart.filePath).length + 1),
+    name: path.basename(fileEntry.filePath),
     isSelected: false,
     helmChartId: helmChart.id,
   };
@@ -115,7 +125,6 @@ export function processHelmChartFolder(
       const filePath = path.join(folder, file);
       const fileEntryPath = filePath.substring(rootFolder.length);
       const fileEntry = createFileEntry({fileEntryPath, fileMap, helmChartId: helmChart.id});
-      helmChart.templateFilePaths.push(fileEntryPath);
 
       if (fileIsExcluded(fileEntry, projectConfig)) {
         fileEntry.isExcluded = true;
@@ -140,6 +149,8 @@ export function processHelmChartFolder(
         createHelmValuesFile(fileEntry, helmChart, helmValuesMap);
       } else if (!isHelmChartFile(filePath) && fileIsIncluded(fileEntry, projectConfig)) {
         extractResourcesForFileEntry(fileEntry, fileMap, resourceMap);
+      } else if (isHelmTemplateFile(fileEntry.filePath)) {
+        helmChart.templateFilePaths.push(fileEntryPath);
       }
 
       result.push(fileEntry.name);

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,17 +1,19 @@
-import {expect, test} from '@playwright/test';
+import {execSync} from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import {Page} from 'playwright';
 import {ElectronApplication} from 'playwright-core';
-import {execSync} from 'child_process';
-import * as path from 'path';
-import * as fs from 'fs';
+
+import {expect, test} from '@playwright/test';
+
 import {ElectronAppInfo, startApp} from './electronHelpers';
-import {getRecordingPath, pause} from './utils';
-import {MainWindow} from './models/mainWindow';
 import {FileExplorerPane} from './models/fileExplorerPane';
-import {KustomizePane} from './models/kustomizePane';
 import {HelmPane} from './models/helmPane';
-import {StartProjectPane} from './models/startProjectPane';
+import {KustomizePane} from './models/kustomizePane';
+import {MainWindow} from './models/mainWindow';
 import {NavigatorPane} from './models/navigatorPane';
+import {StartProjectPane} from './models/startProjectPane';
+import {getRecordingPath, pause} from './utils';
 
 let appWindow: Page;
 let appInfo: ElectronAppInfo;
@@ -67,33 +69,33 @@ const testData = [
     hash: startCommit,
     fileExplorerCount: 54,
     kustomizeCount: 13,
-    helmCount: 9,
+    helmCount: 12,
     navigatorCount: 54,
   },
   {
     hash: removeSomeFiles,
     fileExplorerCount: 33,
     kustomizeCount: 6,
-    helmCount: 9,
+    helmCount: 12,
     navigatorCount: 47,
   },
   {
     hash: removeMoreFiles,
     fileExplorerCount: 16,
     kustomizeCount: 3,
-    helmCount: 9,
+    helmCount: 12,
     navigatorCount: 34,
   },
   {
     hash: startCommit,
     fileExplorerCount: 54,
     kustomizeCount: 13,
-    helmCount: 9,
+    helmCount: 12,
     navigatorCount: 54,
   },
 ];
 
-test('all files should be loaded', async () => {
+test.only('all files should be loaded', async () => {
   await mainWindow.clickLogo();
   await startProjectPane.createProjectFromFolder(electronApp, projectPath);
   await pause(10000);
@@ -125,5 +127,5 @@ test('all files should be loaded', async () => {
 test.afterAll(async () => {
   await appWindow.screenshot({path: getRecordingPath(appInfo.platform, 'final-screen.png')});
   await appWindow.close();
-  fs.rmSync(projectPath, { recursive: true, force: true });
+  fs.rmSync(projectPath, {recursive: true, force: true});
 });


### PR DESCRIPTION
This PR...

## Changes

- added "Templates" section for all helm charts in the Helm pane

## Fixes

- population of `templateFilePaths` property of helm charts
- closes #1647 

## How to test it

-

## Screenshots

<img width="396" alt="image" src="https://user-images.githubusercontent.com/20538711/165330602-88f9176d-0220-4a4b-b28b-544c1b3e22f2.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
