### PR TITLE
feat: sort compare resources sections

### DIFF
--- a/src/components/organisms/CompareModal/ResourceList.styled.tsx
+++ b/src/components/organisms/CompareModal/ResourceList.styled.tsx
@@ -11,10 +11,11 @@ export const ResourceListDiv = styled.div`
   overflow: auto;
 `;
 
-export const HeaderDiv = styled.div<{$showCheckbox: boolean}>`
+export const HeaderDiv = styled.div<{$index: number; $showCheckbox: boolean}>`
   height: 28px;
   margin-left: ${props => (props.$showCheckbox ? '32px' : 0)};
   font-size: 16px;
+  margin-top: ${props => (props.$index ? '20px' : 0)};
 `;
 
 export const Header = styled.h1`


### PR DESCRIPTION
## Changes

- Order compare modal sections the same as in resource navigator

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/175915507-8e2aab69-369a-4c76-a13e-9c563493c4db.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
