### PR TITLE
style: added margin to telemetry buttons content in notification box

### DIFF
--- a/src/components/molecules/NotificationMarkdown/TelemetryButtons.tsx
+++ b/src/components/molecules/NotificationMarkdown/TelemetryButtons.tsx
@@ -48,13 +48,13 @@ export const TelemetryButtons = ({notificationId}: {notificationId?: string}) =>
   }
 
   return (
-    <div>
+    <S.Content>
       <S.Button type="default" onClick={handleOk} id="accept-telemetry">
         I&apos;m fine with it
       </S.Button>
       <S.Button type="text" onClick={handleNotOk}>
         I&apos;m not
       </S.Button>
-    </div>
+    </S.Content>
   );
 };

--- a/src/components/molecules/NotificationMarkdown/styled.tsx
+++ b/src/components/molecules/NotificationMarkdown/styled.tsx
@@ -6,6 +6,10 @@ export const Button = styled(RawButton)`
   padding: 0 20px;
 `;
 
+export const Content = styled.div`
+  margin-top: 10px;
+`;
+
 export const NotificationMarkdownContainer = styled.div`
   & p {
     display: inline;


### PR DESCRIPTION
This PR...

Added Margin to telemetry buttons as requested in #2055 

## Changes

-

## Fixes

-

## How to test it

Run application after removing config.json in Monokle application data folder.

## Screenshots

<img width="1203" alt="Zrzut ekranu 2022-07-6 o 15 17 40" src="https://user-images.githubusercontent.com/12625880/177559453-6cb400df-0f99-4847-a8d7-a40567571e40.png">

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
