### PR TITLE
fix: cluster resource delete

### DIFF
--- a/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
+++ b/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components';
 import {K8sResource} from '@models/k8sresource';
 
 import {useAppSelector} from '@redux/hooks';
-import {currentClusterAccessSelector} from '@redux/selectors';
+import {currentClusterAccessSelector, kubeConfigContextSelector, kubeConfigPathSelector} from '@redux/selectors';
 
 import {useTargetClusterNamespaces} from '@hooks/useTargetClusterNamespaces';
 
@@ -60,10 +60,12 @@ interface IProps {
 const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
   const {isVisible, resources = [], title, onCancel, onOk} = props;
 
-  const configState = useAppSelector(state => state.config);
   const clusterAccess = useAppSelector(currentClusterAccessSelector);
   const clusterNamespaces = clusterAccess?.map(cl => cl.namespace);
   const defaultClusterNamespace = clusterNamespaces && clusterNamespaces.length ? clusterNamespaces[0] : 'default';
+  const kubeConfigContext = useAppSelector(kubeConfigContextSelector);
+  const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
+
   const {defaultNamespace, defaultOption} = getDefaultNamespaceForApply(resources, defaultClusterNamespace);
   const [namespaces] = useTargetClusterNamespaces();
 
@@ -81,7 +83,7 @@ const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
         return;
       }
 
-      const kc = createKubeClient(configState);
+      const kc = createKubeClient(kubeConfigPath, kubeConfigContext);
       const k8sCoreV1Api = kc.makeApiClient(k8s.CoreV1Api);
 
       k8sCoreV1Api
@@ -101,7 +103,7 @@ const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
     } else if (selectedOption === 'none') {
       onOk();
     }
