### PR TITLE
[JSFIX] Major version upgrade of react-redux from version 7.2.8 to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "react-hotkeys-hook": "3.4.4",
         "react-markdown": "8.0.3",
         "react-monaco-editor": "0.46.0",
-        "react-redux": "7.2.8",
+        "react-redux": "^8.0.2",
         "react-reflex": "4.0.6",
         "react-resizable": "3.0.4",
         "react-use": "17.3.2",
@@ -5297,6 +5297,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
@@ -22086,6 +22091,35 @@
         "react-dom": "16 || 17"
       }
     },
+    "node_modules/react-flow-renderer/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-flow-renderer/node_modules/react-redux": {
+      "version": "7.2.8",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-hotkeys-hook": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.4.tgz",
@@ -22167,33 +22201,47 @@
       }
     },
     "node_modules/react-redux": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18"
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
         "react-dom": {
           "optional": true
         },
         "react-native": {
           "optional": true
+        },
+        "redux": {
+          "optional": true
         }
       }
     },
     "node_modules/react-redux/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-reflex": {
       "version": "4.0.6",
@@ -26177,6 +26225,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -31520,6 +31576,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/uuid": {
       "version": "8.3.4",
@@ -43706,6 +43767,26 @@
         "react-draggable": "^4.4.4",
         "react-redux": "^7.2.6",
         "redux": "^4.1.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "react-redux": {
+          "version": "7.2.8",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
+          "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+          "requires": {
+            "@babel/runtime": "^7.15.4",
+            "@types/react-redux": "^7.1.20",
+            "hoist-non-react-statics": "^3.3.2",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.2"
+          }
+        }
       }
     },
     "react-hotkeys-hook": {
@@ -43770,22 +43851,22 @@
       }
     },
     "react-redux": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.8.tgz",
-      "integrity": "sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.2.tgz",
+      "integrity": "sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==",
       "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@types/react-redux": "^7.1.20",
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
         "hoist-non-react-statics": "^3.3.2",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2"
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
       },
       "dependencies": {
         "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },
@@ -46885,6 +46966,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "utf8-byte-length": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "react-hotkeys-hook": "3.4.4",
     "react-markdown": "8.0.3",
     "react-monaco-editor": "0.46.0",
-    "react-redux": "7.2.8",
+    "react-redux": "^8.0.2",
     "react-reflex": "4.0.6",
     "react-resizable": "3.0.4",
     "react-use": "17.3.2",


### PR DESCRIPTION
This pull request was created by [mtorp](https://github.com/mtorp) using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It upgrades react-redux to version 8.0.2.

The JSFIX tool used advanced program analysis to determine how react-redux is used by monokle and how it is affected by breaking changes in react-redux version 8.0.2 (see details below). JSFIX checked for the 3 breaking changes affecting react-redux version 8.0.2 and found 1 occurrences in monokle. 1 of the occurrences must be manually audited. 

<strong>Install the [JSFIX GitHub app](https://github.com/apps/jsfix-updater) to receive other package updates from JSFIX.</strong>

***

<h3>Breaking change details</h3>

<details open><summary><strong> 🚧 - Not automatically fixed breaking changes (please check before merging)</strong></summary><blockquote class="pr-blockquote"><details open>
<summary>Affects all applications (not related to specific API usages in your code).</summary>

* If you are using Typescript, React-Redux is now written in TS and includes its own types. You should remove any dependencies on @types/react-redux.
</details>

</blockquote></details><details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* The connectAdvanced API is now deprecated 
* The pure option for connect has been removed.
</details>



***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.