### PR TITLE
feat: add feature flags

### DIFF
--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -36,9 +36,10 @@ import ModalConfirmWithNamespaceSelect from '@components/molecules/ModalConfirmW
 
 import {useFileExplorer} from '@hooks/useFileExplorer';
 
-import featureJson from '@src/feature-flags.json';
+import {useFeatureFlags} from '@utils/features';
 
 const HotKeysHandler = () => {
+  const {ShowRightMenu} = useFeatureFlags();
   const dispatch = useAppDispatch();
   const mainState = useAppSelector(state => state.main);
   const uiState = useAppSelector(state => state.ui);
@@ -192,9 +193,8 @@ const HotKeysHandler = () => {
   );
 
   useHotkeys(hotkeys.TOGGLE_RIGHT_PANE.key, () => {
-    if (featureJson.ShowRightMenu) {
-      dispatch(toggleRightMenu());
-    }
+    if (!ShowRightMenu) return;
+    dispatch(toggleRightMenu());
   });
 
   useHotkeys(hotkeys.SELECT_FROM_HISTORY_BACK.key, () => {

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import {useAppSelector} from '@redux/hooks';
 import {activeProjectSelector} from '@redux/selectors';
 
-import featureJson from '@src/feature-flags.json';
+import {FeatureFlag, useFeatureFlags} from '@utils/features';
 
 import {RecentProjectsPage, StartProjectPage} from '../StartProjectPane';
 import PaneManagerLeftMenu from './PaneManagerLeftMenu';
@@ -13,6 +13,7 @@ import PaneManagerSplitView from './PaneManagerSplitView';
 import * as S from './styled';
 
 const PaneManager: React.FC = () => {
+  const {ShowRightMenu} = useFeatureFlags();
   const activeProject = useAppSelector(activeProjectSelector);
   const isProjectLoading = useAppSelector(state => state.config.isProjectLoading);
   const isStartProjectPaneVisible = useAppSelector(state => state.ui.isStartProjectPaneVisible);
@@ -25,12 +26,12 @@ const PaneManager: React.FC = () => {
 
     let gridTemplateColumns = 'max-content 1fr';
 
-    if (featureJson.ShowRightMenu) {
+    if (ShowRightMenu) {
       gridTemplateColumns += ' max-content';
     }
 
     return gridTemplateColumns;
-  }, [activeProject, isStartProjectPaneVisible]);
+  }, [activeProject, isStartProjectPaneVisible, ShowRightMenu]);
 
   return (
     <S.PaneManagerContainer $gridTemplateColumns={gridColumns}>
@@ -47,7 +48,9 @@ const PaneManager: React.FC = () => {
         <StartProjectPage />
       )}
 
-      {featureJson.ShowRightMenu && <PaneManagerRightMenu />}
+      <FeatureFlag name="ActionsPaneFooter">
+        <PaneManagerRightMenu />
+      </FeatureFlag>
     </S.PaneManagerContainer>
   );
 };

--- a/src/components/organisms/PaneManager/PaneManagerRightMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerRightMenu.tsx
@@ -7,25 +7,26 @@ import {RightMenuSelectionType} from '@models/ui';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setRightMenuSelection, toggleRightMenu} from '@redux/reducers/ui';
 
-import featureJson from '@src/feature-flags.json';
+import {useFeatureFlags} from '@utils/features';
 
 import MenuIcon from './MenuIcon';
 import * as S from './PaneManagerRightMenu.styled';
 
 const PaneManagerRightMenu: React.FC = () => {
+  const {ShowRightMenu, ShowGraphView} = useFeatureFlags();
   const dispatch = useAppDispatch();
   const rightActive = useAppSelector(state => state.ui.rightMenu.isActive);
   const rightMenuSelection = useAppSelector(state => state.ui.rightMenu.selection);
 
   const setRightActiveMenu = (selectedMenu: RightMenuSelectionType) => {
-    if (featureJson.ShowRightMenu) {
-      if (rightMenuSelection === selectedMenu) {
+    if (!ShowRightMenu) return;
+
+    if (rightMenuSelection === selectedMenu) {
+      dispatch(toggleRightMenu());
+    } else {
+      dispatch(setRightMenuSelection(selectedMenu));
+      if (!rightActive) {
         dispatch(toggleRightMenu());
-      } else {
-        dispatch(setRightMenuSelection(selectedMenu));
-        if (!rightActive) {
-          dispatch(toggleRightMenu());
-        }
       }
     }
   };
@@ -37,7 +38,7 @@ const PaneManagerRightMenu: React.FC = () => {
         type="text"
         onClick={() => setRightActiveMenu('graph')}
         icon={<MenuIcon icon={ApartmentOutlined} active={rightActive} isSelected={rightMenuSelection === 'graph'} />}
-        style={{display: featureJson.ShowGraphView ? 'inline' : 'none'}}
+        style={{display: ShowGraphView ? 'inline' : 'none'}}
       />
 
       <Button

--- a/src/utils/features.tsx
+++ b/src/utils/features.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import featureJson from '@src/feature-flags.json';
+
+const FEATURES = createFeatureFlags(featureJson, {
+  ShowGraphView: false,
+  ShowRightMenu: false,
+  ActionsPaneFooter: false,
+});
+
+function createFeatureFlags<TFeature extends string>(
+  overrides: Record<string, boolean>,
+  features: Record<TFeature, boolean>
+): Record<TFeature, boolean> {
+  return {...features, ...overrides};
+}
+
+type Props = {
+  name: keyof typeof FEATURES;
+  fallback?: React.ComponentType | null;
+};
+
+export const FeatureFlag: React.FC<Props> = ({name, children, fallback = null}) => {
+  return name ? <>{children}</> : <>{fallback}</>;
+};
+
+export function useFeatureFlags(): typeof FEATURES {
+  return FEATURES;
+}


### PR DESCRIPTION
This PR adds a small utility for feature flags.

## Changes

- It adds a `<FeatureFlag />` which dynamically renders based on typed flags.
- It adds a basic `useFeatureFlags` hook to abstract the feature flag implementation (i.e. the JSON file).