### PR TITLE
fix: update checked selection when deleting resources

### DIFF
--- a/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
+++ b/src/components/molecules/CheckedResourcesActionsMenu/CheckedResourcesActionsMenu.tsx
@@ -133,7 +133,6 @@ const deleteCheckedResourcesWithConfirm = (checkedResources: K8sResource[], disp
           alertMessage += `${alertMessage && ' | '}${resource.name}\n`;
         });
         dispatch(removeResources(resourceIdsToRemove));
-        dispatch(uncheckAllResourceIds());
 
         dispatch(setAlert({type: AlertEnum.Success, title: 'Successfully deleted resources', message: alertMessage}));
         resolve({});

--- a/src/redux/thunks/removeResources.ts
+++ b/src/redux/thunks/removeResources.ts
@@ -18,6 +18,8 @@ export const removeResources = createAsyncThunk(
     const state: RootState = thunkAPI.getState();
 
     const nextMainState = createNextState(state.main, mainState => {
+      let deletedCheckedResourcesIds: string[] = [];
+
       resourceIds.forEach(resourceId => {
         const resource = mainState.resourceMap[resourceId];
         if (!resource) {
@@ -25,6 +27,10 @@ export const removeResources = createAsyncThunk(
         }
 
         updateReferringRefsOnDelete(resource, mainState.resourceMap);
+
+        if (mainState.checkedResourceIds.includes(resourceId)) {
+          deletedCheckedResourcesIds.push(resourceId);
+        }
 
         if (mainState.selectedResourceId === resourceId) {
           clearResourceSelections(mainState.resourceMap);
@@ -60,6 +66,10 @@ export const removeResources = createAsyncThunk(
           }
         }
       });
+
+      mainState.checkedResourceIds = mainState.checkedResourceIds.filter(
+        id => !deletedCheckedResourcesIds.includes(id)
+      );
     });
 
     return nextMainState;


### PR DESCRIPTION
## Fixes

- Update number of checked resources on resource delete

## How to test it

- Check multiple resources and delete only one resource

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
