### PR TITLE
feat: added more native resource kinds to navigator

### DIFF
--- a/src/kindhandlers/HorizontalPodAutoscaler.handler.ts
+++ b/src/kindhandlers/HorizontalPodAutoscaler.handler.ts
@@ -1,0 +1,38 @@
+import * as k8s from '@kubernetes/client-node';
+
+import navSectionNames from '@constants/navSectionNames';
+
+import {K8sResource} from '@models/k8sresource';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+const HorizontalPodAutoscalerHandler: ResourceKindHandler = {
+  kind: 'HorizontalPodAutoscaler',
+  apiVersionMatcher: '**',
+  isNamespaced: true,
+  navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.CONFIGURATION, 'HPAs'],
+  clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.autoscaling.v1',
+  isCustom: false,
+  getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
+    const autoscalingV1Api = kubeconfig.makeApiClient(k8s.AutoscalingV1Api);
+    return autoscalingV1Api.readNamespacedHorizontalPodAutoscaler(
+      resource.name,
+      resource.namespace || 'default',
+      'true'
+    );
+  },
+  async listResourcesInCluster(kubeconfig: k8s.KubeConfig, {namespace}) {
+    const autoscalingV1Api = kubeconfig.makeApiClient(k8s.AutoscalingV1Api);
+    const response = namespace
+      ? await autoscalingV1Api.listNamespacedHorizontalPodAutoscaler(namespace)
+      : await autoscalingV1Api.listHorizontalPodAutoscalerForAllNamespaces();
+    return response.body.items;
+  },
+  async deleteResourceInCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource) {
+    const autoscalingV1Api = kubeconfig.makeApiClient(k8s.AutoscalingV1Api);
+    await autoscalingV1Api.deleteNamespacedHorizontalPodAutoscaler(resource.name, resource.namespace || 'default');
+  },
+  helpLink: 'https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/',
+};
+
+export default HorizontalPodAutoscalerHandler;

--- a/src/kindhandlers/LimitRange.handler.ts
+++ b/src/kindhandlers/LimitRange.handler.ts
@@ -1,0 +1,34 @@
+import * as k8s from '@kubernetes/client-node';
+
+import navSectionNames from '@constants/navSectionNames';
+
+import {K8sResource} from '@models/k8sresource';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+const LimitRangeHandler: ResourceKindHandler = {
+  kind: 'LimitRange',
+  apiVersionMatcher: '**',
+  isNamespaced: true,
+  navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.CONFIGURATION, 'Limit Ranges'],
+  clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
+  isCustom: false,
+  getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    return k8sCoreV1Api.readNamespacedLimitRange(resource.name, resource.namespace || 'default', 'true');
+  },
+  async listResourcesInCluster(kubeconfig: k8s.KubeConfig, {namespace}) {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    const response = namespace
+      ? await k8sCoreV1Api.listNamespacedLimitRange(namespace)
+      : await k8sCoreV1Api.listLimitRangeForAllNamespaces();
+    return response.body.items;
+  },
+  async deleteResourceInCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource) {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    await k8sCoreV1Api.deleteNamespacedLimitRange(resource.name, resource.namespace || 'default');
+  },
+  helpLink: 'https://kubernetes.io/docs/concepts/policy/limit-range/',
+};
+
+export default LimitRangeHandler;

--- a/src/kindhandlers/ResourceQuota.handler.ts
+++ b/src/kindhandlers/ResourceQuota.handler.ts
@@ -1,0 +1,34 @@
+import * as k8s from '@kubernetes/client-node';
+
+import navSectionNames from '@constants/navSectionNames';
+
+import {K8sResource} from '@models/k8sresource';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+const ResourceQuotaHandler: ResourceKindHandler = {
+  kind: 'ResourceQuota',
+  apiVersionMatcher: '**',
+  isNamespaced: true,
+  navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.CONFIGURATION, 'Resource Quotas'],
+  clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.core.v1',
+  isCustom: false,
+  getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    return k8sCoreV1Api.readNamespacedResourceQuota(resource.name, resource.namespace || 'default', 'true');
+  },
+  async listResourcesInCluster(kubeconfig: k8s.KubeConfig, {namespace}) {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    const response = namespace
+      ? await k8sCoreV1Api.listNamespacedResourceQuota(namespace)
+      : await k8sCoreV1Api.listResourceQuotaForAllNamespaces();
+    return response.body.items;
+  },
+  async deleteResourceInCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource) {
+    const k8sCoreV1Api = kubeconfig.makeApiClient(k8s.CoreV1Api);
+    await k8sCoreV1Api.deleteNamespacedResourceQuota(resource.name, resource.namespace || 'default');
+  },
+  helpLink: 'https://kubernetes.io/docs/concepts/policy/resource-quotas/',
+};
+
+export default ResourceQuotaHandler;

