### PR TITLE
Improve: go to file - helm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "react-reflex": "4.0.6",
         "react-resizable": "3.0.4",
         "react-use": "17.3.2",
-        "redux": "^4.2.0",
+        "redux": "4.2.0",
         "redux-logger": "3.0.6",
         "redux-thunk": "2.4.1",
         "reselect": "4.1.5",
@@ -29221,8 +29221,7 @@
     "@rjsf/antd": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-4.1.0.tgz",
-      "integrity": "sha512-rXmtuD1rhVSs5FYfFH0jVXTYmJyH8px8jfCANYzQ+SdRMlnFM8j8LYvcFYM8jaIgfefhvSoiGWFuE68dybEpTg==",
-      "requires": {}
+      "integrity": "sha512-rXmtuD1rhVSs5FYfFH0jVXTYmJyH8px8jfCANYzQ+SdRMlnFM8j8LYvcFYM8jaIgfefhvSoiGWFuE68dybEpTg=="
     },
     "@rjsf/core": {
       "version": "4.1.0",
@@ -30826,15 +30825,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -30942,8 +30939,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -31436,8 +31432,7 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
       "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -33154,8 +33149,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-functions-list": {
       "version": "3.0.1",
@@ -33262,8 +33256,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
       "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-select": {
       "version": "4.3.0",
@@ -33394,8 +33387,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -34715,8 +34707,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -34982,8 +34973,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-testing-library": {
       "version": "5.3.1",
@@ -36486,8 +36476,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "idb": {
       "version": "6.1.5",
@@ -36964,8 +36953,7 @@
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "requires": {}
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "isstream": {
       "version": "0.1.2",
@@ -37412,8 +37400,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -40613,8 +40600,7 @@
           "version": "8.4.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
           "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -40697,8 +40683,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
       "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -40771,8 +40756,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
       "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-custom-properties": {
       "version": "12.1.7",
@@ -40805,29 +40789,25 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -40852,8 +40832,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
       "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -40877,15 +40856,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
       "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -40900,8 +40877,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -40961,15 +40937,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
       "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
       "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
@@ -41043,8 +41017,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -41108,8 +41081,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -41213,15 +41185,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
       "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -41315,8 +41285,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
@@ -41328,8 +41297,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -42392,8 +42360,7 @@
     "react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "requires": {}
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
     },
     "react-use": {
       "version": "17.3.2",
@@ -42598,8 +42565,7 @@
       "version": "2.13.9",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.9.tgz",
       "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "redux-logger": {
       "version": "3.0.6",
@@ -42612,8 +42578,7 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {}
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -44040,8 +44005,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "style-search": {
       "version": "0.1.0",
@@ -44211,8 +44175,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
       "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "stylelint-config-standard": {
       "version": "25.0.0",
@@ -45832,8 +45795,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -46313,8 +46275,7 @@
     "ws": {
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "requires": {}
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.styled.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.styled.tsx
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const StyledActionsMenuIconContainer = styled.span<{isSelected: boolean}>`
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+`;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import {Menu} from 'antd';
+
+import styled from 'styled-components';
+
+import {ItemCustomComponentProps} from '@models/navigator';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {selectFile, setSelectingFile} from '@redux/reducers/main';
+import {setLeftMenuSelection} from '@redux/reducers/ui';
+import {isInPreviewModeSelector} from '@redux/selectors';
+
+import {Dots} from '@atoms';
+
+import ContextMenu from '@components/molecules/ContextMenu';
+
+import Colors from '@styles/Colors';
+
+const StyledActionsMenuIconContainer = styled.span<{isSelected: boolean}>`
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+`;
+
+const HelmChartContextMenu: React.FC<ItemCustomComponentProps> = props => {
+  const {itemInstance} = props;
+
+  const dispatch = useAppDispatch();
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+
+  const onClickShowFile = () => {
+    dispatch(setLeftMenuSelection('file-explorer'));
+    dispatch(setSelectingFile(true));
+    dispatch(selectFile({filePath: itemInstance.id}));
+  };
+
+  const menu = (
+    <Menu>
+      <Menu.Item disabled={isInPreviewMode} key="show_file" onClick={onClickShowFile}>
+        Go to file
+      </Menu.Item>
+    </Menu>
+  );
+
+  return (
+    <ContextMenu overlay={menu}>
+      <StyledActionsMenuIconContainer isSelected={itemInstance.isSelected}>
+        <Dots color={itemInstance.isSelected ? Colors.blackPure : undefined} />
+      </StyledActionsMenuIconContainer>
+    </ContextMenu>
+  );
+};
+
+export default HelmChartContextMenu;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import {Menu} from 'antd';
 
-import styled from 'styled-components';
-
 import {ItemCustomComponentProps} from '@models/navigator';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
@@ -17,12 +15,7 @@ import ContextMenu from '@components/molecules/ContextMenu';
 
 import Colors from '@styles/Colors';
 
-const StyledActionsMenuIconContainer = styled.span<{isSelected: boolean}>`
-  cursor: pointer;
-  padding: 8px;
-  display: flex;
-  align-items: center;
-`;
+import {StyledActionsMenuIconContainer} from '@src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.styled';
 
 const HelmChartContextMenu: React.FC<ItemCustomComponentProps> = props => {
   const {itemInstance} = props;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenu.tsx
@@ -22,11 +22,14 @@ const HelmChartContextMenu: React.FC<ItemCustomComponentProps> = props => {
 
   const dispatch = useAppDispatch();
   const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+  const resourceMap = useAppSelector(state => state.main.resourceMap);
 
   const onClickShowFile = () => {
+    console.log(itemInstance);
+    console.log(resourceMap);
     dispatch(setLeftMenuSelection('file-explorer'));
     dispatch(setSelectingFile(true));
-    dispatch(selectFile({filePath: itemInstance.id}));
+    dispatch(selectFile({filePath: itemInstance.meta.filePath || itemInstance.id}));
   };
 
   const menu = (

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenuWrapper.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenuWrapper.tsx
@@ -20,7 +20,7 @@ const HelmChartContextMenu: React.FC<ItemCustomComponentProps> = props => {
   const onClickShowFile = () => {
     dispatch(setLeftMenuSelection('file-explorer'));
     dispatch(setSelectingFile(true));
-    dispatch(selectFile({filePath: itemInstance.id}));
+    dispatch(selectFile({filePath: itemInstance.meta.filePath || itemInstance.id}));
   };
 
   const menu = (

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenuWrapper.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartContextMenuWrapper.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import {Menu} from 'antd';
+
+import {ItemCustomComponentProps} from '@models/navigator';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {selectFile, setSelectingFile} from '@redux/reducers/main';
+import {setLeftMenuSelection} from '@redux/reducers/ui';
+import {isInPreviewModeSelector} from '@redux/selectors';
+
+import ContextMenu from '@components/molecules/ContextMenu';
+
+const HelmChartContextMenu: React.FC<ItemCustomComponentProps> = props => {
+  const {itemInstance, children} = props;
+
+  const dispatch = useAppDispatch();
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+
+  const onClickShowFile = () => {
+    dispatch(setLeftMenuSelection('file-explorer'));
+    dispatch(setSelectingFile(true));
+    dispatch(selectFile({filePath: itemInstance.id}));
+  };
+
+  const menu = (
+    <Menu>
+      <Menu.Item disabled={isInPreviewMode} key="show_file" onClick={onClickShowFile}>
+        Go to file
+      </Menu.Item>
+    </Menu>
+  );
+
+  return (
+    <ContextMenu overlay={menu} triggerOnRightClick>
+      {children}
+    </ContextMenu>
+  );
+};
+
+export default HelmChartContextMenu;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -348,6 +348,8 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
       customization: {
         prefix: {component: ItemPrefix},
         lastItemMarginBottom: 0,
+        contextMenuWrapper: {component: HelmChartContextMenuWrapper, options: {isVisibleOnHover: false}},
+        contextMenu: {component: HelmChartContextMenu, options: {isVisibleOnHover: true}},
       },
     },
     customization: {

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartSectionBlueprint.ts
@@ -13,6 +13,8 @@ import {isDefined} from '@utils/filter';
 import Colors from '@styles/Colors';
 
 import CollapseSectionPrefix from './CollapseSectionPrefix';
+import HelmChartContextMenu from './HelmChartContextMenu';
+import HelmChartContextMenuWrapper from './HelmChartContextMenuWrapper';
 import HelmChartQuickAction from './HelmChartQuickAction';
 import ItemPrefix from './ItemPrefix';
 import PreviewConfigurationNameSuffix from './PreviewConfigurationNameSuffix';
@@ -195,6 +197,8 @@ export function makeHelmChartSectionBlueprint(helmChart: HelmChart) {
           component: ItemPrefix,
         },
         lastItemMarginBottom: 0,
+        contextMenuWrapper: {component: HelmChartContextMenuWrapper, options: {isVisibleOnHover: false}},
+        contextMenu: {component: HelmChartContextMenu, options: {isVisibleOnHover: true}},
       },
     },
   };

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -58,7 +58,6 @@ const RootHelmChartsSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmC
       component: RootHelmChartsSectionEmptyDisplay,
     },
     nameSize: 16,
-    // contextMenuWrapper: {component: KustomizationContextMenuWrapper, options: {isVisibleOnHover: false}},
   },
 };
 

--- a/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
+++ b/src/navsections/HelmChartSectionBlueprint/RootHelmChartsSectionBlueprint.ts
@@ -58,6 +58,7 @@ const RootHelmChartsSectionBlueprint: SectionBlueprint<HelmValuesFile, RootHelmC
       component: RootHelmChartsSectionEmptyDisplay,
     },
     nameSize: 16,
+    // contextMenuWrapper: {component: KustomizationContextMenuWrapper, options: {isVisibleOnHover: false}},
   },
 };
 


### PR DESCRIPTION
This PR...

## Changes
- Add "go to file" for Helm resources

## How to test it
- Open Helm-Charts project
- Go to Helm
- Right-click on a file or hover over the file and click on the "three dots icon"

## Screenshots
![image](https://user-images.githubusercontent.com/12400110/168053739-4b0f6ea6-2c72-4594-8090-595099b88081.png)

![image](https://user-images.githubusercontent.com/12400110/168053800-48bcd5ce-3997-4a31-a071-eab8c93ead6e.png)

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
