### PR TITLE
Wito/fix/unsaved resources

### DIFF
--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -54,11 +54,10 @@ const generateFullFileName = (
   existingFileNames: string[],
   includeKind?: boolean
 ): string => {
-  const {kind, name} = resource;
-  let fullFileName = getFullFileName(
-    `${name}${includeKind ? `-${kind}` : ''}${suffix ? ` (${suffix})` : ''}`,
-    fileIncludes
-  );
+  const name = resource.name;
+  const nameKind = includeKind ? `-${resource.kind.toLowerCase()}` : '';
+  const nameSuffix = suffix ? ` (${suffix})` : '';
+  const fullFileName = getFullFileName(`${name}${nameKind}${nameSuffix}`, fileIncludes);
   let foundFile: fs.Dirent | FileEntry | undefined;
   let foundExistingFileName = false;
 

--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -28,6 +28,7 @@ import FileExplorer from '@components/atoms/FileExplorer';
 
 import {useFileExplorer} from '@hooks/useFileExplorer';
 
+import {isDefined} from '@utils/filter';
 import {removeIgnoredPathsFromResourceContent} from '@utils/resources';
 
 import Colors from '@styles/Colors';
@@ -280,6 +281,10 @@ const SaveResourceToFileFolderModal: React.FC = () => {
       }
 
       let existingFileNames: string[] = [];
+      const resources = resourcesIds.map(id => resourceMap[id]).filter(isDefined);
+      const hasNameClash = resources.some(resource =>
+        resources.filter(r => r.id !== resource.id).some(r => r.name === resource.name)
+      );
 
       resourcesIds.forEach(resourceId => {
         const resource = resourceMap[resourceId];
@@ -290,7 +295,8 @@ const SaveResourceToFileFolderModal: React.FC = () => {
           selectedFolder,
           fileMap,
           0,
-          existingFileNames
+          existingFileNames,
+          hasNameClash
         );
 
         if (!existingFileNames.includes(fullFileName)) {

--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -75,7 +75,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
   const isRoot = treeKey === ROOT_FILE_ENTRY;
   const root = fileMap[ROOT_FILE_ENTRY];
   const relativePath = isRoot ? getBasename(path.normalize(treeKey)) : treeKey;
-  const absolutePath = isRoot ? treeKey : path.join(root.filePath, treeKey);
+  const absolutePath = isRoot ? root.filePath : path.join(root.filePath, treeKey);
 
   const target = isRoot ? ROOT_FILE_ENTRY : treeKey.replace(path.sep, '');
 

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -20,6 +20,7 @@ import {
   ResourceMapType,
   SelectionHistoryEntry,
 } from '@models/appstate';
+import {FileEntry} from '@models/fileentry';
 import {HelmChart} from '@models/helm';
 import {K8sResource} from '@models/k8sresource';
 import {ThunkApi} from '@models/thunk';
@@ -813,14 +814,19 @@ export const mainSlice = createSlice({
         if (resourceFileEntry) {
           resourceFileEntry.timestamp = resourcePayload.fileTimestamp;
         } else {
-          const newFileEntry = {
+          const newFileEntry: FileEntry = {
             ...createFileEntry({fileEntryPath: relativeFilePath, fileMap: state.fileMap}),
             isSupported: true,
+            timestamp: resourcePayload.fileTimestamp,
           };
-          newFileEntry.timestamp = resourcePayload.fileTimestamp;
+          state.fileMap[relativeFilePath] = newFileEntry;
+
+          // add to parent's children
           const childFileName = path.basename(relativeFilePath);
           const parentPath = path.join(path.sep, relativeFilePath.replace(`${path.sep}${childFileName}`, '')).trim();
-          if (parentPath === path.sep) {
+          const isRoot = parentPath === path.sep;
+
+          if (isRoot) {
             const rootFileEntry = state.fileMap[ROOT_FILE_ENTRY];
             if (rootFileEntry.children) {
               rootFileEntry.children.push(childFileName);

--- a/src/redux/thunks/saveUnsavedResources.ts
+++ b/src/redux/thunks/saveUnsavedResources.ts
@@ -1,7 +1,6 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 
 import fs from 'fs';
-import micromatch from 'micromatch';
 import util from 'util';
 
 import {ROOT_FILE_ENTRY, YAML_DOCUMENT_DELIMITER} from '@constants/constants';
@@ -11,7 +10,7 @@ import {FileEntry} from '@models/fileentry';
 import {K8sResource} from '@models/k8sresource';
 import {RootState} from '@models/rootstate';
 
-import {getFileTimestamp} from '@utils/files';
+import {getFileTimestamp, hasValidExtension} from '@utils/files';
 import {ADD_NEW_RESOURCE, trackEvent} from '@utils/telemetry';
 
 import {createRejectionWithAlert} from './utils';
@@ -54,7 +53,7 @@ const performSaveUnsavedResource = async (
   } else {
     const fileName = absolutePath.split('\\').pop();
 
-    if (fileName && !micromatch.isMatch(fileName, fileIncludes)) {
+    if (!hasValidExtension(fileName, ['.yaml', '.yml'])) {
       throw new Error('The selected file does not have .yaml extension.');
     }
 
@@ -115,7 +114,7 @@ export const saveUnsavedResources = createAsyncThunk<
       });
     } catch (e) {
       if (e instanceof Error) {
-        createRejectionWithAlert(thunkAPI, ERROR_TITLE, e.message);
+        return createRejectionWithAlert(thunkAPI, ERROR_TITLE, e.message);
       }
     }
   }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -105,3 +105,8 @@ export interface CreateFolderCallback {
 export function createFolder(rootDir: string, folderName: string, callback: (args: CreateFolderCallback) => any) {
   return fs.mkdir(`${rootDir}${path.sep}${folderName}`, err => callback({rootDir, folderName, err}));
 }
+
+export function hasValidExtension(file: string | undefined, extensions: string[]): boolean {
+  if (!file) return false;
+  return extensions.some(extension => file.endsWith(extension));
+}


### PR DESCRIPTION
This PR fixes #1644.

## Fixes

- Adds resource kind to all resources on name clash.
- Fix an issue where newly added resources are unsupported.
- Fix an issue where newly added resources are unavailable in drop downs.
- Fix appending resources to a file.
- Fix reveal root.

## How to test it

- See the issue description.

## Screenshots

note: there is still a small issue when the appended file is highlighted but its not trivial to fix. These are already sufficient fixes and we can improve the file explorer later (Reason is that highlighted node is not in store).

https://user-images.githubusercontent.com/7761005/165745406-d25075b6-659d-4b1b-9b6f-ab6c62b43c40.mov

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
