### PR TITLE
refactor: show force reload shortcut instead of reload

### DIFF
--- a/electron/app/menu.ts
+++ b/electron/app/menu.ts
@@ -264,7 +264,7 @@ const viewMenu = (state: RootState, dispatch: MainDispatch): MenuItemConstructor
     label: 'View',
     submenu: [
       {
-        role: 'reload',
+        role: 'forceReload',
       },
       {
         label: 'Previous Resource',


### PR DESCRIPTION
## Changes

- Show the force reload shortcut instead of the reload in electron menu

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/169225915-62520a3d-5487-4245-aab8-9fb90cd5e5d2.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
