### PR TITLE
feat: added EndpointSlice handler

### DIFF
--- a/src/kindhandlers/EndpointSlice.handler.ts
+++ b/src/kindhandlers/EndpointSlice.handler.ts
@@ -1,0 +1,67 @@
+import * as k8s from '@kubernetes/client-node';
+
+import navSectionNames from '@constants/navSectionNames';
+
+import {K8sResource} from '@models/k8sresource';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+import {
+  implicitNamespaceMatcher,
+  optionalExplicitNamespaceMatcher,
+  targetKindMatcher,
+} from '@src/kindhandlers/common/customMatchers';
+
+const EndpointSliceHandler: ResourceKindHandler = {
+  kind: 'EndpointSlice',
+  apiVersionMatcher: '**',
+  isNamespaced: true,
+  navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.NETWORK, 'EndpointSlice'],
+  clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.discovery.v1',
+  isCustom: false,
+  getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
+    const discoveryV1Api = kubeconfig.makeApiClient(k8s.DiscoveryV1Api);
+    return discoveryV1Api.readNamespacedEndpointSlice(resource.name, resource.namespace || 'default', 'true');
+  },
+  async listResourcesInCluster(kubeconfig: k8s.KubeConfig, {namespace}) {
+    const discoveryV1Api = kubeconfig.makeApiClient(k8s.DiscoveryV1Api);
+    const response = namespace
+      ? await discoveryV1Api.listNamespacedEndpointSlice(namespace)
+      : await discoveryV1Api.listEndpointSliceForAllNamespaces();
+    return response.body.items;
+  },
+  async deleteResourceInCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource) {
+    const discoveryV1Api = kubeconfig.makeApiClient(k8s.DiscoveryV1Api);
+    await discoveryV1Api.deleteNamespacedEndpointSlice(resource.name, resource.namespace || 'default');
+  },
+  outgoingRefMappers: [
+    {
+      source: {
+        pathParts: ['metadata', 'labels', 'kubernetes.io/service-name'],
+        siblingMatchers: {
+          namespace: implicitNamespaceMatcher,
+        },
+      },
+      target: {
+        kind: 'Service',
+      },
+      type: 'name',
+    },
+    {
+      source: {
+        pathParts: ['targetRef', 'name'],
+        siblingMatchers: {
+          namespace: optionalExplicitNamespaceMatcher,
+          kind: targetKindMatcher,
+        },
+      },
+      target: {
+        kind: '$.*',
+      },
+      type: 'name',
+    },
+  ],
+  helpLink: 'https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#endpointslice-v1-discovery-k8s-io',
+};
+
+export default EndpointSliceHandler;

--- a/src/kindhandlers/Endpoints.handler.ts
+++ b/src/kindhandlers/Endpoints.handler.ts
@@ -5,6 +5,8 @@ import navSectionNames from '@constants/navSectionNames';
 import {K8sResource} from '@models/k8sresource';
 import {ResourceKindHandler} from '@models/resourcekindhandler';
 
+import {optionalExplicitNamespaceMatcher, targetKindMatcher} from '@src/kindhandlers/common/customMatchers';
+
 const EndpointsHandler: ResourceKindHandler = {
   kind: 'Endpoints',
   apiVersionMatcher: '**',
@@ -35,6 +37,19 @@ const EndpointsHandler: ResourceKindHandler = {
       },
       target: {
         kind: 'Service',
+      },
+      type: 'name',
+    },
+    {
+      source: {
+        pathParts: ['targetRef', 'name'],
+        siblingMatchers: {
+          namespace: optionalExplicitNamespaceMatcher,
+          kind: targetKindMatcher,
+        },
+      },
+      target: {
+        kind: '$.*',
       },
       type: 'name',
     },

--- a/src/kindhandlers/index.ts
+++ b/src/kindhandlers/index.ts
@@ -13,6 +13,7 @@ import {refMapperMatchesKind} from '@redux/services/resourceRefs';
 
 import {parseAllYamlDocuments} from '@utils/yaml';
 
+import EndpointSliceHandler from '@src/kindhandlers/EndpointSlice.handler';
 import VolumeAttachmentHandler from '@src/kindhandlers/VolumeAttachment.handler';
 import {extractKindHandler} from '@src/kindhandlers/common/customObjectKindHandler';
 
@@ -54,6 +55,7 @@ export const ResourceKindHandlers: ResourceKindHandler[] = [
   DaemonSetHandler,
   DeploymentHandler,
   EndpointsHandler,
+  EndpointSliceHandler,
   IngressHandler,
   JobHandler,
   NetworkPolicyHandler,


### PR DESCRIPTION
This PR adds support for EndpointSlice resources - see #2034 

Includes RefMappers for target objects and associated services

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/1917063/176856997-cd1b6396-5057-4af2-b987-d02f6ea02907.png">


## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
