### PR TITLE
fix: Error handling for renaming file to same name

### DIFF
--- a/src/components/organisms/RenameEntityModal/RenameEntityModal.tsx
+++ b/src/components/organisms/RenameEntityModal/RenameEntityModal.tsx
@@ -107,14 +107,19 @@ const RenameEntityModal: React.FC = () => {
             ({getFieldValue}) => ({
               validator: () => {
                 return new Promise((resolve: (value?: any) => void, reject) => {
-                  const newEntityNameValue: string = getFieldValue('newEntityName').toLowerCase();
+                  const newEntityNameValue: string = getFieldValue('newEntityName');
 
                   // If the input is empty - it is not valid
                   if (!newEntityNameValue) {
                     reject(new Error("This field can't be empty"));
                   }
 
-                  // If the old name and the new name are equal - it is valid
+                  // If the old name and the new name are equal - it is not valid
+                  if (newEntityNameValue === uiState.entityName) {
+                    reject(new Error("Name can't be the same as the current one"));
+                  }
+
+                  // If the old name and the new name are differ by case - it is valid
                   if (newEntityNameValue.toLowerCase() === uiState.entityName.toLowerCase()) {
                     resolve();
                   }


### PR DESCRIPTION
This PR...

## Fixes

- #1970

## Screenshots

- When rename entity is empty
 ![image](https://user-images.githubusercontent.com/35147480/175947066-b1e97431-70f9-42ee-b85f-f0694636d2c4.png)


- When renaming a file or folder is same as current one
![image](https://user-images.githubusercontent.com/35147480/175947172-53a414af-1d9c-47cd-a7d7-da2b058e8faf.png)


- When renaming a file or folder has prohibited symbol
![image](https://user-images.githubusercontent.com/35147480/175947281-46de5258-3583-4d23-8d0a-122bdcfe1501.png)


- When rename has file or folder with this name already exists in this location
![image](https://user-images.githubusercontent.com/35147480/175947357-4719a6b6-53a6-48d8-8338-93b36fe9eaaa.png)


- When renaming a file or folder resolves
![image](https://user-images.githubusercontent.com/35147480/175947409-4be66a3e-493e-4c36-8466-7f43d611924f.png)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
