### PR TITLE
feat: disable replace in preview mode

### DIFF
--- a/src/navsections/ImagesSectionBlueprint/ImagesQuickAction.styled.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesQuickAction.styled.tsx
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 
 import Colors from '@styles/Colors';
 
-export const ReplaceSpan = styled.span<{$isSelected: boolean}>`
+export const ReplaceSpan = styled.span<{$isDisabled: boolean; $isSelected: boolean}>`
   font-weight: 500;
   font-size: 12px;
   margin: 0 15px 0 5px;
-  cursor: pointer;
-  color: ${({$isSelected}) => ($isSelected ? Colors.blackPure : Colors.blue6)};
+  color: ${({$isDisabled, $isSelected}) =>
+    $isSelected ? Colors.blackPure : $isDisabled ? Colors.grey5 : Colors.blue6};
+  cursor: ${({$isDisabled}) => ($isDisabled ? 'not-allowed' : 'pointer')};
 `;

--- a/src/navsections/ImagesSectionBlueprint/ImagesQuickAction.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesQuickAction.tsx
@@ -1,7 +1,8 @@
 import {ItemCustomComponentProps} from '@models/navigator';
 
-import {useAppDispatch} from '@redux/hooks';
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {openReplaceImageModal} from '@redux/reducers/ui';
+import {isInPreviewModeSelector} from '@redux/selectors';
 
 import * as S from './ImagesQuickAction.styled';
 
@@ -9,13 +10,18 @@ const ImagesQuickAction: React.FC<ItemCustomComponentProps> = props => {
   const {itemInstance} = props;
 
   const dispatch = useAppDispatch();
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
 
   const onReplaceHandler = () => {
+    if (isInPreviewMode) {
+      return;
+    }
+
     dispatch(openReplaceImageModal(itemInstance.id));
   };
 
   return (
-    <S.ReplaceSpan $isSelected={itemInstance.isSelected} onClick={onReplaceHandler}>
+    <S.ReplaceSpan $isDisabled={isInPreviewMode} $isSelected={itemInstance.isSelected} onClick={onReplaceHandler}>
       Replace
     </S.ReplaceSpan>
   );


### PR DESCRIPTION
## Fixes

- Disabled image `Replace` action when in preview mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/176447072-25406ab6-a8a1-4999-b501-68797b315af2.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
