### PR TITLE
fix: tooltip hotkey overflow

### DIFF
--- a/src/components/molecules/HotkeyLabel/HotkeyLabel.styled.tsx
+++ b/src/components/molecules/HotkeyLabel/HotkeyLabel.styled.tsx
@@ -11,6 +11,7 @@ export const KeyboardKey = styled.div`
 export const CommandsContainer = styled.div`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 5px;
 `;
 

--- a/src/index.css
+++ b/src/index.css
@@ -239,6 +239,10 @@ div.monokleEditorErrorRefGlyphClass.monokleEditorUnsatisfiedRefGlyphClass::after
   display: none;
 }
 
+.ant-tooltip {
+  max-width: 300px;
+}
+
 .ant-table-header {
   margin-bottom: 18px;
 }
@@ -279,7 +283,7 @@ div.monokleEditorErrorRefGlyphClass.monokleEditorUnsatisfiedRefGlyphClass::after
   cursor: pointer;
 }
 
-.ant-table-body .ant-table-row:hover .table-column-actions .edit-span-btn{
+.ant-table-body .ant-table-row:hover .table-column-actions .edit-span-btn {
   display: block;
 }
 


### PR DESCRIPTION
## Fixes

- Tooltip hotkey overflow

## How to test it

- Hover over left menu options that have tooltips

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/173518291-43da757d-cd37-4c48-b06e-6efa7f6d508e.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
