### PR TITLE
feat: show release notes only for the next big release

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -196,7 +196,12 @@ const App = () => {
   useEffect(() => {
     fetchAppVersion().then(version => {
       const lastSeenReleaseNotesVersion = electronStore.get('appConfig.lastSeenReleaseNotesVersion');
-      if (!semver.valid(lastSeenReleaseNotesVersion) || semver.lt(lastSeenReleaseNotesVersion, version)) {
+
+      // check if the current version is the next big release version for showing the modal with release notes
+      if (
+        !semver.valid(lastSeenReleaseNotesVersion) ||
+        semver.satisfies(version, `>=${semver.inc(lastSeenReleaseNotesVersion, 'minor')}`)
+      ) {
         setAppVersion(version);
         setShowReleaseNotes(true);
       }


### PR DESCRIPTION
## Changes

- Only show release notes for the next big release, do not show it for patch releases

## How to test it

- Switch version from `1.8.0` to `1.8.1`
- Switch version from `1.7.5` to `1.8.1`


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
