### PR TITLE
Fix is cluster mode

### DIFF
--- a/src/components/organisms/FileTreePane/styled.tsx
+++ b/src/components/organisms/FileTreePane/styled.tsx
@@ -233,4 +233,5 @@ export const ActionsWrapper = styled.div`
   align-items: center;
   justify-content: flex-end;
   flex-direction: row;
+  height: 100%;
 `;

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -12,6 +12,7 @@ import {RootState} from '@models/rootstate';
 
 import {isKustomizationResource} from '@redux/services/kustomize';
 
+import {isDefined} from '@utils/filter';
 import {isResourcePassingFilter} from '@utils/resources';
 
 import {getResourceKindHandler} from '@src/kindhandlers';
@@ -114,12 +115,10 @@ export const isInPreviewModeSelector = (state: RootState) =>
 
 export const isInClusterModeSelector = createSelector(
   (state: RootState) => state,
-  ({main, config}) => {
-    const kubeConfigPath = config.projectConfig?.kubeConfig?.path || config.kubeConfig.path;
-    if (kubeConfigPath) {
-      return Boolean(main.previewResourceId && main.previewResourceId.endsWith(kubeConfigPath));
-    }
-    return false;
+  state => {
+    const kubeConfig = selectCurrentKubeConfig(state);
+    const previewId = state.main.previewResourceId;
+    return kubeConfig && isDefined(previewId) && previewId === kubeConfig.currentContext;
   }
 );
 


### PR DESCRIPTION
This PR I fix a selector that I overlooked while I fixed [fix multiple cluster resource sets](https://github.com/kubeshop/monokle/pull/1910/commits/9fbb6eb390ac318075dbeb7e734d08c09fd42200) and [fix cluster preview](https://github.com/kubeshop/monokle/pull/1910/commits/8095c85ba5f45ff4a7bd3fbf128656e07ed19ea4).

It's quite a visual bug so best to include it in release (In the navigator during preview you currently get the teal colored label instead the orange one) 

So what happened is this: createKubeClient in preview cluster used `createClient(configObject, contextString)` but when we use a configObject and not a configString then we had a bug that it ignored the provided context. Once I fixed that, I found a bug where we actually never passed contextString to begin with but instead the pathString (this was masked by the other bug). So the createClient crashed. I fixed that as well in the second commit but then I did not notice that there was also a selector which now always returned `false` and thus we fallback to the teal preview one. 

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
