### PR TITLE
feat: kill terminal

### DIFF
--- a/electron/app/createWindow.ts
+++ b/electron/app/createWindow.ts
@@ -20,7 +20,8 @@ import {NewVersionCode} from '@models/appconfig';
 import {setAlert} from '@redux/reducers/alert';
 import {setUserDirs, updateNewVersion} from '@redux/reducers/appConfig';
 import {setExtensionsDirs, setPluginMap, setTemplateMap, setTemplatePackMap} from '@redux/reducers/extension';
-import {setAppRehydrating, setWebContentsId} from '@redux/reducers/main';
+import {setAppRehydrating} from '@redux/reducers/main';
+import {setWebContentsId} from '@redux/reducers/terminal';
 import {activeProjectSelector, unsavedResourcesSelector} from '@redux/selectors';
 
 import utilsElectronStore from '@utils/electronStore';
@@ -123,11 +124,11 @@ export const createWindow = (givenPath?: string) => {
     win.webContents.openDevTools();
   }
 
-  autoUpdater.on('update-available', (data: any) => {
+  autoUpdater.on('update-available', () => {
     dispatchToAllWindows(updateNewVersion({code: NewVersionCode.Available, data: null}));
   });
 
-  autoUpdater.on('update-not-available', (data: any) => {
+  autoUpdater.on('update-not-available', () => {
     dispatchToAllWindows(updateNewVersion({code: NewVersionCode.NotAvailable, data: null}));
   });
 
@@ -139,7 +140,7 @@ export const createWindow = (givenPath?: string) => {
     dispatchToAllWindows(updateNewVersion({code: NewVersionCode.Downloading, data: {percent: percent.toFixed(2)}}));
   });
 
-  autoUpdater.on('update-downloaded', (data: any) => {
+  autoUpdater.on('update-downloaded', () => {
     dispatchToAllWindows(updateNewVersion({code: NewVersionCode.Downloaded, data: null}));
   });
 

--- a/electron/app/ipc/ipcListeners.ts
+++ b/electron/app/ipc/ipcListeners.ts
@@ -290,6 +290,7 @@ ipcMain.on('shell.init', (event, args) => {
       cols: 80,
       cwd: rootFilePath,
       env: process.env as Record<string, string>,
+      useConpty: false,
     });
 
     ptyProcessMap[webContentsId] = ptyProcess;

--- a/electron/app/ipc/ipcListeners.ts
+++ b/electron/app/ipc/ipcListeners.ts
@@ -273,11 +273,15 @@ ipcMain.on('global-electron-store-update', (event, args: any) => {
 ipcMain.on('shell.init', (event, args) => {
   const {rootFilePath, webContentsId} = args;
 
+  console.log('Initializing');
+
   if (!webContentsId) {
     return;
   }
 
   const currentWebContents = BrowserWindow.fromId(webContentsId)?.webContents;
+
+  console.log('Pty process Map:', ptyProcessMap);
 
   if (ptyProcessMap[webContentsId]) {
     return;

--- a/electron/app/ipc/ipcListeners.ts
+++ b/electron/app/ipc/ipcListeners.ts
@@ -285,7 +285,7 @@ ipcMain.on('shell.init', (event, args) => {
 
   try {
     const ptyProcess = pty.spawn(shell, [], {
-      name: 'xterm-color',
+      name: 'xterm-256color',
       rows: 24,
       cols: 80,
       cwd: rootFilePath,

--- a/electron/app/ipc/ipcListeners.ts
+++ b/electron/app/ipc/ipcListeners.ts
@@ -273,15 +273,11 @@ ipcMain.on('global-electron-store-update', (event, args: any) => {
 ipcMain.on('shell.init', (event, args) => {
   const {rootFilePath, webContentsId} = args;
 
-  console.log('Initializing');
-
   if (!webContentsId) {
     return;
   }
 
   const currentWebContents = BrowserWindow.fromId(webContentsId)?.webContents;
-
-  console.log('Pty process Map:', ptyProcessMap);
 
   if (ptyProcessMap[webContentsId]) {
     return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5072,9 +5072,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -5358,9 +5358,9 @@
       }
     },
     "node_modules/@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
+      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -10982,9 +10982,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
+      "version": "1.4.202",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz",
+      "integrity": "sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA==",
       "dev": true
     },
     "node_modules/electron-unhandled": {
@@ -23962,9 +23962,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.77.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
-      "integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -24015,9 +24015,9 @@
       }
     },
     "node_modules/rtl-css-js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
-      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+      "integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
       }
@@ -32186,9 +32186,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
-      "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -32465,9 +32465,9 @@
       }
     },
     "@types/prettier": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.3.tgz",
-      "integrity": "sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.6.4.tgz",
+      "integrity": "sha512-fOwvpvQYStpb/zHMx0Cauwywu9yLDmzWiiQBC7gJyq5tYLUXFZvDG7VK1B7WBxxjBJNKFOZ0zLoOQn8vmATbhw==",
       "dev": true
     },
     "@types/prop-types": {
@@ -36769,9 +36769,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
+      "version": "1.4.202",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.202.tgz",
+      "integrity": "sha512-JYsK2ex9lmQD27kj19fhXYxzFJ/phLAkLKHv49A5UY6kMRV2xED3qMMLg/voW/+0AR6wMiI+VxlmK9NDtdxlPA==",
       "dev": true
     },
     "electron-unhandled": {
@@ -46132,9 +46132,9 @@
       }
     },
     "rollup": {
-      "version": "2.77.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
-      "integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
+      "version": "2.77.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -46175,9 +46175,9 @@
       }
     },
     "rtl-css-js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
-      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+      "integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
       "requires": {
         "@babel/runtime": "^7.1.2"
       }

--- a/src/components/organisms/StartProjectPane/StartProjectPage.tsx
+++ b/src/components/organisms/StartProjectPane/StartProjectPage.tsx
@@ -57,7 +57,7 @@ const StartProjectPage = () => {
           const {itemId, itemLogo, itemTitle, itemSemiTitle, itemDescription, itemAction} = item;
 
           return (
-            <S.StartProjectItem id={itemId} onClick={itemAction}>
+            <S.StartProjectItem key={itemId} id={itemId} onClick={itemAction}>
               <S.StartProjectItemLogo src={itemLogo} />
               <S.StartProjectItemTitle>
                 {itemTitle}

--- a/src/components/organisms/TerminalPane/TerminalPane.styled.tsx
+++ b/src/components/organisms/TerminalPane/TerminalPane.styled.tsx
@@ -1,10 +1,21 @@
-import {DownCircleFilled as RawDownCircleFilled} from '@ant-design/icons';
+import {DeleteOutlined as RawDeleteOutlined, DownCircleFilled as RawDownCircleFilled} from '@ant-design/icons';
 
 import styled from 'styled-components';
+
+export const DeleteOutlined = styled(RawDeleteOutlined)`
+  font-size: 16px;
+  cursor: pointer;
+`;
 
 export const DownCircleFilled = styled(RawDownCircleFilled)`
   font-size: 16px;
   cursor: pointer;
+`;
+
+export const TerminalActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
 `;
 
 export const TerminalContainer = styled.div<{$height: number}>`

--- a/src/constants/tooltips.tsx
+++ b/src/constants/tooltips.tsx
@@ -30,6 +30,7 @@ export const FileExplorerChanged = 'File Explorer has some changes. Reload it to
 export const HelmPreviewModeTooltip = 'Set which Helm command to use when generating Helm previews';
 export const HelmPreviewTooltip = 'Preview the Helm Chart with this values file';
 export const ImageTagTooltip = 'Open in external browser';
+export const KillTerminalTooltip = 'Kill terminal';
 export const KubeconfigPathTooltip = 'The path to the kubeconfig to use for cluster/kubectl commands';
 export const KustomizeCommandTooltip = 'Set how to invoke kustomize when previewing and deploying kustomization files';
 export const KustomizationPreviewTooltip = 'Preview the output of this Kustomize file';

--- a/src/models/appstate.ts
+++ b/src/models/appstate.ts
@@ -211,7 +211,6 @@ interface AppState {
       stack: string;
     };
   };
-  webContentsId?: number;
 }
 
 export interface KubernetesObject {

--- a/src/models/rootstate.ts
+++ b/src/models/rootstate.ts
@@ -6,6 +6,7 @@ import {AppState} from './appstate';
 import {ExtensionState} from './extension';
 import {LogsState} from './logs';
 import {NavigatorState} from './navigator';
+import {TerminalState} from './terminal';
 import {UiState} from './ui';
 import {UiCoachState} from './uiCoach';
 
@@ -14,13 +15,14 @@ import {UiCoachState} from './uiCoach';
  * Exported to a separate file so we can use the RootState type in the main process without importing the store
  */
 export type RootState = {
-  config: AppConfig;
-  main: AppState;
-  compare: CompareState;
   alert: AlertState;
-  logs: LogsState;
-  ui: UiState;
-  navigator: NavigatorState;
-  uiCoach: UiCoachState;
+  compare: CompareState;
+  config: AppConfig;
   extension: ExtensionState;
+  logs: LogsState;
+  main: AppState;
+  navigator: NavigatorState;
+  terminal: TerminalState;
+  ui: UiState;
+  uiCoach: UiCoachState;
 };

--- a/src/models/terminal.ts
+++ b/src/models/terminal.ts
@@ -1,0 +1,6 @@
+interface TerminalState {
+  runningTerminals: string[];
+  webContentsId?: number;
+}
+
+export type {TerminalState};

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -8,6 +8,7 @@ import {AppState} from '@models/appstate';
 import {ExtensionState} from '@models/extension';
 import {LogsState} from '@models/logs';
 import {NavigatorState} from '@models/navigator';
+import {TerminalState} from '@models/terminal';
 import {PaneConfiguration, UiState} from '@models/ui';
 import {UiCoachState} from '@models/uiCoach';
 
@@ -255,13 +256,18 @@ const initialExtensionState: ExtensionState = {
   isPluginsDrawerVisible: false,
 };
 
+const initialTerminalState: TerminalState = {
+  runningTerminals: [],
+};
+
 export default {
   alert: initialAlertState,
   config: initialAppConfigState,
-  main: initialAppState,
-  logs: initialLogsState,
-  ui: initialUiState,
-  navigator: initialNavigatorState,
-  uiCoach: initialUiCoachState,
   extension: initialExtensionState,
+  logs: initialLogsState,
+  main: initialAppState,
+  navigator: initialNavigatorState,
+  terminal: initialTerminalState,
+  ui: initialUiState,
+  uiCoach: initialUiCoachState,
 };

--- a/src/redux/reducers/extension.ts
+++ b/src/redux/reducers/extension.ts
@@ -10,31 +10,11 @@ export const extensionSlice = createSlice({
   name: 'extension',
   initialState: initialState.extension,
   reducers: {
-    addPlugin: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyPlugin>>) => {
-      const {extension, folderPath} = action.payload;
-      state.pluginMap[folderPath] = extension;
-    },
-    removePlugin: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
-      const folderPath = action.payload;
-      delete state.pluginMap[folderPath];
-    },
     addMultiplePlugins: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyPlugin>[]>) => {
       action.payload.forEach(current => {
         const {folderPath, extension} = current;
         state.pluginMap[folderPath] = extension;
       });
-    },
-    setPluginMap: (state: Draft<ExtensionState>, action: PayloadAction<Record<string, AnyPlugin>>) => {
-      state.pluginMap = action.payload;
-      state.isLoadingExistingPlugins = false;
-    },
-    addTemplate: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyTemplate>>) => {
-      const {folderPath, extension} = action.payload;
-      state.templateMap[folderPath] = extension;
-    },
-    removeTemplate: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
-      const folderPath = action.payload;
-      delete state.templateMap[folderPath];
     },
     addMultipleTemplates: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyTemplate>[]>) => {
       action.payload.forEach(current => {
@@ -42,28 +22,54 @@ export const extensionSlice = createSlice({
         state.templateMap[folderPath] = extension;
       });
     },
-    removeMultipleTemplates: (state: Draft<ExtensionState>, action: PayloadAction<string[]>) => {
-      action.payload.forEach(templateFolderPath => {
-        delete state.templateMap[templateFolderPath];
-      });
-    },
-    setTemplateMap: (state: Draft<ExtensionState>, action: PayloadAction<Record<string, AnyTemplate>>) => {
-      state.templateMap = action.payload;
-      state.isLoadingExistingTemplates = false;
-    },
-    addTemplatePack: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<TemplatePack>>) => {
-      const {folderPath, extension} = action.payload;
-      state.templatePackMap[folderPath] = extension;
-    },
-    removeTemplatePack: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
-      const folderPath = action.payload;
-      delete state.templatePackMap[folderPath];
+    addPlugin: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyPlugin>>) => {
+      const {extension, folderPath} = action.payload;
+      state.pluginMap[folderPath] = extension;
     },
     addMultipleTemplatePacks: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<TemplatePack>[]>) => {
       action.payload.forEach(current => {
         const {folderPath, extension} = current;
         state.templatePackMap[folderPath] = extension;
       });
+    },
+    addTemplate: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<AnyTemplate>>) => {
+      const {folderPath, extension} = action.payload;
+      state.templateMap[folderPath] = extension;
+    },
+    addTemplatePack: (state: Draft<ExtensionState>, action: PayloadAction<AnyExtension<TemplatePack>>) => {
+      const {folderPath, extension} = action.payload;
+      state.templatePackMap[folderPath] = extension;
+    },
+    closePluginsDrawer: (state: Draft<ExtensionState>) => {
+      state.isPluginsDrawerVisible = false;
+    },
+    openPluginsDrawer: (state: Draft<ExtensionState>) => {
+      state.isPluginsDrawerVisible = true;
+    },
+    removePlugin: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
+      const folderPath = action.payload;
+      delete state.pluginMap[folderPath];
+    },
+    removeMultipleTemplates: (state: Draft<ExtensionState>, action: PayloadAction<string[]>) => {
+      action.payload.forEach(templateFolderPath => {
+        delete state.templateMap[templateFolderPath];
+      });
+    },
+    removeTemplate: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
+      const folderPath = action.payload;
+      delete state.templateMap[folderPath];
+    },
+    removeTemplatePack: (state: Draft<ExtensionState>, action: PayloadAction<string>) => {
+      const folderPath = action.payload;
+      delete state.templatePackMap[folderPath];
+    },
+    setPluginMap: (state: Draft<ExtensionState>, action: PayloadAction<Record<string, AnyPlugin>>) => {
+      state.pluginMap = action.payload;
+      state.isLoadingExistingPlugins = false;
+    },
+    setTemplateMap: (state: Draft<ExtensionState>, action: PayloadAction<Record<string, AnyTemplate>>) => {
+      state.templateMap = action.payload;
+      state.isLoadingExistingTemplates = false;
     },
     setTemplatePackMap: (state: Draft<ExtensionState>, action: PayloadAction<Record<string, TemplatePack>>) => {
       state.templatePackMap = action.payload;
@@ -76,12 +82,6 @@ export const extensionSlice = createSlice({
       state.templatesDir = action.payload.templatesDir;
       state.templatePacksDir = action.payload.templatePacksDir;
       state.pluginsDir = action.payload.pluginsDir;
-    },
-    openPluginsDrawer: (state: Draft<ExtensionState>) => {
-      state.isPluginsDrawerVisible = true;
-    },
-    closePluginsDrawer: (state: Draft<ExtensionState>) => {
-      state.isPluginsDrawerVisible = false;
     },
   },
 });

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -745,9 +745,6 @@ export const mainSlice = createSlice({
       state.selectedPath = undefined;
       state.selectedValuesFileId = undefined;
     },
-    setWebContentsId: (state: Draft<AppState>, action: PayloadAction<number>) => {
-      state.webContentsId = action.payload;
-    },
     setImagesSearchedValue: (state: Draft<AppState>, action: PayloadAction<string>) => {
       state.imagesSearchedValue = action.payload;
     },
@@ -1240,10 +1237,11 @@ export const mainSlice = createSlice({
       (state, action) => {
         if (action.payload?.alert) {
           const notification: AlertType = action.payload.alert;
-          notification.id = uuidv4();
-          notification.hasSeen = false;
-          notification.createdAt = new Date().getTime();
-          state.notifications = [notification, ...state.notifications];
+
+          state.notifications = [
+            {...notification, id: uuidv4(), hasSeen: false, createdAt: new Date().getTime()},
+            ...state.notifications,
+          ];
         }
       }
     );
@@ -1351,7 +1349,6 @@ export const {
   setImagesSearchedValue,
   setSelectingFile,
   setSelectionHistory,
-  setWebContentsId,
   startPreviewLoader,
   stopPreviewLoader,
   toggleAllRules,

--- a/src/redux/reducers/terminal.ts
+++ b/src/redux/reducers/terminal.ts
@@ -8,11 +8,17 @@ export const terminalSlice = createSlice({
   name: 'terminal',
   initialState: initialState.terminal,
   reducers: {
+    addRunningTerminal: (state: Draft<TerminalState>, action: PayloadAction<string>) => {
+      state.runningTerminals.push(action.payload);
+    },
+    removeRunningTerminal: (state: Draft<TerminalState>, action: PayloadAction<string>) => {
+      state.runningTerminals = state.runningTerminals.filter(id => id !== action.payload);
+    },
     setWebContentsId: (state: Draft<TerminalState>, action: PayloadAction<number>) => {
       state.webContentsId = action.payload;
     },
   },
 });
 
-export const {setWebContentsId} = terminalSlice.actions;
+export const {addRunningTerminal, removeRunningTerminal, setWebContentsId} = terminalSlice.actions;
 export default terminalSlice.reducer;

--- a/src/redux/reducers/terminal.ts
+++ b/src/redux/reducers/terminal.ts
@@ -1,0 +1,18 @@
+import {Draft, PayloadAction, createSlice} from '@reduxjs/toolkit';
+
+import {TerminalState} from '@models/terminal';
+
+import initialState from '@redux/initialState';
+
+export const terminalSlice = createSlice({
+  name: 'terminal',
+  initialState: initialState.terminal,
+  reducers: {
+    setWebContentsId: (state: Draft<TerminalState>, action: PayloadAction<number>) => {
+      state.webContentsId = action.payload;
+    },
+  },
+});
+
+export const {setWebContentsId} = terminalSlice.actions;
+export default terminalSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -13,6 +13,7 @@ import {extensionSlice} from './reducers/extension';
 import {logsSlice} from './reducers/logs';
 import {imageSelectedListener, mainSlice, resourceMapChangedListener} from './reducers/main';
 import {navigatorSlice, updateNavigatorInstanceState} from './reducers/navigator';
+import {terminalSlice} from './reducers/terminal';
 import {uiSlice} from './reducers/ui';
 import {uiCoachSlice} from './reducers/uiCoach';
 
@@ -39,15 +40,16 @@ combineListeners([
 ]);
 
 const appReducer = combineReducers({
-  config: configSlice.reducer,
-  main: mainSlice.reducer,
   alert: alertSlice.reducer,
-  logs: logsSlice.reducer,
-  ui: uiSlice.reducer,
-  navigator: navigatorSlice.reducer,
-  uiCoach: uiCoachSlice.reducer,
-  extension: extensionSlice.reducer,
   compare: compareSlice.reducer,
+  config: configSlice.reducer,
+  extension: extensionSlice.reducer,
+  logs: logsSlice.reducer,
+  main: mainSlice.reducer,
+  navigator: navigatorSlice.reducer,
+  terminal: terminalSlice.reducer,
+  ui: uiSlice.reducer,
+  uiCoach: uiCoachSlice.reducer,
 });
 
 const rootReducer: typeof appReducer = (state, action) => {


### PR DESCRIPTION
## Changes

- Add action button to kill the terminal instead of just hiding it

## Fixes

- Fit on reopening terminal
- Start project page keys missing from a map warning

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/181243292-ec83bc9c-d636-4e48-83cb-44cc5cf3064f.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
