### PR TITLE
fix: Namespace help link goes to wrong kubernetes docs page

### DIFF
--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -39,7 +39,7 @@ export function openUniqueObjectNameTopic() {
 }
 
 export function openNamespaceTopic() {
-  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/');
+  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces');
 }
 
 export function openExternalResourceKindDocumentation(resourceKindDocLink?: string) {

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -39,7 +39,7 @@ export function openUniqueObjectNameTopic() {
 }
 
 export function openNamespaceTopic() {
-  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names');
+  shell.openExternal('https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/');
 }
 
 export function openExternalResourceKindDocumentation(resourceKindDocLink?: string) {


### PR DESCRIPTION
This PR...

## Fixes

- #2027

## How to test it

1. Create a project using template
2. Click on "Create a resource" in navigator
3. In Namespace click "read more" you can see "read more" by hovering on help symbol
4. Link direct to [Namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 
## Screenshots
![image](https://user-images.githubusercontent.com/35147480/176605929-47ea362f-3313-4bbe-bc99-f70ef7dc44d4.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
