### PR TITLE
fix: restore the previous selection history when preview fails

### DIFF
--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -125,6 +125,8 @@ interface AppState {
   currentSelectionHistoryIndex?: number;
   /** a list of previously selected resources of paths */
   selectionHistory: SelectionHistoryEntry[];
+  /** the previous list of previously selected resources of paths */
+  previousSelectionHistory: SelectionHistoryEntry[];
   /** the id of the currently selected resource */
   selectedResourceId?: string;
   /** a list of checked resources for multi-resource actions */

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -17,6 +17,7 @@ const initialAppState: AppState = {
   isRehydrating: false,
   wasRehydrated: false,
   selectionHistory: [],
+  previousSelectionHistory: [],
   resourceMap: {},
   resourceFilter: {
     labels: {},

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -460,6 +460,7 @@ export const mainSlice = createSlice({
       state.checkedResourceIds = [];
     },
     clearPreviewAndSelectionHistory: (state: Draft<AppState>) => {
+      state.previousSelectionHistory = state.selectionHistory;
       clearSelectedResourceOnPreviewExit(state);
       setPreviewData({}, state);
       state.previewType = undefined;
@@ -753,11 +754,14 @@ export const mainSlice = createSlice({
         state.selectedPreviewConfigurationId = undefined;
         state.clusterDiff.shouldReload = true;
         state.checkedResourceIds = [];
+        state.previousSelectionHistory = [];
       })
       .addCase(previewKustomization.rejected, state => {
         state.previewLoader.isLoading = false;
         state.previewLoader.targetId = undefined;
         state.previewType = undefined;
+        state.selectionHistory = state.previousSelectionHistory;
+        state.previousSelectionHistory = [];
       });
 
     builder
@@ -774,11 +778,14 @@ export const mainSlice = createSlice({
           selectFilePath(state.helmValuesMap[action.payload.previewResourceId].filePath, state);
         }
         state.selectedValuesFileId = action.payload.previewResourceId;
+        state.previousSelectionHistory = [];
       })
       .addCase(previewHelmValuesFile.rejected, state => {
         state.previewLoader.isLoading = false;
         state.previewLoader.targetId = undefined;
         state.previewType = undefined;
+        state.selectionHistory = state.previousSelectionHistory;
+        state.previousSelectionHistory = [];
       });
 
     builder
@@ -792,11 +799,14 @@ export const mainSlice = createSlice({
         state.selectedImage = undefined;
         state.selectedPath = undefined;
         state.checkedResourceIds = [];
+        state.previousSelectionHistory = [];
       })
       .addCase(runPreviewConfiguration.rejected, state => {
         state.previewLoader.isLoading = false;
         state.previewLoader.targetId = undefined;
         state.previewType = undefined;
+        state.selectionHistory = state.previousSelectionHistory;
+        state.previousSelectionHistory = [];
       });
 
     builder
@@ -815,11 +825,14 @@ export const mainSlice = createSlice({
           resource.isSelected = false;
           resource.isHighlighted = false;
         });
+        state.previousSelectionHistory = [];
       })
       .addCase(previewCluster.rejected, state => {
         state.previewLoader.isLoading = false;
         state.previewLoader.targetId = undefined;
         state.previewType = undefined;
+        state.selectionHistory = state.previousSelectionHistory;
+        state.previousSelectionHistory = [];
       });
 
     builder


### PR DESCRIPTION
This PR...

## Fixes

- Restores the previous selection history when previewing a helm chart or kustomize fails.

## How to test it

- Build up a selection history by moving between files or resources, make a change that will lead to a failure when launching a preview, then click preview. After the preview fails check that the selection history has been restored to its previous state.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
