### PR TITLE
fix: overflow-y auto for table on selectors

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelectionTable.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelectionTable.styled.tsx
@@ -13,6 +13,10 @@ export const Table = styled(props => <RawTable {...props} />)`
   tbody {
     vertical-align: top;
   }
+
+  & .ant-table-container .ant-table-body {
+    overflow-y: auto !important;
+  }
 `;
 
 export const ClusterAccessContainer = styled.span`

--- a/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
@@ -71,7 +71,7 @@ export const ProjectContainer = styled.div`
   border-radius: 4px;
   width: 180px;
   background: ${Colors.grey3b};
-  padding 2px 4px;
+  padding: 2px 4px;
 `;
 
 export const ProjectMenu = styled.div`
@@ -143,4 +143,8 @@ export const Table = styled(props => <RawTable {...props} />)`
   width: 800px;
   border-top: 1px solid ${Colors.grey3};
   padding-top: 18px;
+
+  & .ant-table-container .ant-table-body {
+    overflow-y: auto !important;
+  }
 `;


### PR DESCRIPTION
## Fixes

- Remove the paddings from table body by setting the overflow-y to `auto`


## Screenshots

![image](https://user-images.githubusercontent.com/47887589/171345962-b08482ae-82be-405d-b258-f0cc1ef51072.png)

![image](https://user-images.githubusercontent.com/47887589/171345999-e13a1784-bc28-4ddf-8d75-4fa654abd6f8.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
