### PR TITLE
fix: hotfix build

### DIFF
--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -2,8 +2,6 @@ import {ipcRenderer} from 'electron';
 
 import Nucleus from 'nucleus-nodejs';
 
-import {ValidationIntegrationId} from '@components/organisms/ValidationDrawer/integrations';
-
 import {isRendererThread} from './thread';
 
 export const trackEvent = <TEvent extends Event>(
@@ -48,7 +46,7 @@ export type EventMap = {
   APPLY_FILE: undefined;
   APPLY_HELM_CHART: undefined;
   RUN_PREVIEW_CONFIGURATION: undefined;
-  VALIDATION_PANE_OPENED: {id: ValidationIntegrationId};
+  VALIDATION_PANE_OPENED: {id: string};
   OPA_ENABLED: {all: boolean};
   OPA_DISABLED: {all: boolean};
 };


### PR DESCRIPTION
This PR hotfixes our build.

## Fixes

- It no longer imports `jsx` in the Electron build.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