-  }, [createNamespaceName, selectedNamespace, selectedOption, onOk, configState]);
+  }, [selectedOption, createNamespaceName, kubeConfigPath, kubeConfigContext, onOk, selectedNamespace]);
 
   useEffect(() => {
     if (defaultOption && defaultOption === 'none') {

--- a/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
+++ b/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
@@ -22,6 +22,7 @@ import {
   currentConfigSelector,
   isInClusterModeSelector,
   kubeConfigContextSelector,
+  kubeConfigPathSelector,
 } from '@redux/selectors';
 import {isKustomizationResource} from '@redux/services/kustomize';
 import {applyResource} from '@redux/thunks/applyResource';
@@ -50,6 +51,7 @@ const DiffModal = () => {
   const fileMap = useAppSelector(state => state.main.fileMap);
   const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const kubeConfigContext = useAppSelector(kubeConfigContextSelector);
+  const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
   const projectConfig = useAppSelector(currentConfigSelector);
   const previewType = useAppSelector(state => state.main.previewType);
   const resourceFilter = useAppSelector(state => state.main.resourceFilter);
@@ -210,7 +212,7 @@ const DiffModal = () => {
     }
 
     const getClusterResources = async () => {
-      const kc = createKubeClient(configState);
+      const kc = createKubeClient(kubeConfigPath, kubeConfigContext);
 
       const resourceKindHandler = getResourceKindHandler(targetResource.kind);
       const getResources = async () => {

--- a/src/redux/services/compare/fetchResources.ts
+++ b/src/redux/services/compare/fetchResources.ts
@@ -23,7 +23,7 @@ import {
   KustomizeResourceSet,
   ResourceSet,
 } from '@redux/compare';
-import {currentConfigSelector} from '@redux/selectors';
+import {currentConfigSelector, kubeConfigPathSelector} from '@redux/selectors';
 import {runKustomize} from '@redux/thunks/previewKustomization';
 
 import {
@@ -72,9 +72,10 @@ function fetchLocalResources(state: RootState): K8sResource[] {
 
 async function fetchResourcesFromCluster(state: RootState, options: ClusterResourceSet): Promise<K8sResource[]> {
   try {
+    const kubeConfigPath = kubeConfigPathSelector(state);
     const currentContext = options.context;
     const clusterAccess = state.config.projectConfig?.clusterAccess?.filter(ca => ca.context === currentContext) || [];
-    const kc = createKubeClient(state.config, currentContext);
+    const kc = createKubeClient(kubeConfigPath, currentContext);
 
     const res = clusterAccess.length
       ? await Promise.all(clusterAccess.map(ca => getClusterObjects(kc, ca.namespace)))

--- a/src/redux/thunks/loadClusterDiff.ts
+++ b/src/redux/thunks/loadClusterDiff.ts
@@ -9,7 +9,7 @@ import {AppDispatch} from '@models/appdispatch';
 import {ResourceMapType} from '@models/appstate';
 import {RootState} from '@models/rootstate';
 
-import {currentKubeContext} from '@redux/selectors';
+import {currentKubeContext, kubeConfigPathSelector} from '@redux/selectors';
 import getClusterObjects from '@redux/services/getClusterObjects';
 import {extractK8sResources} from '@redux/services/resource';
 
@@ -38,9 +38,10 @@ export const loadClusterDiff = createAsyncThunk<
     return;
   }
   try {
+    const kubeConfigPath = kubeConfigPathSelector(state);
     const currentContext = currentKubeContext(state.config);
     const clusterAccess = state.config.projectConfig?.clusterAccess?.filter(ca => ca.context === currentContext) || [];
-    const kc = createKubeClient(state.config);
+    const kc = createKubeClient(kubeConfigPath, currentContext);
     try {
       const res = clusterAccess.length
         ? await Promise.all(clusterAccess.map(ca => getClusterObjects(kc, ca.namespace)))

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -14,7 +14,7 @@ import {K8sResource} from '@models/k8sresource';
 import {RootState} from '@models/rootstate';
 
 import {SetPreviewDataPayload} from '@redux/reducers/main';
-import {currentClusterAccessSelector, currentConfigSelector} from '@redux/selectors';
+import {currentClusterAccessSelector, currentConfigSelector, kubeConfigPathSelector} from '@redux/selectors';
 import {getK8sVersion} from '@redux/services/projectConfig';
 import {extractK8sResources, processResources} from '@redux/services/resource';
 import {createPreviewResult, createRejectionWithAlert, getK8sObjectsAsYaml} from '@redux/thunks/utils';
@@ -40,11 +40,14 @@ const previewClusterHandler = async (context: string, thunkAPI: any) => {
   const resourceRefsProcessingOptions = thunkAPI.getState().main.resourceRefsProcessingOptions;
   const projectConfig = currentConfigSelector(thunkAPI.getState());
   const k8sVersion = getK8sVersion(projectConfig);
-  const userDataDir = thunkAPI.getState().config.userDataDir;
   const clusterAccess = currentClusterAccessSelector(thunkAPI.getState());
+  const kubeConfigPath = kubeConfigPathSelector(thunkAPI.getState());
+
+  const config = thunkAPI.getState().config;
+  const {userDataDir} = config;
 
   try {
-    const kc = createKubeClient(thunkAPI.getState().config, context);
+    const kc = createKubeClient(config, context);
     const results =
       clusterAccess && clusterAccess.length > 0
         ? await Promise.all(clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace)))
@@ -72,7 +75,7 @@ const previewClusterHandler = async (context: string, thunkAPI: any) => {
       context,
       'Get Cluster Resources',
       resourceRefsProcessingOptions,
-      context,
+      kubeConfigPath,
       kc.currentContext
     );
 

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -47,7 +47,7 @@ const previewClusterHandler = async (context: string, thunkAPI: any) => {
   const {userDataDir} = config;
 
   try {
-    const kc = createKubeClient(config, context);
+    const kc = createKubeClient(kubeConfigPath, context);
     const results =
       clusterAccess && clusterAccess.length > 0
         ? await Promise.all(clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace)))

--- a/src/utils/kubeclient.ts
+++ b/src/utils/kubeclient.ts
@@ -3,26 +3,21 @@ import * as k8s from '@kubernetes/client-node';
 import log from 'loglevel';
 import {v4 as uuid} from 'uuid';
 
-import {AppConfig, ClusterAccess, ClusterAccessWithContext, KubePermissions} from '@models/appconfig';
+import {ClusterAccess, ClusterAccessWithContext, KubePermissions} from '@models/appconfig';
 
 import {runCommandInMainThread} from '@utils/commands';
 import electronStore from '@utils/electronStore';
 import {getMainProcessEnv} from '@utils/env';
 
-export function createKubeClient(config: string | AppConfig, context?: string) {
+export function createKubeClient(path: string, context?: string) {
   const kc = new k8s.KubeConfig();
 
-  const path = typeof config === 'string' ? config : config.projectConfig?.kubeConfig?.path || config.kubeConfig.path;
   if (!path) {
     throw new Error('Missing path to kubeconfing');
   }
 
   kc.loadFromFile(path);
-  let currentContext =
-    context ??
-    (typeof config === 'string'
-      ? undefined
-      : config.projectConfig?.kubeConfig?.currentContext ?? config.kubeConfig?.currentContext);
+  let currentContext = context;
 
   if (!currentContext) {
     currentContext = kc.currentContext;


### PR DESCRIPTION
## Changes

- Use kube config selector for getting the path and context used for creating the kube client

## How to test it

- Delete a resource from the cluster directly


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
