### PR TITLE
fix: removed media query and displaying title always in two lines after investigation with @julio

### DIFF
--- a/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.styled.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import {AnimationDurations} from '@styles/Animations';
 import Colors from '@styles/Colors';
-import {Device} from '@styles/Device';
 
 export const Container = styled.div`
   display: flex;
@@ -61,10 +60,6 @@ export const StartProjectItemTitle = styled.div`
   text-align: center;
   display: flex;
   flex-direction: column;
-
-  @media ${Device.laptopM} {
-    flex-direction: row;
-  }
 `;
 
 export const StartProjectItemSemiTitle = styled.span`

--- a/src/components/organisms/StartProjectPane/StartProjectPage.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.tsx
@@ -61,7 +61,7 @@ const StartProjectPage = () => {
               <S.StartProjectItemLogo src={itemLogo} />
               <S.StartProjectItemTitle>
                 {itemTitle}
-                <S.StartProjectItemSemiTitle>{`\b ${itemSemiTitle}`}</S.StartProjectItemSemiTitle>
+                <S.StartProjectItemSemiTitle>{itemSemiTitle}</S.StartProjectItemSemiTitle>
               </S.StartProjectItemTitle>
               <S.StartProjectItemDescription>{itemDescription}</S.StartProjectItemDescription>
             </S.StartProjectItem>


### PR DESCRIPTION
This PR...

## Changes

-

## Fixes

- removed media queries and displayed title always in two lines
- fixed square symbol on windows

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
