### PR TITLE
feat: separate walkthrough for new users and release features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,7 +192,9 @@ const App = () => {
   const onCloseReleaseNotes = useCallback(() => {
     setShowReleaseNotes(false);
     if (!electronStore.get('appConfig.lastSeenReleaseNotesVersion')) {
-      dispatch(handleWalkThroughStep(StepEnum.Next));
+      dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
+    } else {
+      dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'release'}));
     }
     electronStore.set('appConfig.lastSeenReleaseNotesVersion', appVersion);
   }, [appVersion, dispatch]);

--- a/src/components/molecules/SectionRenderer/SectionHeader.tsx
+++ b/src/components/molecules/SectionRenderer/SectionHeader.tsx
@@ -113,7 +113,7 @@ function SectionHeader(props: SectionHeaderProps) {
               <NamePrefix.Component sectionInstance={sectionInstance} onClick={toggleCollapse} />
             )}
             {name === 'K8s Resources' ? (
-              <WalkThrough placement="rightTop" step="resource">
+              <WalkThrough placement="rightTop" step="resource" collection="novice">
                 <S.Name
                   $isSelected={sectionInstance.isSelected && isCollapsed}
                   $isHighlighted={sectionInstance.isSelected && isCollapsed}

--- a/src/components/molecules/WalkThrough/WalkThrough.tsx
+++ b/src/components/molecules/WalkThrough/WalkThrough.tsx
@@ -13,11 +13,11 @@ import {walkThroughNoviceContent} from './walkThroughNoviceContent';
 
 import * as S from './styled';
 
-type WalkThroughProps = {
-  step: WalkThroughStep;
+type WalkThroughProps<C extends WalkThroughCollection> = {
+  step: WalkThroughStep<C>;
   children: React.ReactNode;
   placement?: PopoverProps['placement'];
-  collection: WalkThroughCollection;
+  collection: C;
 };
 
 const walkThroughCollection = {
@@ -68,8 +68,8 @@ const WalkThroughContent = (props: WalkThroughContentProps) => {
   );
 };
 
-const WalkThrough = (props: WalkThroughProps) => {
-  const {placement, children, step, collection} = props;
+const WalkThrough = <C extends WalkThroughCollection>(props: WalkThroughProps<C>) => {
+  const {placement, step, collection, children} = props;
   const walkThroughStep = useAppSelector(state => state.ui.walkThrough[collection].currentStep);
   const data = walkThroughCollection[collection][walkThroughStep] || {};
 

--- a/src/components/molecules/WalkThrough/WalkThrough.tsx
+++ b/src/components/molecules/WalkThrough/WalkThrough.tsx
@@ -7,8 +7,9 @@ import {CloseOutlined} from '@ant-design/icons';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {cancelWalkThrough, handleWalkThroughStep} from '@redux/reducers/ui';
 
-import {StepEnum, WalkThroughContentProps, WalkThroughStep} from './types';
-import {walkThroughContent} from './walkThroughContent';
+import {newReleaseFeatureContent} from './newReleaseFeaturesContent';
+import {StepEnum, WalkThroughCollection, WalkThroughContentProps, WalkThroughStep} from './types';
+import {walkThroughNoviceContent} from './walkThroughNoviceContent';
 
 import * as S from './styled';
 
@@ -16,14 +17,20 @@ type WalkThroughProps = {
   step: WalkThroughStep;
   children: React.ReactNode;
   placement?: PopoverProps['placement'];
+  collection: WalkThroughCollection;
 };
 
-const WalkThroughTitle = (props: {title: string}) => {
-  const {title} = props;
+const walkThroughCollection = {
+  novice: walkThroughNoviceContent,
+  release: newReleaseFeatureContent,
+};
+
+const WalkThroughTitle = (props: {title: string; collection: WalkThroughCollection}) => {
+  const {title, collection} = props;
   const dispatch = useAppDispatch();
 
   const handleClose = () => {
-    dispatch(cancelWalkThrough());
+    dispatch(cancelWalkThrough(collection));
   };
 
   return (
@@ -35,14 +42,14 @@ const WalkThroughTitle = (props: {title: string}) => {
 };
 
 const WalkThroughContent = (props: WalkThroughContentProps) => {
-  const {data, currentStep} = props;
+  const {data, currentStep, collection} = props;
   const dispatch = useAppDispatch();
 
   const handleStep = (step: number) => {
-    dispatch(handleWalkThroughStep(step));
+    dispatch(handleWalkThroughStep({step, collection}));
   };
 
-  const totalSteps = useMemo(() => walkThroughContent.length, []);
+  const totalSteps = useMemo(() => walkThroughCollection[collection].length, []);
   return (
     <>
       <S.Description>{data.content}</S.Description>
@@ -62,15 +69,15 @@ const WalkThroughContent = (props: WalkThroughContentProps) => {
 };
 
 const WalkThrough = (props: WalkThroughProps) => {
-  const {placement, children, step} = props;
-  const walkThroughStep = useAppSelector(state => state.ui.walkThrough.currentStep);
-  const data = walkThroughContent[walkThroughStep] || {};
+  const {placement, children, step, collection} = props;
+  const walkThroughStep = useAppSelector(state => state.ui.walkThrough[collection].currentStep);
+  const data = walkThroughCollection[collection][walkThroughStep] || {};
 
   return (
     <Popover
       placement={placement}
-      content={<WalkThroughContent data={data} currentStep={walkThroughStep} />}
-      title={<WalkThroughTitle title={data.title} />}
+      content={<WalkThroughContent data={data} currentStep={walkThroughStep} collection={collection} />}
+      title={<WalkThroughTitle title={data.title} collection={collection} />}
       visible={data.step === step}
       overlayClassName="walkthrough"
     >

--- a/src/components/molecules/WalkThrough/newReleaseFeaturesContent.ts
+++ b/src/components/molecules/WalkThrough/newReleaseFeaturesContent.ts
@@ -1,0 +1,9 @@
+import {WalkThroughContentProps} from './types';
+
+export const newReleaseFeatureContent: WalkThroughContentProps['data'][] = [
+  {
+    step: 'validation',
+    title: 'Validate policies',
+    content: 'Enable policies to ensure your resources are configured securely.',
+  },
+];

--- a/src/components/molecules/WalkThrough/types.ts
+++ b/src/components/molecules/WalkThrough/types.ts
@@ -1,3 +1,4 @@
+export type WalkThroughCollection = 'novice' | 'release';
 export type WalkThroughStep = 'template' | 'resource' | 'syntax' | 'cluster' | 'kustomizeHelm' | 'validation';
 export type WalkThroughContentProps = {
   data: {
@@ -5,6 +6,7 @@ export type WalkThroughContentProps = {
     title: string;
     content: string;
   };
+  collection: WalkThroughCollection;
   currentStep: number;
 };
 

--- a/src/components/molecules/WalkThrough/types.ts
+++ b/src/components/molecules/WalkThrough/types.ts
@@ -1,5 +1,8 @@
 export type WalkThroughCollection = 'novice' | 'release';
-export type WalkThroughStep = 'template' | 'resource' | 'syntax' | 'cluster' | 'kustomizeHelm' | 'validation';
+export type WalkThroughStep<C extends WalkThroughCollection = WalkThroughCollection> = C extends 'novice'
+  ? 'template' | 'resource' | 'syntax' | 'cluster' | 'kustomizeHelm'
+  : 'validation';
+
 export type WalkThroughContentProps = {
   data: {
     step: WalkThroughStep;

--- a/src/components/molecules/WalkThrough/walkThroughNoviceContent.ts
+++ b/src/components/molecules/WalkThrough/walkThroughNoviceContent.ts
@@ -1,6 +1,6 @@
 import {WalkThroughContentProps} from './types';
 
-export const walkThroughContent: WalkThroughContentProps['data'][] = [
+export const walkThroughNoviceContent: WalkThroughContentProps['data'][] = [
   {
     step: 'template',
     title: 'Find your projects here',
@@ -30,10 +30,5 @@ export const walkThroughContent: WalkThroughContentProps['data'][] = [
     title: 'Validate Kustomize and Helm output',
     content:
       'Check out and debug your Kustomize and Helm outputs. Change kustomizations and see effects on the generated resources.',
-  },
-  {
-    step: 'validation',
-    title: 'Validate policies',
-    content: 'Enable policies to ensure your resources are configured securely.',
   },
 ];

--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -497,7 +497,7 @@ const ActionsPane: React.FC<Props> = ({height}) => {
               <TabPane
                 key="source"
                 tab={
-                  <WalkThrough placement="leftTop" step="syntax">
+                  <WalkThrough placement="leftTop" step="syntax" collection="novice">
                     <TabHeader icon={<CodeOutlined />}>Source</TabHeader>
                   </WalkThrough>
                 }

--- a/src/components/organisms/NavigatorPane/ClusterCompareButton.tsx
+++ b/src/components/organisms/NavigatorPane/ClusterCompareButton.tsx
@@ -28,7 +28,7 @@ const ClusterCompareButton: React.FC = ({children}) => {
   };
 
   return (
-    <WalkThrough placement="leftTop" step="cluster">
+    <WalkThrough placement="leftTop" step="cluster" collection="novice">
       <Tooltip
         mouseEnterDelay={isFolderOpen ? TOOLTIP_DELAY : 0}
         title={

--- a/src/components/organisms/PageHeader/HelpMenu.tsx
+++ b/src/components/organisms/PageHeader/HelpMenu.tsx
@@ -122,10 +122,13 @@ const HelpMenu = () => {
         </Row>
       </MenuItem>
 
-      <MenuItem onClick={() => {
-        dispatch(cancelWalkThrough());
-        dispatch(handleWalkThroughStep(StepEnum.Next));
-        }} key="replay">
+      <MenuItem
+        onClick={() => {
+          dispatch(cancelWalkThrough('novice'));
+          dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
+        }}
+        key="replay"
+      >
         <Row align="middle">
           <Col span={5}>
             <IconContainerSpan>

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -255,7 +255,7 @@ const ProjectSelection = () => {
 
   return (
     <S.ProjectContainer id="projects-dropdown-container">
-      <WalkThrough placement="leftTop" step="template">
+      <WalkThrough placement="leftTop" step="template" collection="novice">
         <Dropdown
           arrow
           disabled={previewLoader.isLoading || isInPreviewMode}

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -134,7 +134,7 @@ const PaneManagerLeftMenu: React.FC = () => {
         title="View Helm Charts"
         placement="right"
       >
-        <WalkThrough placement="rightTop" step="kustomizeHelm">
+        <WalkThrough placement="rightTop" step="kustomizeHelm" collection="novice">
           <MenuButton
             id="helm-pane"
             isSelected={Boolean(activeProject) && !leftDrawerVisible && leftMenuSelection === 'helm-pane'}
@@ -181,7 +181,7 @@ const PaneManagerLeftMenu: React.FC = () => {
       </PaneTooltip>
 
       <PaneTooltip show={!leftDrawerVisible} title="View Validation" placement="right">
-        <WalkThrough placement="rightTop" step="validation">
+        <WalkThrough placement="rightTop" step="validation" collection="release">
           <MenuButton
             isSelected={leftDrawerVisible}
             isActive={isActive}

--- a/src/models/ui.ts
+++ b/src/models/ui.ts
@@ -123,7 +123,12 @@ export type UiState = {
   };
   activeSettingsPanel?: SettingsPanel;
   walkThrough: {
-    currentStep: number;
+    novice: {
+      currentStep: number;
+    };
+    release: {
+      currentStep: number;
+    };
   };
 };
 

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -196,7 +196,12 @@ const initialUiState: UiState = {
     connectToCluster: false,
   },
   walkThrough: {
-    currentStep: -1,
+    novice: {
+      currentStep: -1,
+    },
+    release: {
+      currentStep: -1,
+    },
   },
 };
 

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -23,6 +23,8 @@ import {setRootFolder} from '@redux/thunks/setRootFolder';
 
 import {SettingsPanel} from '@organisms/SettingsManager/types';
 
+import {WalkThroughCollection} from '@components/molecules/WalkThrough/types';
+
 import electronStore from '@utils/electronStore';
 
 export const uiSlice = createSlice({
@@ -239,11 +241,16 @@ export const uiSlice = createSlice({
     closeAboutModal: (state: Draft<UiState>) => {
       state.isAboutModalOpen = false;
     },
-    cancelWalkThrough: (state: Draft<UiState>) => {
-      state.walkThrough.currentStep = -1;
+    cancelWalkThrough: (state: Draft<UiState>, action: PayloadAction<WalkThroughCollection>) => {
+      const collection = action.payload;
+      state.walkThrough[collection].currentStep = -1;
     },
-    handleWalkThroughStep: (state: Draft<UiState>, action: PayloadAction<number>) => {
-      state.walkThrough.currentStep += action.payload;
+    handleWalkThroughStep: (
+      state: Draft<UiState>,
+      action: PayloadAction<{step: number; collection: WalkThroughCollection}>
+    ) => {
+      const {step, collection} = action.payload;
+      state.walkThrough[collection].currentStep += step;
     },
   },
   extraReducers: builder => {


### PR DESCRIPTION
This PR...

Separates walkthrough logic for new users and new release features.
Currently, the new release feature contains only one step about the validation policy.
I removed the step about validation for a basic walkthrough guide, but maybe we want to join it all together?
Also, the replay functionality will replay only the basic guide.

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
