### PR TITLE
refactor: antd menu deprecated children

### DIFF
--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionMenu.styled.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionMenu.styled.tsx
@@ -1,0 +1,33 @@
+import {Menu as RawMenu} from 'antd';
+
+import styled from 'styled-components';
+
+import Colors from '@styles/Colors';
+
+export const Menu = styled(RawMenu)`
+  background: linear-gradient(90deg, #112a45 0%, #111d2c 100%);
+  color: ${Colors.blue6};
+  height: 40px;
+  line-height: 1.57;
+  display: flex;
+  align-items: center;
+  border-bottom: none;
+
+  & .ant-menu-item {
+    padding: 0 12px !important;
+  }
+
+  & .ant-menu-item::after {
+    border-bottom: none !important;
+  }
+
+  & .ant-menu-item::after {
+    left: 12px;
+    right: 12px;
+  }
+
+  & li:first-child {
+    color: ${Colors.grey7};
+    cursor: default;
+  }
+`;

--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -102,125 +102,116 @@ const TreeItem: React.FC<TreeItemProps> = props => {
     e.stopPropagation();
     canPreview(relativePath) && onPreview(relativePath);
   };
-  const menu = (
-    <Menu>
-      {canPreview(relativePath) && (
-        <>
-          <Menu.Item
-            onClick={e => {
+
+  const menuItems = [
+    ...(canPreview(relativePath)
+      ? [
+          {
+            key: 'preview',
+            label: 'Preview',
+            onClick: (e: any) => {
               e.domEvent.stopPropagation();
               onPreview(relativePath);
-            }}
-            key="preview"
-          >
-            Preview
-          </Menu.Item>
-          <S.ContextMenuDivider />
-        </>
-      )}
-      {isFolder ? (
-        <>
-          <Menu.Item
-            disabled={isInPreviewMode}
-            onClick={e => {
+            },
+          },
+          {key: 'divider-preview', type: 'divider'},
+        ]
+      : []),
+    ...(isFolder
+      ? [
+          {
+            key: 'create_directory',
+            label: 'New Folder',
+            disabled: isInPreviewMode,
+            onClick: (e: any) => {
               e.domEvent.stopPropagation();
               onCreateFolder(absolutePath);
-            }}
-            key="create_directory"
-          >
-            New Folder
-          </Menu.Item>
-        </>
-      ) : null}
-
-      <Menu.Item
-        disabled={
-          isInPreviewMode ||
-          isHelmChartFile(relativePath) ||
-          isHelmValuesFile(relativePath) ||
-          (!isFolder && (isExcluded || !isSupported))
-        }
-        onClick={e => {
-          e.domEvent.stopPropagation();
-          onCreateResource(isFolder ? {targetFolder: target} : {targetFile: target});
-        }}
-        key="create_resource"
-      >
-        {isFolder ? 'New Resource' : 'Add Resource'}
-      </Menu.Item>
-      <S.ContextMenuDivider />
-      <Menu.Item
-        key={`filter_on_this_${isFolder ? 'folder' : 'file'}`}
-        disabled={isInPreviewMode || (!isFolder && (isExcluded || !isSupported))}
-        onClick={e => {
-          e.domEvent.stopPropagation();
-
-          if (isRoot || (fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter)) {
-            onFilterByFileOrFolder(undefined);
-          } else {
-            onFilterByFileOrFolder(relativePath);
-          }
-        }}
-      >
-        {fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter
+            },
+          },
+        ]
+      : []),
+    {
+      key: 'create_resource',
+      label: isFolder ? 'New Resource' : 'Add Resource',
+      disabled:
+        isInPreviewMode ||
+        isHelmChartFile(relativePath) ||
+        isHelmValuesFile(relativePath) ||
+        (!isFolder && (isExcluded || !isSupported)),
+      onClick: (e: any) => {
+        e.domEvent.stopPropagation();
+        onCreateResource(isFolder ? {targetFolder: target} : {targetFile: target});
+      },
+    },
+    {key: 'divider-1', type: 'divider'},
+    {
+      key: `filter_on_this_${isFolder ? 'folder' : 'file'}`,
+      label:
+        fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter
           ? 'Remove from filter'
-          : `Filter on this ${isFolder ? 'folder' : 'file'}`}
-      </Menu.Item>
-      {fileMap[ROOT_FILE_ENTRY].filePath !== treeKey ? (
-        <>
-          <Menu.Item
-            disabled={isInPreviewMode || (!isFolder && !isSupported && !isExcluded)}
-            onClick={e => {
+          : `Filter on this ${isFolder ? 'folder' : 'file'}`,
+      disabled: isInPreviewMode || (!isFolder && (isExcluded || !isSupported)),
+      onClick: (e: any) => {
+        e.domEvent.stopPropagation();
+
+        if (isRoot || (fileOrFolderContainedInFilter && relativePath === fileOrFolderContainedInFilter)) {
+          onFilterByFileOrFolder(undefined);
+        } else {
+          onFilterByFileOrFolder(relativePath);
+        }
+      },
+    },
+    ...(fileMap[ROOT_FILE_ENTRY].filePath !== treeKey
+      ? [
+          {
+            key: 'add_to_files_exclude',
+            label: `${isExcluded ? 'Remove from' : 'Add to'} Files: Exclude`,
+            disabled: isInPreviewMode || (!isFolder && !isSupported && !isExcluded),
+            onClick: (e: any) => {
               e.domEvent.stopPropagation();
               if (isExcluded) {
                 onIncludeToProcessing(relativePath);
               } else {
                 onExcludeFromProcessing(relativePath);
               }
-            }}
-            key="add_to_files_exclude"
-          >
-            {isExcluded ? 'Remove from' : 'Add to'} Files: Exclude
-          </Menu.Item>
-        </>
-      ) : null}
-      <S.ContextMenuDivider />
-      <Menu.Item
-        onClick={e => {
-          e.domEvent.stopPropagation();
-          navigator.clipboard.writeText(absolutePath);
-        }}
-        key="copy_full_path"
-      >
-        Copy Path
-      </Menu.Item>
-      <Menu.Item
-        onClick={e => {
-          e.domEvent.stopPropagation();
-
-          navigator.clipboard.writeText(relativePath);
-        }}
-        key="copy_relative_path"
-      >
-        Copy Relative Path
-      </Menu.Item>
-      {fileMap[ROOT_FILE_ENTRY].filePath !== treeKey ? (
-        <>
-          <S.ContextMenuDivider />
-          <Menu.Item
-            disabled={isInPreviewMode}
-            onClick={e => {
+            },
+          },
+        ]
+      : []),
+    {key: 'divider-2', type: 'divider'},
+    {
+      key: 'copy_full_path',
+      label: 'Copy Path',
+      onClick: (e: any) => {
+        e.domEvent.stopPropagation();
+        navigator.clipboard.writeText(absolutePath);
+      },
+    },
+    {
+      key: 'copy_relative_path',
+      label: 'Copy Relative Path',
+      onClick: (e: any) => {
+        e.domEvent.stopPropagation();
+        navigator.clipboard.writeText(relativePath);
+      },
+    },
+    ...(fileMap[ROOT_FILE_ENTRY].filePath !== treeKey
+      ? [
+          {key: 'divider-3', type: 'divider'},
+          {
+            key: 'rename_entity',
+            label: 'Rename',
+            disabled: isInPreviewMode,
+            onClick: (e: any) => {
               e.domEvent.stopPropagation();
               onRename(absolutePath, osPlatform);
-            }}
-            key="rename_entity"
-          >
-            Rename
-          </Menu.Item>
-          <Menu.Item
-            disabled={isInPreviewMode}
-            key="delete_entity"
-            onClick={e => {
+            },
+          },
+          {
+            key: 'delete_entity',
+            label: 'Delete',
+            disabled: isInPreviewMode,
+            onClick: (e: any) => {
               e.domEvent.stopPropagation();
               deleteEntityWizard(
                 {entityAbsolutePath: absolutePath},
@@ -230,27 +221,23 @@ const TreeItem: React.FC<TreeItemProps> = props => {
                 },
                 () => {}
               );
-            }}
-          >
-            Delete
-          </Menu.Item>
-        </>
-      ) : null}
-      <S.ContextMenuDivider />
-      <Menu.Item
-        onClick={e => {
-          e.domEvent.stopPropagation();
-          showItemInFolder(absolutePath);
-        }}
-        key="reveal_in_finder"
-      >
-        Reveal in {platformFilemanagerName}
-      </Menu.Item>
-    </Menu>
-  );
+            },
+          },
+        ]
+      : []),
+    {key: 'divider-4', type: 'divider'},
+    {
+      key: 'reveal_in_finder',
+      label: `  Reveal in ${platformFilemanagerName}`,
+      onClick: (e: any) => {
+        e.domEvent.stopPropagation();
+        showItemInFolder(absolutePath);
+      },
+    },
+  ];
 
   return (
-    <ContextMenu overlay={menu} triggerOnRightClick>
+    <ContextMenu overlay={<Menu items={menuItems} />} triggerOnRightClick>
       <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
         <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={absolutePath} placement="bottom">
           <S.TitleWrapper>
@@ -278,7 +265,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
                 Preview
               </S.PreviewButton>
             )}