--- a/src/kindhandlers/StorageClass.handler.ts
+++ b/src/kindhandlers/StorageClass.handler.ts
@@ -1,0 +1,32 @@
+import * as k8s from '@kubernetes/client-node';
+
+import navSectionNames from '@constants/navSectionNames';
+
+import {K8sResource} from '@models/k8sresource';
+import {ResourceKindHandler} from '@models/resourcekindhandler';
+
+const StorageClassHandler: ResourceKindHandler = {
+  kind: 'StorageClass',
+  apiVersionMatcher: '**',
+  isNamespaced: false,
+  navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.STORAGE, 'StorageClasses'],
+  clusterApiVersion: 'v1',
+  validationSchemaPrefix: 'io.k8s.api.storage.v1',
+  isCustom: false,
+  getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
+    const storageV1Api = kubeconfig.makeApiClient(k8s.StorageV1Api);
+    return storageV1Api.readStorageClass(resource.name, 'true');
+  },
+  async listResourcesInCluster(kubeconfig: k8s.KubeConfig, {namespace}) {
+    const storageV1Api = kubeconfig.makeApiClient(k8s.StorageV1Api);
+    const response = await storageV1Api.listStorageClass();
+    return response.body.items;
+  },
+  async deleteResourceInCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource) {
+    const storageV1Api = kubeconfig.makeApiClient(k8s.StorageV1Api);
+    await storageV1Api.deleteStorageClass(resource.name);
+  },
+  helpLink: 'https://kubernetes.io/docs/concepts/storage/storage-classes/',
+};
+
+export default StorageClassHandler;

--- a/src/kindhandlers/VolumeAttachment.handler.ts
+++ b/src/kindhandlers/VolumeAttachment.handler.ts
@@ -14,7 +14,7 @@ const VolumeAttachmentHandler: ResourceKindHandler = {
   isNamespaced: false,
   navigatorPath: [navSectionNames.K8S_RESOURCES, navSectionNames.STORAGE, 'VolumeAttachments'],
   clusterApiVersion: 'v1',
-  validationSchemaPrefix: 'storage.k8s.io.v1',
+  validationSchemaPrefix: 'io.k8s.api.storage.v1',
   isCustom: false,
   getResourceFromCluster(kubeconfig: k8s.KubeConfig, resource: K8sResource): Promise<any> {
     const k8sStorageApi = kubeconfig.makeApiClient(k8s.StorageV1Api);

--- a/src/kindhandlers/index.ts
+++ b/src/kindhandlers/index.ts
@@ -14,6 +14,10 @@ import {refMapperMatchesKind} from '@redux/services/resourceRefs';
 import {parseAllYamlDocuments} from '@utils/yaml';
 
 import EndpointSliceHandler from '@src/kindhandlers/EndpointSlice.handler';
+import HorizontalPodAutoscalerHandler from '@src/kindhandlers/HorizontalPodAutoscaler.handler';
+import LimitRangeHandler from '@src/kindhandlers/LimitRange.handler';
+import ResourceQuotaHandler from '@src/kindhandlers/ResourceQuota.handler';
+import StorageClassHandler from '@src/kindhandlers/StorageClass.handler';
 import VolumeAttachmentHandler from '@src/kindhandlers/VolumeAttachment.handler';
 import {extractKindHandler} from '@src/kindhandlers/common/customObjectKindHandler';
 
@@ -72,6 +76,10 @@ export const ResourceKindHandlers: ResourceKindHandler[] = [
   ServiceAccountHandler,
   StatefulSetHandler,
   VolumeAttachmentHandler,
+  StorageClassHandler,
+  ResourceQuotaHandler,
+  LimitRangeHandler,
+  HorizontalPodAutoscalerHandler,
 ];
 
 const HandlerByResourceKind = Object.fromEntries(


### PR DESCRIPTION
This PR adds support for the following k8s objects
- HorizontalPodAutoscaler (#1588)
- LimitRange
- ResourceQuota
- StorageClass


## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
