### PR TITLE
feat: hide namespace for cluster scoped resources

### DIFF
--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -39,8 +39,8 @@ interface K8sResource {
   version: string;
   /** k8s namespace is specified (for filtering) */
   namespace?: string;
-  /** if resource is namespaced */
-  isNamespaced: boolean;
+  /** if resource kind is namespaced */
+  isKindNamespaced: boolean;
   /** if highlighted in UI (should probalby move to UI state object) */
   isHighlighted: boolean;
   /** if selected in UI (should probably move to UI state object) */

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -39,6 +39,8 @@ interface K8sResource {
   version: string;
   /** k8s namespace is specified (for filtering) */
   namespace?: string;
+  /** if resource is namespaced */
+  isNamespaced: boolean;
   /** if highlighted in UI (should probalby move to UI state object) */
   isHighlighted: boolean;
   /** if selected in UI (should probably move to UI state object) */

--- a/src/models/k8sresource.ts
+++ b/src/models/k8sresource.ts
@@ -39,8 +39,8 @@ interface K8sResource {
   version: string;
   /** k8s namespace is specified (for filtering) */
   namespace?: string;
-  /** if resource kind is namespaced */
-  isKindNamespaced: boolean;
+  /** if a resource is cluster scoped ( kind is namespaced ) */
+  isClusterScoped: boolean;
   /** if highlighted in UI (should probalby move to UI state object) */
   isHighlighted: boolean;
   /** if selected in UI (should probably move to UI state object) */

--- a/src/redux/services/compare/transferResource.ts
+++ b/src/redux/services/compare/transferResource.ts
@@ -141,7 +141,7 @@ function createResource(rawResource: any, overrides?: Partial<K8sResource>): K8s
     filePath: `${UNSAVED_PREFIX}${id}`,
     isHighlighted: false,
     isSelected: false,
-    isKindNamespaced: getResourceKindHandler(rawResource.kind)?.isNamespaced || false,
+    isClusterScoped: getResourceKindHandler(rawResource.kind)?.isNamespaced || false,
     ...overrides,
   };
 }

--- a/src/redux/services/compare/transferResource.ts
+++ b/src/redux/services/compare/transferResource.ts
@@ -19,6 +19,8 @@ import {createKubectlApplyCommand} from '@utils/commands/kubectl';
 import {createKubeClient} from '@utils/kubeclient';
 import {jsonToYaml} from '@utils/yaml';
 
+import {getResourceKindHandler} from '@src/kindhandlers';
+
 type Type = ResourceSet['type'];
 
 export function canTransfer(from: Type | undefined, to: Type | undefined): boolean {
@@ -139,6 +141,7 @@ function createResource(rawResource: any, overrides?: Partial<K8sResource>): K8s
     filePath: `${UNSAVED_PREFIX}${id}`,
     isHighlighted: false,
     isSelected: false,
+    isNamespaced: getResourceKindHandler(rawResource.kind)?.isNamespaced || false,
     ...overrides,
   };
 }

--- a/src/redux/services/compare/transferResource.ts
+++ b/src/redux/services/compare/transferResource.ts
@@ -141,7 +141,7 @@ function createResource(rawResource: any, overrides?: Partial<K8sResource>): K8s
     filePath: `${UNSAVED_PREFIX}${id}`,
     isHighlighted: false,
     isSelected: false,
-    isNamespaced: getResourceKindHandler(rawResource.kind)?.isNamespaced || false,
+    isKindNamespaced: getResourceKindHandler(rawResource.kind)?.isNamespaced || false,
     ...overrides,
   };
 }

