### PR TITLE
fix: images list

### DIFF
--- a/src/navsections/ImagesSectionBlueprint/ImagesSectionBlueprint.ts
+++ b/src/navsections/ImagesSectionBlueprint/ImagesSectionBlueprint.ts
@@ -10,6 +10,7 @@ import sectionBlueprintMap from '../sectionBlueprintMap';
 import ImagesQuickAction from './ImagesQuickAction';
 import ImagesSectionEmptyDisplay from './ImagesSectionEmptyDisplay';
 import ImagesSectionNameDisplay from './ImagesSectionNameDisplay';
+import ImagesSectionNameSuffix from './ImagesSectionNameSuffix';
 
 export type ImagesScopeType = {
   resourceMap: ResourceMapType;
@@ -110,6 +111,9 @@ const ImagesSectionBlueprint: SectionBlueprint<ImageType, ImagesScopeType> = {
       quickAction: {
         component: ImagesQuickAction,
         options: {isVisibleOnHover: true},
+      },
+      suffix: {
+        component: ImagesSectionNameSuffix,
       },
     },
   },

--- a/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.styled.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.styled.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+import Colors, {FontColors} from '@styles/Colors';
+
+export const Counter = styled.span<{$selected: boolean}>`
+  ${({$selected}) => `
+    color: ${$selected ? Colors.blackPure : FontColors.grey};
+  `}
+
+  margin-left: 6px;
+  font-size: 12px;
+`;

--- a/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.tsx
@@ -1,0 +1,20 @@
+import {ItemInstance} from '@models/navigator';
+
+import * as S from './ImagesSectionNameSuffix.styled';
+
+interface IProps {
+  itemInstance: ItemInstance;
+}
+
+const ImagesSectionNameSuffix: React.FC<IProps> = props => {
+  const {
+    itemInstance: {
+      isSelected,
+      meta: {resourcesIds},
+    },
+  } = props;
+
+  return <S.Counter $selected={isSelected}>{resourcesIds.length}</S.Counter>;
+};
+
+export default ImagesSectionNameSuffix;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -1,8 +1,6 @@
-// eslint-disable-next-line
-import {shallowEqual} from 'react-redux';
+import {Draft, PayloadAction, createAsyncThunk, createNextState, createSlice} from '@reduxjs/toolkit';
 
-import {Draft, PayloadAction, createAsyncThunk, createNextState, createSlice, isAnyOf} from '@reduxjs/toolkit';
-
+import isEqual from 'lodash/isEqual';
 import log from 'loglevel';
 import path from 'path';
 import {v4 as uuidv4} from 'uuid';
@@ -1279,29 +1277,21 @@ export const {
 } = mainSlice.actions;
 export default mainSlice.reducer;
 
-const selectingActions = isAnyOf(
-  selectK8sResource,
-  selectImage,
-  selectFile,
-  selectPreviewConfiguration,
-  selectHelmValuesFile
-);
-
 /* * * * * * * * * * * * * *
  * Listeners
  * * * * * * * * * * * * * */
 export const resourceMapChangedListener: AppListenerFn = listen => {
   listen({
     predicate: (action, currentState, previousState) => {
-      return !selectingActions(action) && !shallowEqual(currentState.main.resourceMap, previousState.main.resourceMap);
+      return !isEqual(currentState.main.resourceMap, previousState.main.resourceMap);
     },
 
     effect: async (_action, {dispatch, getState}) => {
-      const resourceMap = getState().main.resourceMap;
+      const resourceMap = getActiveResourceMap(getState().main);
       const imagesList = getState().main.imagesList;
       const images = getImages(resourceMap);
 
-      if (!shallowEqual(images, imagesList)) {
+      if (!isEqual(images, imagesList)) {
         dispatch(setImagesList(images));
       }
     },


### PR DESCRIPTION
## Changes

- Show corresponding resources counter for each image ( screenshot )

## Fixes

- Use lodash `isEqual` for updating images list when the resource map changes
- Use active resources for generating the images list 

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/169983285-6e14ac07-cc26-4631-b337-ca92a6c204e0.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
