### PR TITLE
feat: resources popover for images

### DIFF
--- a/src/components/molecules/ResourceRefsIconPopover/RefsPopoverContent.tsx
+++ b/src/components/molecules/ResourceRefsIconPopover/RefsPopoverContent.tsx
@@ -10,6 +10,7 @@ import {setMonacoEditor} from '@redux/reducers/ui';
 import {isKustomizationResource} from '@redux/services/kustomize';
 import {areRefPosEqual} from '@redux/services/resource';
 
+import {getRefRange} from '@utils/refs';
 import {FOLLOW_LINK, trackEvent} from '@utils/telemetry';
 
 import RefLink from './RefLink';
@@ -28,18 +29,6 @@ const getRefKind = (ref: ResourceRef, resourceMap: ResourceMapType) => {
       return resourceMap[ref.target.resourceId]?.kind;
     }
   }
-};
-
-const getRefRange = (ref: ResourceRef) => {
-  if (!ref.position) {
-    return undefined;
-  }
-  return {
-    startLineNumber: ref.position.line,
-    endLineNumber: ref.position.line,
-    startColumn: ref.position.column,
-    endColumn: ref.position.column + ref.position.length,
-  };
 };
 
 const RefsPopoverContent = (props: {children: React.ReactNode; resource: K8sResource; resourceRefs: ResourceRef[]}) => {

--- a/src/components/molecules/ValidationErrorsPopover/ErrorsPopoverContent.tsx
+++ b/src/components/molecules/ValidationErrorsPopover/ErrorsPopoverContent.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import {useMemo} from 'react';
 
 import {Divider, Typography} from 'antd';
 

--- a/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.styled.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.styled.tsx
@@ -1,0 +1,49 @@
+import {Divider as RawDivider, Typography} from 'antd';
+
+import styled from 'styled-components';
+
+import Colors, {FontColors} from '@styles/Colors';
+
+export const Container = styled.div`
+  margin: 0;
+  padding: 0 8px;
+  max-height: 350px;
+  overflow-y: auto;
+`;
+
+export const Divider = styled(RawDivider)`
+  margin: 5px 0;
+`;
+
+export const PopoverTitle = styled(Typography.Text)`
+  font-weight: 500;
+`;
+
+export const PositionText = styled.span`
+  margin-left: 5px;
+  color: ${FontColors.grey};
+`;
+
+export const RefContainer = styled.div`
+  display: block;
+  margin: 5px 0;
+`;
+
+export const RefLinkContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const ResourceKindLabel = styled.span`
+  margin-left: 8px;
+  font-style: italic;
+  color: ${Colors.grey7};
+`;
+
+export const ResourceNameLabel = styled.span`
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.tsx
@@ -20,7 +20,7 @@ const ImageOutgoingResourcesPopover: React.FC<IProps> = ({resourcesIds}) => {
   const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
 
   const refs = useMemo(() => {
-    return resourcesIds.reduce((currentRefs, id) => {
+    return resourcesIds.reduce((currentRefs: {[key: string]: ResourceRef[]}, id) => {
       const resource = resourceMap[id];
       const resourceRefs = resource.refs;
 
@@ -35,7 +35,7 @@ const ImageOutgoingResourcesPopover: React.FC<IProps> = ({resourcesIds}) => {
       }
 
       return currentRefs;
-    }, {} as {[key: string]: ResourceRef[]});
+    }, {});
   }, [resourceMap, resourcesIds]);
 
   const handleOnResourceClick = (resource: K8sResource, ref: ResourceRef) => {

--- a/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImageOutgoingResourcesPopover.tsx
@@ -1,0 +1,78 @@
+import {useMemo} from 'react';
+
+import {K8sResource, ResourceRef} from '@models/k8sresource';
+
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {selectK8sResource} from '@redux/reducers/main';
+import {setMonacoEditor} from '@redux/reducers/ui';
+
+import {getRefRange} from '@utils/refs';
+
+import * as S from './ImageOutgoingResourcesPopover.styled';
+
+interface IProps {
+  resourcesIds: string[];
+}
+
+const ImageOutgoingResourcesPopover: React.FC<IProps> = ({resourcesIds}) => {
+  const dispatch = useAppDispatch();
+  const resourceMap = useAppSelector(state => state.main.resourceMap);
+  const selectedResourceId = useAppSelector(state => state.main.selectedResourceId);
+
+  const refs = useMemo(() => {
+    return resourcesIds.reduce((currentRefs, id) => {
+      const resource = resourceMap[id];
+      const resourceRefs = resource.refs;
+
+      if (!resourceRefs) {
+        return currentRefs;
+      }
+
+      const imageRefs = resourceRefs.filter(ref => ref.type === 'outgoing' && ref.target?.type === 'image');
+
+      if (imageRefs.length) {
+        currentRefs[id] = imageRefs;
+      }
+
+      return currentRefs;
+    }, {} as {[key: string]: ResourceRef[]});
+  }, [resourceMap, resourcesIds]);
+
+  const handleOnResourceClick = (resource: K8sResource, ref: ResourceRef) => {
+    if (selectedResourceId !== resource.id) {
+      dispatch(selectK8sResource({resourceId: resource.id}));
+    }
+
+    const refRange = getRefRange(ref);
+
+    if (refRange) {
+      setImmediate(() => {
+        dispatch(setMonacoEditor({selection: {type: 'resource', resourceId: resource.id, range: refRange}}));
+      });
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.PopoverTitle>Resources Links</S.PopoverTitle>
+      <S.Divider />
+      {Object.entries(refs).map(([resourceId, resourceRefs]) => {
+        const resource = resourceMap[resourceId];
+        return resourceRefs.map(ref => (
+          <S.RefContainer key={`${resourceId}-${ref.name}-${ref.position?.line}-${ref.position?.column}`}>
+            <S.RefLinkContainer>
+              <S.ResourceNameLabel onClick={() => handleOnResourceClick(resource, ref)}>
+                {resource.name}
+              </S.ResourceNameLabel>
+
+              <S.ResourceKindLabel>{resource.kind}</S.ResourceKindLabel>
+              {ref.position && <S.PositionText>Ln {ref.position.line}</S.PositionText>}
+            </S.RefLinkContainer>
+          </S.RefContainer>
+        ));
+      })}
+    </S.Container>
+  );
+};
+
+export default ImageOutgoingResourcesPopover;

--- a/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.styled.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.styled.tsx
@@ -2,6 +2,12 @@ import styled from 'styled-components';
 
 import Colors, {FontColors} from '@styles/Colors';
 
+export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
 export const Counter = styled.span<{$selected: boolean}>`
   ${({$selected}) => `
     color: ${$selected ? Colors.blackPure : FontColors.grey};

--- a/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.tsx
+++ b/src/navsections/ImagesSectionBlueprint/ImagesSectionNameSuffix.tsx
@@ -1,5 +1,10 @@
+import {Popover} from 'antd';
+
 import {ItemInstance} from '@models/navigator';
 
+import {Icon} from '@atoms';
+
+import ImageOutgoingResourcesPopover from './ImageOutgoingResourcesPopover';
 import * as S from './ImagesSectionNameSuffix.styled';
 
 interface IProps {
@@ -14,7 +19,19 @@ const ImagesSectionNameSuffix: React.FC<IProps> = props => {
     },
   } = props;
 
-  return <S.Counter $selected={isSelected}>{resourcesIds.length}</S.Counter>;
+  return (
+    <S.Container>
+      <S.Counter $selected={isSelected}>{resourcesIds.length}</S.Counter>
+
+      <Popover
+        mouseEnterDelay={0.5}
+        content={<ImageOutgoingResourcesPopover resourcesIds={resourcesIds} />}
+        placement="rightTop"
+      >
+        <Icon name="outgoingRefs" />
+      </Popover>
+    </S.Container>
+  );
 };
 
 export default ImagesSectionNameSuffix;

--- a/src/utils/refs.ts
+++ b/src/utils/refs.ts
@@ -1,0 +1,13 @@
+import {ResourceRef} from '@models/k8sresource';
+
+export const getRefRange = (ref: ResourceRef) => {
+  if (!ref.position) {
+    return undefined;
+  }
+  return {
+    startLineNumber: ref.position.line,
+    endLineNumber: ref.position.line,
+    startColumn: ref.position.column,
+    endColumn: ref.position.column + ref.position.length,
+  };
+};


### PR DESCRIPTION
## Changes

- Add popover with corresponding resources links for each image

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/176460761-687a94fd-1c16-49e1-ab2f-1ff532eeb505.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
