### PR TITLE
refactor: show footer on start page + recent projects

### DIFF
--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -19,6 +19,10 @@ const PaneManager: React.FC = () => {
   const projects = useAppSelector(state => state.config.projects);
 
   const gridColumns = useMemo(() => {
+    if (!activeProject || isStartProjectPaneVisible) {
+      return '1fr';
+    }
+
     let gridTemplateColumns = 'max-content 1fr';
 
     if (featureJson.ShowRightMenu) {
@@ -26,7 +30,7 @@ const PaneManager: React.FC = () => {
     }
 
     return gridTemplateColumns;
-  }, []);
+  }, [activeProject, isStartProjectPaneVisible]);
 
   return (
     <S.PaneManagerContainer $gridTemplateColumns={gridColumns}>

--- a/src/components/organisms/StartProjectPane/Guide.styled.tsx
+++ b/src/components/organisms/StartProjectPane/Guide.styled.tsx
@@ -9,7 +9,6 @@ export const Container = styled.div`
   justify-content: center;
   align-items: center;
   gap: 1.2rem;
-  width: 100%;
   margin: 10px 0;
   height: 100%;
 `;

--- a/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
@@ -7,10 +7,8 @@ import {GlobalScrollbarStyle} from '@utils/scrollbar';
 import Colors from '@styles/Colors';
 
 export const Container = styled.div`
-  width: 100vw;
-  height: calc(100vh - 47px);
   display: grid;
-  grid-template-rows: 1.25rem calc(100vh - 47px - 16.25rem) 15rem;
+  grid-template-rows: 1.25rem 1fr 15rem;
 `;
 
 export const ProjectsContainer = styled.div`

--- a/src/components/organisms/StartProjectPane/RecentProjectsPage.tsx
+++ b/src/components/organisms/StartProjectPane/RecentProjectsPage.tsx
@@ -45,6 +45,7 @@ const NewRecentProjectsPane = () => {
   return (
     <S.Container>
       <Guide />
+
       <S.Projects>
         <S.ProjectsTitle id="recent-project-title">Recent Projects</S.ProjectsTitle>
         <S.ProjectsContainer id="recent-projects-container">
@@ -59,6 +60,7 @@ const NewRecentProjectsPane = () => {
           ))}
         </S.ProjectsContainer>
       </S.Projects>
+
       <S.Actions>
         <S.ActionsTitle>Start a new project</S.ActionsTitle>
         <S.ActionItems>

--- a/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
@@ -5,18 +5,14 @@ import styled from 'styled-components';
 import Colors from '@styles/Colors';
 
 export const Container = styled.div`
-  width: 100vw;
-  height: calc(100vh - 47px);
   display: grid;
-  grid-template-rows: 1.25rem 15rem calc(100vh - 47px - 16.25rem);
+  grid-template-rows: 1.25rem 15rem 1fr;
 `;
 
 export const InformationMessage = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  height: 100%;
   font-size: 16px;
   color: ${Colors.grey7};
   font-weight: 600;
@@ -25,8 +21,6 @@ export const InformationMessage = styled.div`
 export const StartProjectContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  alig-items: center;
-  width: 100%;
   padding: 0 6rem;
 `;
 


### PR DESCRIPTION
## Changes

- Show footer on Start Project page and Recent Projects page
- Refactor CSS styling

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/166886258-a1ac0d9e-228f-4882-8366-d9106bf9b8b5.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
