### PR TITLE
fix: reprocess resources on preview

### DIFF
--- a/src/redux/services/validation.ts
+++ b/src/redux/services/validation.ts
@@ -2,7 +2,7 @@ import Ajv, {ValidateFunction} from 'ajv';
 import {get} from 'lodash';
 import {Document, LineCounter, Node, ParsedNode, isCollection, isNode} from 'yaml';
 
-import {K8sResource, RefPosition, ResourceRef, ResourceValidationError} from '@models/k8sresource';
+import {K8sResource, RefPosition, ResourceValidationError} from '@models/k8sresource';
 import {POLICY_VALIDATOR_MAP, Policy, SarifRule} from '@models/policy';
 
 import {isKustomizationPatch} from '@redux/services/kustomize';
@@ -74,9 +74,6 @@ function isManagedByKustomize(resource: K8sResource): boolean {
 
   return false;
 }
-
-const hasKustomizationReference = (ref: ResourceRef) =>
-  (ref.target?.type === 'resource' && ref.target.resourceKind === 'Kustomization') ?? false;
 
 function validatePolicyRule(resource: K8sResource, policy: Policy, rule: SarifRule): ResourceValidationError[] {
   const validator = POLICY_VALIDATOR_MAP[policy.validatorId!];
@@ -177,7 +174,7 @@ function determineContainerIndex(
 ): YamlPath {
   for (let i = 0; i < properties.length; i += 1) {
     const property = properties[i];
-    const containers: {name: string}[] = get(resource.content, prefix.concat(property), []);
+    const containers = get<{name: string}[]>(resource.content, prefix.concat(property), []) ?? [];
     const containerIndex = containers.findIndex(c => c.name === container);
     if (containerIndex !== -1) {
       return [property, containerIndex];

--- a/src/redux/thunks/previewHelmValuesFile.ts
+++ b/src/redux/thunks/previewHelmValuesFile.ts
@@ -35,6 +35,7 @@ export const previewHelmValuesFile = createAsyncThunk<
   const kubeconfig = projectConfig.kubeConfig?.path;
   const currentContext = projectConfig.kubeConfig?.currentContext;
   const valuesFile = state.helmValuesMap[valuesFileId];
+  const policyPlugins = state.policies.plugins;
 
   if (kubeconfig && valuesFile && valuesFile.filePath && currentContext) {
     const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;
@@ -84,7 +85,10 @@ export const previewHelmValuesFile = createAsyncThunk<
           result.stdout,
           valuesFile.id,
           'Helm Preview',
-          state.resourceRefsProcessingOptions
+          state.resourceRefsProcessingOptions,
+          undefined,
+          undefined,
+          {policyPlugins}
         );
       }
 

--- a/src/redux/thunks/previewKustomization.ts
+++ b/src/redux/thunks/previewKustomization.ts
@@ -34,6 +34,7 @@ export const previewKustomization = createAsyncThunk<
   const k8sVersion = getK8sVersion(projectConfig);
   const userDataDir = thunkAPI.getState().config.userDataDir;
   const resource = state.resourceMap[resourceId];
+  const policyPlugins = state.policies.plugins;
 
   if (resource && resource.filePath) {
     const rootFolder = state.fileMap[ROOT_FILE_ENTRY].filePath;
@@ -56,7 +57,10 @@ export const previewKustomization = createAsyncThunk<
         result.stdout,
         resource.id,
         'Kustomize Preview',
-        state.resourceRefsProcessingOptions
+        state.resourceRefsProcessingOptions,
+        undefined,
+        undefined,
+        {policyPlugins}
       );
     }
   }

--- a/src/redux/thunks/runPreviewConfiguration.ts
+++ b/src/redux/thunks/runPreviewConfiguration.ts
@@ -39,6 +39,7 @@ export const runPreviewConfiguration = createAsyncThunk<
   const currentContext =
     thunkAPI.getState().config.projectConfig?.kubeConfig?.currentContext ||
     thunkAPI.getState().config.kubeConfig.currentContext;
+  const policyPlugins = mainState.policies.plugins;
 
   const rootFolderPath = mainState.fileMap[ROOT_FILE_ENTRY].filePath;
 
@@ -127,7 +128,10 @@ export const runPreviewConfiguration = createAsyncThunk<
       result.stdout,
       previewConfiguration.id,
       'Helm Preview',
-      mainState.resourceRefsProcessingOptions
+      mainState.resourceRefsProcessingOptions,
+      undefined,
+      undefined,
+      {policyPlugins}
     );
   }
 

--- a/src/redux/thunks/utils.ts
+++ b/src/redux/thunks/utils.ts
@@ -7,6 +7,7 @@ import {PREVIEW_PREFIX, YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/const
 import {AlertEnum} from '@models/alert';
 import {ResourceMapType, ResourceRefsProcessingOptions} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
+import {Policy} from '@models/policy';
 
 import {extractK8sResources, processResources} from '@redux/services/resource';
 
@@ -44,7 +45,8 @@ export function createPreviewResult(
   title: string,
   resourceRefsProcessingOptions: ResourceRefsProcessingOptions,
   previewKubeConfigPath?: string,
-  previewKubeConfigContext?: string
+  previewKubeConfigContext?: string,
+  processOptions?: {policyPlugins?: Policy[]}
 ) {
   const resources = extractK8sResources(resourcesYaml, PREVIEW_PREFIX + previewResourceId);
   const resourceMap = resources.reduce((rm: ResourceMapType, r) => {
@@ -52,7 +54,8 @@ export function createPreviewResult(
     return rm;
   }, {});
 
-  processResources(schemaVersion, userDataDir, resourceMap, resourceRefsProcessingOptions);
+  processResources(schemaVersion, userDataDir, resourceMap, resourceRefsProcessingOptions, processOptions);
+
   return {
     previewResourceId,
     previewResources: resourceMap,


### PR DESCRIPTION
This PR reprocesses resources on generating a preview.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
