### PR TITLE
chore: temp alternative telemetry

### DIFF
--- a/.github/workflows/monokle-build-nightly.yml
+++ b/.github/workflows/monokle-build-nightly.yml
@@ -83,6 +83,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: package
@@ -216,6 +217,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: package
@@ -328,6 +330,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: package

--- a/.github/workflows/monokle-publish-downloads.yml
+++ b/.github/workflows/monokle-publish-downloads.yml
@@ -85,6 +85,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         run: |
@@ -214,6 +215,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         run: |
@@ -310,6 +312,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         run: |

--- a/.github/workflows/monokle-publish.yml
+++ b/.github/workflows/monokle-publish.yml
@@ -79,6 +79,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: build
@@ -199,6 +200,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: package
@@ -287,6 +289,7 @@ jobs:
           # Set CI flag to false, or the build fails on all warnings, not just errors as locally.
           CI: false
           NUCLEUS_SH_APP_ID: ${{ secrets.NUCLEUS_SH_APP_ID }}
+          MONOKLE_INSTALLS_URL: ${{ secrets.MONOKLE_INSTALLS_URL }}
 
       - name: Package
         id: package

--- a/electron/app/index.ts
+++ b/electron/app/index.ts
@@ -23,7 +23,7 @@ const userDataDir = app.getPath('userData');
 // This has to run before everything else related to Nucleus.
 Nucleus.appStarted();
 
-let {disableErrorReports} = initNucleus(isDev, app);
+let {disableErrorReports, disableTracking} = initNucleus(isDev, app);
 unhandled({
   logger: error => {
     if (!disableErrorReports) {
@@ -35,7 +35,7 @@ unhandled({
 
 setProjectsRootFolder(userHomeDir);
 saveInitialK8sSchema(userDataDir);
-setDeviceID(machineIdSync());
+setDeviceID(machineIdSync(), disableTracking);
 fixPath();
 
 if (process.env.MONOKLE_RUN_AS_NODE) {


### PR DESCRIPTION
This PR...

## Changes

- to make sure the Nucleus installations and sessions are tracked correctly, we will also temporarily track them using our own endpoint

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
