### PR TITLE
Fixes for release

### DIFF
--- a/electron/app/commands.ts
+++ b/electron/app/commands.ts
@@ -71,6 +71,11 @@ export const saveFileDialog = (event: Electron.IpcMainInvokeEvent, options: File
   return dialog.showSaveDialogSync(dialogOptions);
 };
 
+export const forceLoad = (event: Electron.IpcMainInvokeEvent) => {
+  const browserWindow = BrowserWindow.fromId(event.sender.id);
+  browserWindow?.webContents.reloadIgnoringCache();
+};
+
 /**
  * Checks for a new version of monokle
  */

--- a/electron/app/ipc/ipcListeners.ts
+++ b/electron/app/ipc/ipcListeners.ts
@@ -39,7 +39,14 @@ import {UPDATE_APPLICATION, trackEvent} from '@utils/telemetry';
 
 import {getAmplitudeClient} from '../amplitude';
 import autoUpdater from '../autoUpdater';
-import {checkNewVersion, interpolateTemplate, runCommand, saveFileDialog, selectFileDialog} from '../commands';
+import {
+  checkNewVersion,
+  forceLoad as forceReload,
+  interpolateTemplate,
+  runCommand,
+  saveFileDialog,
+  selectFileDialog,
+} from '../commands';
 import {downloadPlugin, updatePlugin} from '../services/pluginService';
 import {
   downloadTemplate,
@@ -238,6 +245,10 @@ ipcMain.on('quit-and-install', () => {
   trackEvent(UPDATE_APPLICATION);
   autoUpdater.quitAndInstall();
   dispatchToAllWindows(updateNewVersion({code: NewVersionCode.Idle, data: null}));
+});
+
+ipcMain.on('force-reload', async (event: any) => {
+  forceReload(event);
 });
 
 ipcMain.on('confirm-action', (event: any, args) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "react-reflex": "4.0.6",
         "react-resizable": "3.0.4",
         "react-use": "17.3.2",
-        "redux": "^4.2.0",
+        "redux": "4.2.0",
         "redux-logger": "3.0.6",
         "redux-thunk": "2.4.1",
         "reselect": "4.1.5",
@@ -29317,8 +29317,7 @@
     "@rjsf/antd": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-4.1.0.tgz",
-      "integrity": "sha512-rXmtuD1rhVSs5FYfFH0jVXTYmJyH8px8jfCANYzQ+SdRMlnFM8j8LYvcFYM8jaIgfefhvSoiGWFuE68dybEpTg==",
-      "requires": {}
+      "integrity": "sha512-rXmtuD1rhVSs5FYfFH0jVXTYmJyH8px8jfCANYzQ+SdRMlnFM8j8LYvcFYM8jaIgfefhvSoiGWFuE68dybEpTg=="
     },
     "@rjsf/core": {
       "version": "4.1.0",
@@ -30922,15 +30921,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -31038,8 +31035,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -31532,8 +31528,7 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
       "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -33250,8 +33245,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-functions-list": {
       "version": "3.0.1",
@@ -33358,8 +33352,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
       "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "4.3.0",
@@ -33490,8 +33483,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -34811,8 +34803,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -35078,8 +35069,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-testing-library": {
       "version": "5.3.1",
@@ -36625,8 +36615,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "6.1.5",
@@ -37103,8 +37092,7 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "requires": {}
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "isstream": {
       "version": "0.1.2",
@@ -37551,8 +37539,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -40757,8 +40744,7 @@
           "version": "8.4.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
           "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -40852,8 +40838,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
       "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -40926,8 +40911,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
       "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-custom-properties": {
       "version": "12.1.7",
@@ -40960,29 +40944,25 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -41007,8 +40987,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
       "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -41032,15 +41011,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
       "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -41055,8 +41032,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -41116,15 +41092,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
       "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
       "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
@@ -41198,8 +41172,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -41263,8 +41236,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -41368,15 +41340,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
       "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -41470,8 +41440,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
@@ -41483,8 +41452,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -42555,8 +42523,7 @@
     "react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "requires": {}
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
     },
     "react-use": {
       "version": "17.3.2",
@@ -42761,8 +42728,7 @@
       "version": "2.13.9",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
       "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "redux-logger": {
       "version": "3.0.6",
@@ -42775,8 +42741,7 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {}
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -44203,8 +44168,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "style-search": {
       "version": "0.1.0",
@@ -44383,8 +44347,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
       "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-standard": {
       "version": "25.0.0",
@@ -46004,8 +45967,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -46485,8 +46447,7 @@
     "ws": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "requires": {}
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/components/organisms/ErrorPage/ErrorPage.tsx
+++ b/src/components/organisms/ErrorPage/ErrorPage.tsx
@@ -1,4 +1,4 @@
-import {shell} from 'electron';
+import {ipcRenderer, shell} from 'electron';
 
 import {useCallback, useEffect} from 'react';
 import {FallbackProps} from 'react-error-boundary';
@@ -14,7 +14,7 @@ import crashFigure from '@assets/figures/crash.svg';
 import * as S from './ErrorPage.styled';
 import {ErrorStack} from './ErrorStack';
 
-export const ErrorPage: React.FC<FallbackProps> = ({error, resetErrorBoundary}) => {
+export const ErrorPage: React.FC<FallbackProps> = ({error}) => {
   const createGitHubIssue = useCallback(() => {
     const url = newGithubIssueUrl({
       user: 'kubeshop',
@@ -31,6 +31,10 @@ export const ErrorPage: React.FC<FallbackProps> = ({error, resetErrorBoundary}) 
     logToFile.error(error);
   }, [error]);
 
+  const onRestart = useCallback(() => {
+    ipcRenderer.send('force-reload');
+  }, []);
+
   return (
     <S.ErrorContainer>
       <S.Figure src={crashFigure} />
@@ -43,7 +47,7 @@ export const ErrorPage: React.FC<FallbackProps> = ({error, resetErrorBoundary}) 
         <Button type="default" onClick={createGitHubIssue}>
           Help us by creating an automatic GitHub issue
         </Button>
-        <Button type="primary" onClick={resetErrorBoundary}>
+        <Button type="primary" onClick={onRestart}>
           Back to Monokle
         </Button>
       </Space>

--- a/src/components/organisms/ErrorPage/ErrorStack.styled.tsx
+++ b/src/components/organisms/ErrorPage/ErrorStack.styled.tsx
@@ -12,6 +12,7 @@ export const DownOutlined = styled(DownOutlinedBase)`
 `;
 
 export const ErrorStack = styled.div`
+  width: 700px;
   margin-bottom: 6px;
 `;
 
@@ -22,6 +23,6 @@ export const ErrorButton = styled(Button)`
 
 export const ErrorStackContent = styled(motion.section)`
   height: 100%;
-  overflow-y: auto;
+  overflow: auto;
   ${GlobalScrollbarStyle}
 `;

--- a/src/components/organisms/ErrorPage/ErrorStack.tsx
+++ b/src/components/organisms/ErrorPage/ErrorStack.tsx
@@ -32,7 +32,7 @@ export function ErrorStack({error}: Props) {
             transition={{duration: 0.6}}
           >
             <code>{error.message}</code>
-            <pre>
+            <pre style={{marginBottom: 0}}>
               <code>{error.stack}</code>
             </pre>
           </S.ErrorStackContent>

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -3,17 +3,13 @@ import {useMemo} from 'react';
 import {useAppSelector} from '@redux/hooks';
 import {activeProjectSelector} from '@redux/selectors';
 
-import {FeatureFlag, useFeatureFlags} from '@utils/features';
-
 import {RecentProjectsPage, StartProjectPage} from '../StartProjectPane';
 import PaneManagerLeftMenu from './PaneManagerLeftMenu';
-import PaneManagerRightMenu from './PaneManagerRightMenu';
 import PaneManagerSplitView from './PaneManagerSplitView';
 
 import * as S from './styled';
 
 const PaneManager: React.FC = () => {
-  const {ShowRightMenu} = useFeatureFlags();
   const activeProject = useAppSelector(activeProjectSelector);
   const isProjectLoading = useAppSelector(state => state.config.isProjectLoading);
   const isStartProjectPaneVisible = useAppSelector(state => state.ui.isStartProjectPaneVisible);
@@ -24,14 +20,8 @@ const PaneManager: React.FC = () => {
       return '1fr';
     }
 
-    let gridTemplateColumns = 'max-content 1fr';
-
-    if (ShowRightMenu) {
-      gridTemplateColumns += ' max-content';
-    }
-
-    return gridTemplateColumns;
-  }, [activeProject, isStartProjectPaneVisible, ShowRightMenu]);
+    return 'max-content 1fr';
+  }, [activeProject, isStartProjectPaneVisible]);
 
   return (
     <S.PaneManagerContainer $gridTemplateColumns={gridColumns}>
@@ -47,10 +37,6 @@ const PaneManager: React.FC = () => {
       ) : (
         <StartProjectPage />
       )}
-
-      <FeatureFlag name="ActionsPaneFooter">
-        <PaneManagerRightMenu />
-      </FeatureFlag>
     </S.PaneManagerContainer>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,8 +9,7 @@ import 'antd/dist/antd.less';
 import * as log from 'loglevel';
 
 import '@redux/ipcRendererRedux';
-import {setLoadingProject} from '@redux/reducers/appConfig';
-import store, {resetStore} from '@redux/store';
+import store from '@redux/store';
 import '@redux/storeListeners';
 
 import {ErrorPage} from '@components/organisms/ErrorPage/ErrorPage';
@@ -26,17 +25,7 @@ if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
 
 ReactDOM.render(
   <Provider store={store}>
-    <ErrorBoundary
-      FallbackComponent={ErrorPage}
-      onReset={() => {
-        store.dispatch(resetStore());
-
-        // Immediately on startup an effect is performed.
-        // Skip all and go to new/recent projects to have best chance of a recovery.
-        // See src/App.tsx:131 onExecutedFrom
-        store.dispatch(setLoadingProject(false));
-      }}
-    >
+    <ErrorBoundary FallbackComponent={ErrorPage}>
       <App />
     </ErrorBoundary>
   </Provider>,

--- a/src/utils/features.tsx
+++ b/src/utils/features.tsx
@@ -21,7 +21,8 @@ type Props = {
 };
 
 export const FeatureFlag: React.FC<Props> = ({name, children, fallback = null}) => {
-  return name ? <>{children}</> : <>{fallback}</>;
+  const isEnabled = FEATURES[name];
+  return isEnabled ? <>{children}</> : <>{fallback}</>;
 };
 
 export function useFeatureFlags(): typeof FEATURES {


### PR DESCRIPTION
This PR:

- Hotfixes feature flags.
- Removes right pane as we have to see how this fits within the rework of both the start page and the split pane.
- Improves styling for very long error messages
- Fix "Back to Monokle" on error page by force reloading. Note: there is too much scattered global state for Monokle to reset properly by restoring Redux store to its initial state.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
