### PR TITLE
fix: replace deprecated placement prop for antd dropdown

### DIFF
--- a/src/components/molecules/ContextMenu/ContextMenu.tsx
+++ b/src/components/molecules/ContextMenu/ContextMenu.tsx
@@ -9,7 +9,7 @@ const ContextMenu: React.FC<ContextMenuProps> = props => {
   const {overlay, children, triggerOnRightClick = false} = props;
 
   return (
-    <Dropdown overlay={overlay} trigger={triggerOnRightClick ? ['contextMenu'] : ['click']} placement="bottomCenter">
+    <Dropdown overlay={overlay} trigger={triggerOnRightClick ? ['contextMenu'] : ['click']} placement="bottom">
       {children}
     </Dropdown>
   );

--- a/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
+++ b/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
@@ -143,7 +143,7 @@ function WarningsAndErrorsDisplay() {
         <Dropdown
           overlay={<RefDropdownMenu type="warning" warnings={warnings} />}
           trigger={['click']}
-          placement="bottomCenter"
+          placement="bottom"
         >
           <S.ErrorWarningContainer $type="warning">
             <Icon name="warning" />
@@ -153,11 +153,7 @@ function WarningsAndErrorsDisplay() {
       )}
 
       {errorsCount > 0 && (
-        <Dropdown
-          overlay={<RefDropdownMenu type="error" warnings={errors} />}
-          trigger={['click']}
-          placement="bottomCenter"
-        >
+        <Dropdown overlay={<RefDropdownMenu type="error" warnings={errors} />} trigger={['click']} placement="bottom">
           <S.ErrorWarningContainer $type="error">
             <Icon name="error" style={{paddingTop: '2px'}} />
             <S.Label>{errorsCount}</S.Label>

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -164,7 +164,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
               <Dropdown
                 overlay={<ClusterSelectionTable setIsClusterDropdownOpen={setIsClusterDropdownOpen} />}
                 overlayClassName="cluster-dropdown-item"
-                placement="bottomCenter"
+                placement="bottom"
                 arrow
                 trigger={['click']}
                 disabled={previewLoader.isLoading || isInClusterMode}

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -260,7 +260,7 @@ const ProjectSelection = () => {
           arrow
           disabled={previewLoader.isLoading || isInPreviewMode}
           overlay={projectMenu}
-          placement="bottomCenter"
+          placement="bottom"
           trigger={['click']}
           visible={isDropdownMenuVisible}
           onVisibleChange={onDropdownVisibleChange}


### PR DESCRIPTION
## Fixes

- Replace deprecated dropdown placement prop `bottomCenter` with `bottom`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
