### PR TITLE
fix: fix filter scroll style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,18 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
+.reflex-container > .reflex-element::-webkit-scrollbar {
+  width: 8px;
+}
+
+.reflex-container > .reflex-element::-webkit-scrollbar-track {
+  background: #141414;
+}
+
+.reflex-container > .reflex-element::-webkit-scrollbar-thumb {
+  background: #303030;
+}
+
 .reflex-container.vertical > .reflex-splitter {
   width: 2px;
   background-color: #262626;


### PR DESCRIPTION
This PR adds missing scroll bar style to the resource filter on Windows.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Video

https://user-images.githubusercontent.com/7761005/166421561-be497c69-e456-4fb5-8f78-454938a07181.mov
