### PR TITLE
fix: select hover in search fixed

### DIFF
--- a/src/components/organisms/SearchPane/styled.tsx
+++ b/src/components/organisms/SearchPane/styled.tsx
@@ -229,7 +229,7 @@ export const RecentSearchItem = styled.div`
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
-
+  width: max-content;
   &:hover {
     cursor: pointer;
     color: ${Colors.cyan7};


### PR DESCRIPTION
This PR...

## Fixes

- #2114 

## How to test it

- Hover on the Search items, you can only select the words and not the blank space area

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
