### PR TITLE
fix: fixed displaying list of FilePatternListItem in cluster when editing context

### DIFF
--- a/src/components/molecules/FilePatternList/FilePatternList.tsx
+++ b/src/components/molecules/FilePatternList/FilePatternList.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import {Button, Input, InputRef, Tooltip} from 'antd';
 
@@ -38,7 +38,7 @@ const FilePatternList = (props: FilePatternListProps) => {
   const [patternInput, setPatternInput] = useState<string>('');
   const [inputRef, focusInput] = useFocus<InputRef>();
   const filePatternInputRef = useRef<any>();
-  const isValueNotEmpty = value.length > 0;
+  const isValueNotEmpty = useMemo(() => value.length > 0, [value]);
 
   useOnClickOutside(filePatternInputRef, () => {
     setIsAddingPattern(false);

--- a/src/components/molecules/FilePatternList/FilePatternList.tsx
+++ b/src/components/molecules/FilePatternList/FilePatternList.tsx
@@ -34,11 +34,11 @@ const StyledButton = styled(Button)`
 
 const FilePatternList = (props: FilePatternListProps) => {
   const {value, onChange, tooltip, isSettingsOpened, showButtonLabel, showApplyButton, onApplyClick} = props;
-
   const [isAddingPattern, setIsAddingPattern] = useState<Boolean>(false);
   const [patternInput, setPatternInput] = useState<string>('');
   const [inputRef, focusInput] = useFocus<InputRef>();
   const filePatternInputRef = useRef<any>();
+  const isValueNotEmpty = value.length > 0;
 
   useOnClickOutside(filePatternInputRef, () => {
     setIsAddingPattern(false);
@@ -89,17 +89,19 @@ const FilePatternList = (props: FilePatternListProps) => {
 
   return (
     <div>
-      <StyledUl>
-        {value.map(pattern => (
-          <FilePatternListItem
-            key={pattern}
-            pattern={pattern}
-            validateInput={isPatternUnique}
-            onChange={(oldPattern, newPattern) => updatePattern(oldPattern, newPattern)}
-            onRemove={() => removePattern(pattern)}
-          />
-        ))}
-      </StyledUl>
+      {isValueNotEmpty && (
+        <StyledUl>
+          {value.map(pattern => (
+            <FilePatternListItem
+              key={pattern}
+              pattern={pattern}
+              validateInput={isPatternUnique}
+              onChange={(oldPattern, newPattern) => updatePattern(oldPattern, newPattern)}
+              onRemove={() => removePattern(pattern)}
+            />
+          ))}
+        </StyledUl>
+      )}
       {isAddingPattern ? (
         <div ref={filePatternInputRef}>
           <Input


### PR DESCRIPTION
This PR... related to #2053

## Changes

- fixed styling when editing cluster selection namespace

## Fixes

-

## How to test it

-

## Screenshots
Was:
![image](https://user-images.githubusercontent.com/12625880/177763067-4061d0eb-3184-4db1-afcf-f6a180bd13e9.png)

Fixed:
<img width="841" alt="image" src="https://user-images.githubusercontent.com/12625880/177763191-f3bd2002-e3c9-4522-a885-2f40f3f1a809.png">


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