--- a/src/redux/services/resource.test.ts
+++ b/src/redux/services/resource.test.ts
@@ -16,7 +16,7 @@ test('get-namespaces', () => {
     version: '1.0',
     isHighlighted: false,
     isSelected: false,
-    isKindNamespaced: true,
+    isClusterScoped: true,
     content: {
       apiVersion: 'v1',
       kind: 'Deployment',

--- a/src/redux/services/resource.test.ts
+++ b/src/redux/services/resource.test.ts
@@ -16,7 +16,7 @@ test('get-namespaces', () => {
     version: '1.0',
     isHighlighted: false,
     isSelected: false,
-    isNamespaced: true,
+    isKindNamespaced: true,
     content: {
       apiVersion: 'v1',
       kind: 'Deployment',

--- a/src/redux/services/resource.test.ts
+++ b/src/redux/services/resource.test.ts
@@ -16,6 +16,7 @@ test('get-namespaces', () => {
     version: '1.0',
     isHighlighted: false,
     isSelected: false,
+    isNamespaced: true,
     content: {
       apiVersion: 'v1',
       kind: 'Deployment',

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -733,7 +733,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: content.apiVersion,
             content,
             text,
-            isKindNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
+            isClusterScoped: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           if (
@@ -779,7 +779,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: KUSTOMIZATION_API_VERSION,
             content,
             text: fileContent,
-            isKindNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
+            isClusterScoped: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           // if this is a single-resource file we can save the parsedDoc and lineCounter

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -733,7 +733,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: content.apiVersion,
             content,
             text,
-            isNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
+            isKindNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           if (
@@ -779,7 +779,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: KUSTOMIZATION_API_VERSION,
             content,
             text: fileContent,
-            isNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
+            isKindNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           // if this is a single-resource file we can save the parsedDoc and lineCounter

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -733,6 +733,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: content.apiVersion,
             content,
             text,
+            isNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           if (
@@ -778,6 +779,7 @@ export function extractK8sResources(fileContent: string, relativePath: string) {
             version: KUSTOMIZATION_API_VERSION,
             content,
             text: fileContent,
+            isNamespaced: getResourceKindHandler(content.kind)?.isNamespaced || false,
           };
 
           // if this is a single-resource file we can save the parsedDoc and lineCounter

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -10,6 +10,8 @@ import {addMultipleResources, addResource, selectK8sResource} from '@redux/reduc
 
 import {parseYamlDocument} from '@utils/yaml';
 
+import {getResourceKindHandler} from '@src/kindhandlers';
+
 function createDefaultResourceText(input: {name: string; kind: string; apiVersion?: string; namespace?: string}) {
   return `
 apiVersion: ${input.apiVersion ? input.apiVersion : 'v1'}
@@ -60,6 +62,7 @@ export function createUnsavedResource(
     namespace: input.namespace,
     text: newResourceText,
     content: newResourceContent,
+    isNamespaced: getResourceKindHandler(input.kind)?.isNamespaced || false,
   };
   dispatch(addResource(newResource));
   dispatch(selectK8sResource({resourceId: newResource.id}));
@@ -107,6 +110,7 @@ export function createMultipleUnsavedResources(
     namespace: resourceMap[resourceId].input.namespace,
     text: resourceMap[resourceId].text,
     content: resourceMap[resourceId].content,
+    isNamespaced: getResourceKindHandler(resourceMap[resourceId].input.kind)?.isNamespaced || false,
   }));
 
   dispatch(addMultipleResources(newResources));

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -62,7 +62,7 @@ export function createUnsavedResource(
     namespace: input.namespace,
     text: newResourceText,
     content: newResourceContent,
-    isKindNamespaced: getResourceKindHandler(input.kind)?.isNamespaced || false,
+    isClusterScoped: getResourceKindHandler(input.kind)?.isNamespaced || false,
   };
   dispatch(addResource(newResource));
   dispatch(selectK8sResource({resourceId: newResource.id}));
@@ -110,7 +110,7 @@ export function createMultipleUnsavedResources(
     namespace: resourceMap[resourceId].input.namespace,
     text: resourceMap[resourceId].text,
     content: resourceMap[resourceId].content,
-    isKindNamespaced: getResourceKindHandler(resourceMap[resourceId].input.kind)?.isNamespaced || false,
+    isClusterScoped: getResourceKindHandler(resourceMap[resourceId].input.kind)?.isNamespaced || false,
   }));
 
   dispatch(addMultipleResources(newResources));

--- a/src/redux/services/unsavedResource.ts
+++ b/src/redux/services/unsavedResource.ts
@@ -62,7 +62,7 @@ export function createUnsavedResource(
     namespace: input.namespace,
     text: newResourceText,
     content: newResourceContent,
-    isNamespaced: getResourceKindHandler(input.kind)?.isNamespaced || false,
+    isKindNamespaced: getResourceKindHandler(input.kind)?.isNamespaced || false,
   };
   dispatch(addResource(newResource));
   dispatch(selectK8sResource({resourceId: newResource.id}));
@@ -110,7 +110,7 @@ export function createMultipleUnsavedResources(
     namespace: resourceMap[resourceId].input.namespace,
     text: resourceMap[resourceId].text,
     content: resourceMap[resourceId].content,
-    isNamespaced: getResourceKindHandler(resourceMap[resourceId].input.kind)?.isNamespaced || false,
+    isKindNamespaced: getResourceKindHandler(resourceMap[resourceId].input.kind)?.isNamespaced || false,
   }));
 
   dispatch(addMultipleResources(newResources));


### PR DESCRIPTION
## Changes

- Add `isKindNamespaced` property on K8sResource
- Hide namespace input on the new resource wizard if the kind is not namespaced

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/175018049-6363c928-2c3c-4fcc-9104-3d8df669171c.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