-            <ContextMenu overlay={menu}>
+            <ContextMenu overlay={<Menu items={menuItems} />}>
               <div
                 onClick={e => {
                   e.stopPropagation();

--- a/src/components/organisms/PageHeader/HelpMenu.styled.tsx
+++ b/src/components/organisms/PageHeader/HelpMenu.styled.tsx
@@ -1,0 +1,25 @@
+import {Menu as RawMenu} from 'antd';
+
+import {QuestionCircleOutlined as RawQuestionCircleOutlined} from '@ant-design/icons';
+
+import styled from 'styled-components';
+
+import {FontColors} from '@styles/Colors';
+
+export const IconContainerSpan = styled.span`
+  width: 18px;
+  height: 18px;
+  color: ${FontColors.elementSelectTitle};
+  font-size: 18px;
+  cursor: pointer;
+`;
+
+export const Menu = styled(RawMenu)`
+  width: 200px;
+`;
+
+export const QuestionCircleOutlined = styled(RawQuestionCircleOutlined)`
+  cursor: pointer;
+  font-size: 20px;
+  color: ${FontColors.elementSelectTitle};
+`;

--- a/src/components/organisms/PageHeader/HelpMenu.tsx
+++ b/src/components/organisms/PageHeader/HelpMenu.tsx
@@ -1,17 +1,10 @@
 import {useMemo} from 'react';
 
-import {Col, Dropdown, Menu, Row} from 'antd';
+import {Col, Dropdown, Row} from 'antd';
 
-import {
-  FileSearchOutlined,
-  FireOutlined,
-  GithubOutlined,
-  MessageOutlined,
-  QuestionCircleOutlined,
-} from '@ant-design/icons';
+import {FileSearchOutlined, FireOutlined, GithubOutlined, MessageOutlined} from '@ant-design/icons';
 
 import semver from 'semver';
-import styled from 'styled-components';
 
 import {useAppDispatch} from '@redux/hooks';
 import {
@@ -30,25 +23,9 @@ import {openDiscord, openDocumentation, openGitHub} from '@utils/shell';
 
 import DiscordLogo from '@assets/DiscordLogo.svg';
 
-import Colors, {FontColors} from '@styles/Colors';
+import Colors from '@styles/Colors';
 
-const IconContainerSpan = styled.span`
-  width: 18px;
-  height: 18px;
-  color: ${FontColors.elementSelectTitle};
-  font-size: 18px;
-  cursor: pointer;
-`;
-
-const StyledQuestionCircleOutlined = styled(QuestionCircleOutlined)`
-  cursor: pointer;
-  font-size: 20px;
-  color: ${FontColors.elementSelectTitle};
-`;
-
-const MenuItem = styled(Menu.Item)`
-  padding-right: 12px;
-`;
+import * as S from './HelpMenu.styled';
 
 const HelpMenu = () => {
   const dispatch = useAppDispatch();
@@ -70,91 +47,99 @@ const HelpMenu = () => {
     dispatch(openKeyboardShortcutsModal());
   };
 
-  const menu = (
-    <Menu inlineIndent={25} style={{width: '200px'}}>
-      <MenuItem onClick={openDocumentation} key="documentation">
+  const menuItems = [
+    {
+      key: 'documentation',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <FileSearchOutlined />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>Documentation</Col>
         </Row>
-      </MenuItem>
-
-      <MenuItem onClick={onClickReleaseNotes} key="releasenotes">
+      ),
+      onClick: openDocumentation,
+    },
+    {
+      key: 'releasenotes',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <FireOutlined />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>New in {parsedAppVersion || 'this version'}</Col>
         </Row>
-      </MenuItem>
-
-      <MenuItem onClick={openKeyboardShortcuts} key="hotkeys">
+      ),
+      onClick: onClickReleaseNotes,
+    },
+    {
+      key: 'hotkeys',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <Icon name="shortcuts" color={Colors.blue6} />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>Keyboard Shortcuts</Col>
         </Row>
-      </MenuItem>
-
-      <MenuItem onClick={openGitHub} key="github">
+      ),
+      onClick: openKeyboardShortcuts,
+    },
+    {
+      key: 'github',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <GithubOutlined />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>GitHub</Col>
         </Row>
-      </MenuItem>
-
-      <MenuItem onClick={openDiscord} key="discord">
+      ),
+      onClick: openGitHub,
+    },
+    {
+      key: 'discord',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <img src={DiscordLogo} style={{height: '18px', width: '18px'}} />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>Discord</Col>
         </Row>
-      </MenuItem>
-
-      <MenuItem
-        onClick={() => {
-          dispatch(cancelWalkThrough('novice'));
-          dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
-        }}
-        key="replay"
-      >
+      ),
+      onClick: openDiscord,
+    },
+    {
+      key: 'replay',
+      label: (
         <Row align="middle">
           <Col span={5}>
-            <IconContainerSpan>
+            <S.IconContainerSpan>
               <MessageOutlined style={{transform: 'rotate(180deg)'}} />
-            </IconContainerSpan>
+            </S.IconContainerSpan>
           </Col>
-
           <Col span={19}>Re-play Quick Guide</Col>
         </Row>
-      </MenuItem>
-    </Menu>
-  );
+      ),
+      onClick: () => {
+        dispatch(cancelWalkThrough('novice'));
+        dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
+      },
+    },
+  ];
 
   return (
-    <Dropdown key="more" overlay={menu}>
-      <StyledQuestionCircleOutlined />
+    <Dropdown key="more" overlay={<S.Menu items={menuItems} />}>
+      <S.QuestionCircleOutlined />
     </Dropdown>
   );
 };

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
@@ -106,35 +106,34 @@ const ResourceKindContextMenu = (props: ItemCustomComponentProps) => {
     dispatch(openSaveResourcesToFileFolderModal([itemInstance.id]));
   };
 
