### PR TITLE
fix: recentSearch boolean check added to child component

### DIFF
--- a/src/components/organisms/SearchPane/SearchPane.tsx
+++ b/src/components/organisms/SearchPane/SearchPane.tsx
@@ -280,7 +280,7 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
                   </p>
                 </S.MatchText>
               )}
-              {!searchQuery && !isFindingMatches && (
+              {recentSearch.length !== 0 && !searchQuery && !isFindingMatches && (
                 <RecentSearch
                   recentSearch={recentSearch}
                   handleClick={query => {

--- a/src/components/organisms/SearchPane/SearchPane.tsx
+++ b/src/components/organisms/SearchPane/SearchPane.tsx
@@ -280,7 +280,7 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
                   </p>
                 </S.MatchText>
               )}
-              {recentSearch.length !== 0 && !searchQuery && !isFindingMatches && (
+              {recentSearch.length && !searchQuery && !isFindingMatches && (
                 <RecentSearch
                   recentSearch={recentSearch}
                   handleClick={query => {


### PR DESCRIPTION
This PR...
## Fixes

- #2115

## How to test it

- You can find the `RECENT SEARCH` is disabled when no search was previously made.
- Once you did the search `RECENT SEARCH` will be enabled.

## Screenshots

- You can see initially `RECENT SEARCH` is not visible.
![image](https://user-images.githubusercontent.com/35147480/180152865-55750cb7-189f-4c86-820a-bd86366649ee.png)

- After search you can see the `RECENT SEARCH`
![image](https://user-images.githubusercontent.com/35147480/180153062-985f12e8-c615-4486-ad17-20fc6c6c18e1.png)



## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
