### PR TITLE
fix: disable helm/kustomize panels in cluster mode

### DIFF
--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -236,17 +236,25 @@ const HotKeysHandler = () => {
     dispatch(setLeftMenuSelection('file-explorer'));
   });
 
-  useHotkeys(hotkeys.OPEN_KUSTOMIZATION_TAB.key, () => {
-    if (!isInClusterMode) {
-      dispatch(setLeftMenuSelection('kustomize-pane'));
-    }
-  });
+  useHotkeys(
+    hotkeys.OPEN_KUSTOMIZATION_TAB.key,
+    () => {
+      if (!isInClusterMode) {
+        dispatch(setLeftMenuSelection('kustomize-pane'));
+      }
+    },
+    [isInClusterMode]
+  );
 
-  useHotkeys(hotkeys.OPEN_HELM_TAB.key, () => {
-    if (!isInClusterMode) {
-      dispatch(setLeftMenuSelection('helm-pane'));
-    }
-  });
+  useHotkeys(
+    hotkeys.OPEN_HELM_TAB.key,
+    () => {
+      if (!isInClusterMode) {
+        dispatch(setLeftMenuSelection('helm-pane'));
+      }
+    },
+    [isInClusterMode]
+  );
 
   useHotkeys(hotkeys.OPEN_VALIDATION_TAB.key, () => {
     dispatch(setLeftMenuSelection('validation-pane'));

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -18,6 +18,7 @@ import {
 } from '@redux/reducers/ui';
 import {
   currentConfigSelector,
+  isInClusterModeSelector,
   isInPreviewModeSelector,
   kubeConfigContextSelector,
   kubeConfigPathSelector,
@@ -42,6 +43,7 @@ const HotKeysHandler = () => {
   const dispatch = useAppDispatch();
   const mainState = useAppSelector(state => state.main);
   const uiState = useAppSelector(state => state.ui);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const isInPreviewMode = useSelector(isInPreviewModeSelector);
   const kubeConfigContext = useAppSelector(kubeConfigContextSelector);
   const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
@@ -235,11 +237,15 @@ const HotKeysHandler = () => {
   });
 
   useHotkeys(hotkeys.OPEN_KUSTOMIZATION_TAB.key, () => {
-    dispatch(setLeftMenuSelection('kustomize-pane'));
+    if (!isInClusterMode) {
+      dispatch(setLeftMenuSelection('kustomize-pane'));
+    }
   });
 
   useHotkeys(hotkeys.OPEN_HELM_TAB.key, () => {
-    dispatch(setLeftMenuSelection('helm-pane'));
+    if (!isInClusterMode) {
+      dispatch(setLeftMenuSelection('helm-pane'));
+    }
   });
 
   useHotkeys(hotkeys.OPEN_VALIDATION_TAB.key, () => {

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -15,7 +15,7 @@ import {LeftMenuSelectionType} from '@models/ui';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {setLeftMenuSelection, toggleLeftMenu} from '@redux/reducers/ui';
-import {activeProjectSelector, kustomizationsSelector} from '@redux/selectors';
+import {activeProjectSelector, isInClusterModeSelector, kustomizationsSelector} from '@redux/selectors';
 
 import WalkThrough from '@components/molecules/WalkThrough';
 
@@ -41,7 +41,9 @@ const PaneManagerLeftMenu: React.FC = () => {
   const leftMenuSelection = useAppSelector(state => state.ui.leftMenu.selection);
   const helmCharts = useAppSelector(state => Object.values(state.main.helmChartMap));
   const highlightedItems = useAppSelector(state => state.ui.highlightedItems);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const kustomizations = useAppSelector(kustomizationsSelector);
+
   const isActive = Boolean(activeProject) && leftActive;
 
   const [hasSeenKustomizations, setHasSeenKustomizations] = useState<boolean>(false);
@@ -82,6 +84,8 @@ const PaneManagerLeftMenu: React.FC = () => {
     setHasSeenHelmCharts(false);
   }, [rootFileEntry]);
 
+  console.log(isInClusterMode);
+
   return (
     <S.Container id="LeftToolbar" isLeftActive={isActive}>
       <PaneTooltip
@@ -107,7 +111,7 @@ const PaneManagerLeftMenu: React.FC = () => {
       </PaneTooltip>
 
       <PaneTooltip
-        show={!leftActive || !(leftMenuSelection === 'kustomize-pane')}
+        show={(!leftActive || !(leftMenuSelection === 'kustomize-pane')) && !isInClusterMode}
         title={<KustomizeTabTooltip />}
         placement="right"
       >
@@ -117,7 +121,7 @@ const PaneManagerLeftMenu: React.FC = () => {
           isActive={isActive}
           onClick={() => setLeftActiveMenu('kustomize-pane')}
           sectionNames={[KUSTOMIZATION_SECTION_NAME, KUSTOMIZE_PATCH_SECTION_NAME]}
-          disabled={!activeProject}
+          disabled={!activeProject || isInClusterMode}
         >
           <S.Badge
             count={!hasSeenKustomizations && kustomizations.length ? kustomizations.length : 0}
@@ -136,7 +140,7 @@ const PaneManagerLeftMenu: React.FC = () => {
 
       <WalkThrough placement="rightTop" step="kustomizeHelm" collection="novice">
         <PaneTooltip
-          show={!leftActive || !(leftMenuSelection === 'helm-pane')}
+          show={(!leftActive || !(leftMenuSelection === 'helm-pane')) && !isInClusterMode}
           title={<HelmTabTooltip />}
           placement="right"
         >
@@ -146,7 +150,7 @@ const PaneManagerLeftMenu: React.FC = () => {
             isActive={isActive}
             onClick={() => setLeftActiveMenu('helm-pane')}
             sectionNames={[HELM_CHART_SECTION_NAME]}
-            disabled={!activeProject}
+            disabled={!activeProject || isInClusterMode}
           >
             <S.Badge
               count={!hasSeenHelmCharts && helmCharts.length ? helmCharts.length : 0}

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -19,6 +19,7 @@ import {
 
 import initialState from '@redux/initialState';
 import {isKustomizationResource} from '@redux/services/kustomize';
+import {previewCluster} from '@redux/thunks/previewCluster';
 import {setRootFolder} from '@redux/thunks/setRootFolder';
 
 import {SettingsPanel} from '@organisms/SettingsManager/types';
@@ -302,6 +303,11 @@ export const uiSlice = createSlice({
       })
       .addCase(setRootFolder.rejected, state => {
         state.isFolderLoading = false;
+      })
+      .addCase(previewCluster.pending, state => {
+        if (state.leftMenu.selection === 'kustomize-pane' || state.leftMenu.selection === 'helm-pane') {
+          state.leftMenu.selection = 'file-explorer';
+        }
       });
   },
 });


### PR DESCRIPTION
## Fixes

- Disable helm/kustomize panes in cluster mode

## How to test it

- Load cluster
- Try to open helm/kustomize panes from the left menu or with hotkeys

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