-  const menu = (
-    <Menu>
-      {(isInPreviewMode || isUnsavedResource(resource)) && (
-        <>
-          <Menu.Item onClick={onClickSaveToFileFolder} key="save_to_file_folder">
-            Save to file/folder
-          </Menu.Item>
-          <ContextMenuDivider />
-        </>
-      )}
-
-      <Menu.Item disabled={isInPreviewMode} onClick={onClickRename} key="rename">
-        Rename
-      </Menu.Item>
-
-      {knownResourceKinds.includes(resource.kind) && (
-        <Menu.Item disabled={isInPreviewMode} onClick={onClickClone} key="clone">
-          Clone
-        </Menu.Item>
-      )}
-
-      <Menu.Item disabled={isInPreviewMode && previewType !== 'cluster'} onClick={onClickDelete} key="delete">
-        Delete
-      </Menu.Item>
-    </Menu>
-  );
+  const menuItems = [
+    ...(isInPreviewMode || isUnsavedResource(resource)
+      ? [
+          {
+            key: 'save_to_file_folder',
+            label: 'Save to file/folder',
+            disabled: isInPreviewMode,
+            onClick: onClickSaveToFileFolder,
+          },
+          {key: 'divider', type: 'divider'},
+        ]
+      : []),
+    {key: 'rename', label: 'Rename', onClick: onClickRename},
+    ...(knownResourceKinds.includes(resource.kind)
+      ? [
+          {
+            key: 'clone',
+            label: 'Clone',
+            disabled: isInPreviewMode,
+            onClick: onClickClone,
+          },
+        ]
+      : []),
+    {key: 'delete', label: 'Delete', disabled: isInPreviewMode && previewType !== 'cluster', onClick: onClickDelete},
+  ];
 
   return (
-    <ContextMenu overlay={menu}>
+    <ContextMenu overlay={<Menu items={menuItems} />}>
       <StyledActionsMenuIconContainer isSelected={itemInstance.isSelected}>
         <Dots color={isResourceSelected ? Colors.blackPure : undefined} />
       </StyledActionsMenuIconContainer>

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenuWrapper.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenuWrapper.tsx
@@ -2,8 +2,6 @@ import {Menu, Modal} from 'antd';
 
 import {ExclamationCircleOutlined} from '@ant-design/icons';
 
-import styled from 'styled-components';
-
 import {AppDispatch} from '@models/appdispatch';
 import {ResourceMapType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
@@ -17,10 +15,6 @@ import {isFileResource, isUnsavedResource} from '@redux/services/resource';
 import {removeResources} from '@redux/thunks/removeResources';
 
 import ContextMenu from '@components/molecules/ContextMenu';
-
-const ContextMenuDivider = styled.div`
-  border-bottom: 1px solid rgba(255, 255, 255, 0.25);
-`;
 
 function deleteResourceWithConfirm(resource: K8sResource, resourceMap: ResourceMapType, dispatch: AppDispatch) {
   let title = `Are you sure you want to delete ${resource.name}?`;
@@ -88,35 +82,34 @@ const ResourceKindContextMenuWrapper = (props: ItemCustomComponentProps) => {
     dispatch(openSaveResourcesToFileFolderModal([itemInstance.id]));
   };
 
-  const menu = (
-    <Menu>
-      {(isInPreviewMode || isUnsavedResource(resource)) && (
-        <>
-          <Menu.Item onClick={onClickSaveToFileFolder} key="save_to_file_folder">
-            Save to file/folder
-          </Menu.Item>
-          <ContextMenuDivider />
-        </>
-      )}
-
-      <Menu.Item disabled={isInPreviewMode} onClick={onClickRename} key="rename">
-        Rename
-      </Menu.Item>
-
-      {knownResourceKinds.includes(resource.kind) && (
-        <Menu.Item disabled={isInPreviewMode} onClick={onClickClone} key="clone">
-          Clone
-        </Menu.Item>
-      )}
-
-      <Menu.Item disabled={isInPreviewMode && previewType !== 'cluster'} onClick={onClickDelete} key="delete">
-        Delete
-      </Menu.Item>
-    </Menu>
-  );
+  const menuItems = [
+    ...(isInPreviewMode || isUnsavedResource(resource)
+      ? [
+          {
+            key: 'save_to_file_folder',
+            label: 'Save to file/folder',
+            disabled: isInPreviewMode,
+            onClick: onClickSaveToFileFolder,
+          },
+          {key: 'divider', type: 'divider'},
+        ]
+      : []),
+    {key: 'rename', label: 'Rename', onClick: onClickRename},
+    ...(knownResourceKinds.includes(resource.kind)
+      ? [
+          {
+            key: 'clone',
+            label: 'Clone',
+            disabled: isInPreviewMode,
+            onClick: onClickClone,
+          },
+        ]
+      : []),
+    {key: 'delete', label: 'Delete', disabled: isInPreviewMode && previewType !== 'cluster', onClick: onClickDelete},
+  ];
 
   return (
-    <ContextMenu overlay={menu} triggerOnRightClick>
+    <ContextMenu overlay={<Menu items={menuItems} />} triggerOnRightClick>
       {children}
     </ContextMenu>
   );

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationContextMenu.tsx
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationContextMenu.tsx
@@ -46,16 +46,17 @@ const KustomizationContextMenu: React.FC<ItemCustomComponentProps> = props => {
     }
   };
 
-  const menu = (
-    <Menu>
-      <Menu.Item disabled={isInPreviewMode} key="show_file" onClick={onClickShowFile}>
-        Go to file
-      </Menu.Item>
-    </Menu>
-  );
+  const menuItems = [
+    {
+      key: 'show_file',
+      label: 'Go to file',
+      disabled: isInPreviewMode,
+      onClick: onClickShowFile,
+    },
+  ];
 
   return (
-    <ContextMenu overlay={menu}>
+    <ContextMenu overlay={<Menu items={menuItems} />}>
       <StyledActionsMenuIconContainer isSelected={itemInstance.isSelected}>
         <Dots color={isResourceSelected ? Colors.blackPure : undefined} />
       </StyledActionsMenuIconContainer>

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationContextMenuWrapper.tsx
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationContextMenuWrapper.tsx
@@ -28,16 +28,17 @@ const KustomizationContextMenu: React.FC<ItemCustomComponentProps> = props => {
     }
   };
 
-  const menu = (
-    <Menu>
-      <Menu.Item disabled={isInPreviewMode} key="show_file" onClick={onClickShowFile}>
-        Go to file
-      </Menu.Item>
-    </Menu>
-  );
+  const menuItems = [
+    {
+      key: 'show_file',
+      label: 'Go to file',
+      disabled: isInPreviewMode,
+      onClick: onClickShowFile,
+    },
+  ];
 
   return (
-    <ContextMenu overlay={menu} triggerOnRightClick>
+    <ContextMenu overlay={<Menu items={menuItems} />} triggerOnRightClick>
       {children}
     </ContextMenu>
   );


### PR DESCRIPTION
## Changes

- Replace deprecated Antd menu component `children` with `items`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
