### PR TITLE
refactor: start project + recent project styling update

### DIFF
--- a/src/components/organisms/StartProjectPane/Guide.styled.tsx
+++ b/src/components/organisms/StartProjectPane/Guide.styled.tsx
@@ -9,8 +9,7 @@ export const Container = styled.div`
   justify-content: center;
   align-items: center;
   gap: 1.2rem;
-  margin: 10px 0;
-  height: 100%;
+  margin-top: 10px;
 `;
 
 export const Item = styled(ButtonRaw)`

--- a/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
@@ -61,7 +61,7 @@ export const ActionsTitle = styled.div`
 
 export const Container = styled.div`
   display: grid;
-  grid-template-rows: 1.25rem 1fr 15rem;
+  grid-template-rows: max-content 1fr 15rem;
   grid-row-gap: 10px;
 `;
 

--- a/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/RecentProjectsPage.styled.tsx
@@ -6,49 +6,16 @@ import {GlobalScrollbarStyle} from '@utils/scrollbar';
 
 import Colors from '@styles/Colors';
 
-export const Container = styled.div`
-  display: grid;
-  grid-template-rows: 1.25rem calc(100vh - 70px - 16.25rem) 15rem;
-`;
-
-export const ProjectsContainer = styled.div`
-  height: 100%;
-  width: 30rem;
-  overflow-y: auto;
-  ${GlobalScrollbarStyle}
-`;
-
-export const Projects = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  height: 100%;
-`;
-
-export const ActionItems = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 2rem;
-`;
-
 export const ActionItem = styled.div`
   display: flex;
-  width: 13rem;
-  margin: 0 3rem;
-
-  &:first-child {
-    margin-left: 0;
-  }
-  &:last-child {
-    margin-right: 0;
-  }
 `;
 
-export const ActionItemLogo = styled.img`
-  width: 4.5rem;
-  height: 4.5rem;
+export const ActionItemButton = styled(Button)`
+  display: flex;
+  padding: 0;
+  margin: 0;
+  align-items: end;
+  font-size: 13px;
 `;
 
 export const ActionItemContext = styled.div`
@@ -58,6 +25,22 @@ export const ActionItemContext = styled.div`
   padding: 0 0 0 1rem;
   font-weight: 400;
   font-size: 13px;
+`;
+
+export const ActionItemLogo = styled.img`
+  width: 4.5rem;
+  height: 4.5rem;
+`;
+
+export const ActionItemText = styled.div``;
+
+export const ActionItems = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 13rem);
+  grid-column-gap: 3rem;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2rem;
 `;
 
 export const Actions = styled.div`
@@ -76,13 +59,32 @@ export const ActionsTitle = styled.div`
   color: ${Colors.whitePure};
 `;
 
-export const ActionItemText = styled.div``;
-export const ActionItemButton = styled(Button)`
+export const Container = styled.div`
+  display: grid;
+  grid-template-rows: 1.25rem 1fr 15rem;
+  grid-row-gap: 10px;
+`;
+
+export const Projects = styled.div`
   display: flex;
-  padding: 0;
-  margin: 0;
-  align-items: end;
-  font-size: 13px;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: 100%;
+`;
+
+export const ProjectsContainer = styled.div`
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+  ${GlobalScrollbarStyle}
+`;
+
+export const ProjectsContainerWrapper = styled.div`
+  position: relative;
+  height: 100%;
+  width: 30rem;
 `;
 
 export const ProjectsTitle = styled.div`

