### PR TITLE
fix: enable markdown for see more notification content

### DIFF
--- a/src/components/molecules/NotificationMarkdown/NotificationMarkdown.tsx
+++ b/src/components/molecules/NotificationMarkdown/NotificationMarkdown.tsx
@@ -44,7 +44,11 @@ const NotificationMarkdown: React.FC<NotificationProps> = props => {
   const handleSeeMore = () => {
     // @ts-ignore
     Modal[type]({
-      content: <S.NotificationModalContent>{message}</S.NotificationModalContent>,
+      content: (
+        <S.NotificationModalContent>
+          <ReactMarkdown>{message}</ReactMarkdown>
+        </S.NotificationModalContent>
+      ),
       title: (
         <Provider store={store}>
           <NotificationModalTitle message={message} title={title} />


### PR DESCRIPTION
## Fixes

- Apply markdown on the see more notification content


## Screenshots

![image](https://user-images.githubusercontent.com/47887589/181018464-515d9134-8597-49c0-b493-5aa31b888b4e.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
