### PR TITLE
fix: highlight unsaved resource after append

### DIFF
--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -922,6 +922,10 @@ export const mainSlice = createSlice({
         if (resource) {
           resource.filePath = relativeFilePath;
           resource.range = resourcePayload.resourceRange;
+
+          if (state.selectedPath === relativeFilePath) {
+            resource.isHighlighted = true;
+          }
         }
       });
     });

--- a/src/redux/thunks/saveUnsavedResources.ts
+++ b/src/redux/thunks/saveUnsavedResources.ts
@@ -38,7 +38,6 @@ const performSaveUnsavedResource = async (
   resource: K8sResource,
   rootFolder: FileEntry | undefined,
   absolutePath: string,
-  fileIncludes: string[],
   saveMode: 'saveToFolder' | 'appendToFile'
 ) => {
   let resourceRange: {start: number; length: number} | undefined;
@@ -88,7 +87,6 @@ export const saveUnsavedResources = createAsyncThunk<
   }
 >('main/saveUnsavedResources', async (args, thunkAPI) => {
   const mainState = thunkAPI.getState().main;
-  const configState = thunkAPI.getState().config;
   const rootFolder = mainState.fileMap[ROOT_FILE_ENTRY];
 
   let resourcePayloads: ResourcePayload[] = [];
@@ -102,7 +100,6 @@ export const saveUnsavedResources = createAsyncThunk<
         resource,
         rootFolder,
         absolutePath,
-        configState.fileIncludes,
         args.saveMode
       );
 


### PR DESCRIPTION
## Fixes

- Highlight unsaved resource after appending to file ( if the file is already selected )

## How to test it

- Select file from file explorer and then append to the file an unsaved resource

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