--- a/src/components/organisms/StartProjectPane/RecentProjectsPage.tsx
+++ b/src/components/organisms/StartProjectPane/RecentProjectsPage.tsx
@@ -48,21 +48,25 @@ const NewRecentProjectsPane = () => {
 
       <S.Projects>
         <S.ProjectsTitle id="recent-project-title">Recent Projects</S.ProjectsTitle>
-        <S.ProjectsContainer id="recent-projects-container">
-          {sortProjects(projects, Boolean(activeProject)).map((project: Project) => (
-            <RecentProject
-              key={project.rootFolder}
-              project={project}
-              isActive={project.rootFolder === activeProject?.rootFolder}
-              onProjectItemClick={onProjectItemClick}
-              onPinChange={() => handleOnProjectPinChange(project)}
-            />
-          ))}
-        </S.ProjectsContainer>
+
+        <S.ProjectsContainerWrapper>
+          <S.ProjectsContainer id="recent-projects-container">
+            {sortProjects(projects, Boolean(activeProject)).map((project: Project) => (
+              <RecentProject
+                key={project.rootFolder}
+                project={project}
+                isActive={project.rootFolder === activeProject?.rootFolder}
+                onProjectItemClick={onProjectItemClick}
+                onPinChange={() => handleOnProjectPinChange(project)}
+              />
+            ))}
+          </S.ProjectsContainer>
+        </S.ProjectsContainerWrapper>
       </S.Projects>
 
       <S.Actions>
         <S.ActionsTitle>Start a new project</S.ActionsTitle>
+
         <S.ActionItems>
           <S.ActionItem>
             <S.ActionItemLogo src={SelectFolder} />
@@ -73,6 +77,7 @@ const NewRecentProjectsPane = () => {
               </S.ActionItemButton>
             </S.ActionItemContext>
           </S.ActionItem>
+
           <S.ActionItem>
             <S.ActionItemLogo src={CreateScratch} />
             <S.ActionItemContext>
@@ -82,6 +87,7 @@ const NewRecentProjectsPane = () => {
               </S.ActionItemButton>
             </S.ActionItemContext>
           </S.ActionItem>
+
           <S.ActionItem>
             <S.ActionItemLogo src={CreateFromTemplate} />
             <S.ActionItemContext>

--- a/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
@@ -8,7 +8,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding-bottom: 10px;
+  padding-bottom: 20px;
 `;
 
 export const InformationMessage = styled.div`

--- a/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
@@ -5,8 +5,10 @@ import styled from 'styled-components';
 import Colors from '@styles/Colors';
 
 export const Container = styled.div`
-  display: grid;
-  grid-template-rows: 1.25rem 15rem calc(100vh - 70px - 16.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 10px;
 `;
 
 export const InformationMessage = styled.div`
@@ -16,11 +18,15 @@ export const InformationMessage = styled.div`
   font-size: 16px;
   color: ${Colors.grey7};
   font-weight: 600;
+  min-height: 5rem;
+  max-height: 15rem;
+  height: 100%;
 `;
 
 export const StartProjectContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  gap: 1.5rem;
   padding: 0 6rem;
 `;
 
@@ -28,13 +34,7 @@ export const StartProjectItem = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 0 1.5rem;
-  :first-child {
-    margin: 0 1.5rem 0 0;
-  }
-  :last-child {
-    margin: 0 0 0 1.5rem;
-  }
+  justify-content: space-between;
 `;
 
 export const StartProjectItemLogo = styled.img`
@@ -48,16 +48,13 @@ export const StartProjectItemTitle = styled.div`
   color: ${Colors.whitePure};
   font-weight: 600;
   text-align: center;
-  width: 100%;
 `;
 
 export const StartProjectItemDescription = styled.div`
   margin-top: 1rem;
   font-size: 14px;
   color: ${Colors.whitePure};
-  font-weight: 400;
   text-align: center;
-  width: 100%;
 `;
 
 export const StartProjectItemButton = styled(Button)`
@@ -65,7 +62,6 @@ export const StartProjectItemButton = styled(Button)`
   color: ${Colors.whitePure};
   margin-top: 1.5rem;
   border: 1px solid ${Colors.blue6};
-  font-weight: 400;
   box-shadow: 0px 2px 0px rgba(0, 0, 0, 0.043);
   border-radius: 2px;
 

--- a/src/components/organisms/StartProjectPane/StartProjectPage.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.tsx
@@ -21,7 +21,9 @@ const StartProjectPage = () => {
   return (
     <S.Container>
       <Guide />
+
       <S.InformationMessage>Choose your way to start your first project:</S.InformationMessage>
+
       <S.StartProjectContainer>
         <S.StartProjectItem>
           <S.StartProjectItemLogo src={SelectFolder} />
@@ -33,6 +35,7 @@ const StartProjectPage = () => {
             Open
           </S.StartProjectItemButton>
         </S.StartProjectItem>
+
         <S.StartProjectItem>
           <S.StartProjectItemLogo src={CreateScratch} />
           <S.StartProjectItemTitle>Create a project from scratch</S.StartProjectItemTitle>
@@ -43,6 +46,7 @@ const StartProjectPage = () => {
             Create
           </S.StartProjectItemButton>
         </S.StartProjectItem>
+
         <S.StartProjectItem>
           <S.StartProjectItemLogo src={CreateFromTemplate} />
           <S.StartProjectItemTitle>Start from a template</S.StartProjectItemTitle>


### PR DESCRIPTION
## Changes

- Overflow scroll for recent projects
- Same height for Start project items ( for lower widths )
- Min and Max height for Start Project information message ( for lower heights )

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/166960047-abdfe24b-6389-4e73-a4a8-0de7a424a586.png)
![image](https://user-images.githubusercontent.com/47887589/166960327-aae66d58-34bf-4682-a8bd-49f1c36ffe22.png)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
