### PR TITLE
refactor: rename WalkThrough to Walkthrough

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import {clearNotifications, closePreviewConfigurationEditor, reprocessAllResourc
 import {
   closeFolderExplorer,
   closeReleaseNotesDrawer,
-  handleWalkThroughStep,
+  handleWalkthroughStep,
   toggleNotifications,
   toggleSettings,
 } from '@redux/reducers/ui';
@@ -232,9 +232,9 @@ const App = () => {
   const onCloseReleaseNotes = useCallback(() => {
     setShowReleaseNotes(false);
     if (!electronStore.get('appConfig.lastSeenReleaseNotesVersion')) {
-      dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
+      dispatch(handleWalkthroughStep({step: StepEnum.Next, collection: 'novice'}));
     } else {
-      dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'release'}));
+      dispatch(handleWalkthroughStep({step: StepEnum.Next, collection: 'release'}));
     }
     electronStore.set('appConfig.lastSeenReleaseNotesVersion', appVersion);
   }, [appVersion, dispatch]);

--- a/src/components/molecules/Walkthrough/Walkthrough.tsx
+++ b/src/components/molecules/Walkthrough/Walkthrough.tsx
@@ -4,16 +4,16 @@ import {Popover, PopoverProps} from 'antd';
 
 import {CloseOutlined} from '@ant-design/icons';
 
-import {StepEnum, WalkThroughCollection, WalkThroughContentProps, WalkThroughStep} from '@models/walkthrough';
+import {StepEnum, WalkthroughCollection, WalkthroughContentProps, WalkthroughStep} from '@models/walkthrough';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {cancelWalkThrough, handleWalkThroughStep} from '@redux/reducers/ui';
+import {cancelWalkthrough, handleWalkthroughStep} from '@redux/reducers/ui';
 
 import * as S from './Walkthrough.styled';
 import {newReleaseFeaturesContent, noviceContent} from './content';
 
-type WalkThroughProps<C extends WalkThroughCollection> = {
-  step: WalkThroughStep<C>;
+type WalkthroughProps<C extends WalkthroughCollection> = {
+  step: WalkthroughStep<C>;
   children: React.ReactNode;
   placement?: PopoverProps['placement'];
   collection: C;
@@ -24,12 +24,12 @@ const walkThroughCollection = {
   release: newReleaseFeaturesContent,
 };
 
-const WalkthroughTitle = (props: {title: string; collection: WalkThroughCollection}) => {
+const WalkthroughTitle = (props: {title: string; collection: WalkthroughCollection}) => {
   const {title, collection} = props;
   const dispatch = useAppDispatch();
 
   const handleClose = () => {
-    dispatch(cancelWalkThrough(collection));
+    dispatch(cancelWalkthrough(collection));
   };
 
   return (
@@ -40,12 +40,12 @@ const WalkthroughTitle = (props: {title: string; collection: WalkThroughCollecti
   );
 };
 
-const WalkthroughContent = (props: WalkThroughContentProps) => {
+const WalkthroughContent = (props: WalkthroughContentProps) => {
   const {data, currentStep, collection} = props;
   const dispatch = useAppDispatch();
 
   const handleStep = (step: number) => {
-    dispatch(handleWalkThroughStep({step, collection}));
+    dispatch(handleWalkthroughStep({step, collection}));
   };
 
   const totalSteps = useMemo(() => walkThroughCollection[collection].length, [collection]);
@@ -68,7 +68,7 @@ const WalkthroughContent = (props: WalkThroughContentProps) => {
   );
 };
 
-const Walkthrough = <C extends WalkThroughCollection>(props: WalkThroughProps<C>) => {
+const Walkthrough = <C extends WalkthroughCollection>(props: WalkthroughProps<C>) => {
   const {placement, step, collection, children} = props;
   const walkThroughStep = useAppSelector(state => state.ui.walkThrough[collection].currentStep);
   const data = walkThroughCollection[collection][walkThroughStep] || {};

--- a/src/components/molecules/Walkthrough/content/newReleaseFeatures.ts
+++ b/src/components/molecules/Walkthrough/content/newReleaseFeatures.ts
@@ -1,6 +1,6 @@
-import {WalkThroughContentProps} from '@models/walkthrough';
+import {WalkthroughContentProps} from '@models/walkthrough';
 
-export const newReleaseFeaturesContent: WalkThroughContentProps['data'][] = [
+export const newReleaseFeaturesContent: WalkthroughContentProps['data'][] = [
   {
     step: 'compare',
     title: 'Compare anything',

--- a/src/components/molecules/Walkthrough/content/novice.ts
+++ b/src/components/molecules/Walkthrough/content/novice.ts
@@ -1,6 +1,6 @@
-import {WalkThroughContentProps} from '@models/walkthrough';
+import {WalkthroughContentProps} from '@models/walkthrough';
 
-export const noviceContent: WalkThroughContentProps['data'][] = [
+export const noviceContent: WalkthroughContentProps['data'][] = [
   {
     step: 'template',
     title: 'Find your projects here',

--- a/src/components/organisms/PageHeader/HelpMenu.tsx
+++ b/src/components/organisms/PageHeader/HelpMenu.tsx
@@ -14,8 +14,8 @@ import {StepEnum} from '@models/walkthrough';
 import {useAppDispatch} from '@redux/hooks';
 import {openPluginsDrawer} from '@redux/reducers/extension';
 import {
-  cancelWalkThrough,
-  handleWalkThroughStep,
+  cancelWalkthrough,
+  handleWalkthroughStep,
   openAboutModal,
   openKeyboardShortcutsModal,
   openReleaseNotesDrawer,
@@ -134,8 +134,8 @@ export const HelpMenu = ({onMenuClose}: {onMenuClose?: Function}) => {
           type="link"
           size="small"
           onClick={() => {
-            dispatch(cancelWalkThrough('novice'));
-            dispatch(handleWalkThroughStep({step: StepEnum.Next, collection: 'novice'}));
+            dispatch(cancelWalkthrough('novice'));
+            dispatch(handleWalkthroughStep({step: StepEnum.Next, collection: 'novice'}));
             handleMenuClose();
           }}
         >

--- a/src/models/walkthrough.ts
+++ b/src/models/walkthrough.ts
@@ -1,16 +1,16 @@
-export type WalkThroughCollection = 'novice' | 'release';
+export type WalkthroughCollection = 'novice' | 'release';
 
-export type WalkThroughStep<C extends WalkThroughCollection = WalkThroughCollection> = C extends 'novice'
+export type WalkthroughStep<C extends WalkthroughCollection = WalkthroughCollection> = C extends 'novice'
   ? 'template' | 'resource' | 'syntax' | 'kustomizeHelm'
   : 'compare' | 'images';
 
-export type WalkThroughContentProps = {
+export type WalkthroughContentProps = {
   data: {
-    step: WalkThroughStep;
+    step: WalkthroughStep;
     title: string;
     content: string;
   };
-  collection: WalkThroughCollection;
+  collection: WalkthroughCollection;
   currentStep: number;
 };
 

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -17,7 +17,7 @@ import {
   RightMenuSelectionType,
   UiState,
 } from '@models/ui';
-import {WalkThroughCollection} from '@models/walkthrough';
+import {WalkthroughCollection} from '@models/walkthrough';
 
 import initialState from '@redux/initialState';
 import {isKustomizationResource} from '@redux/services/kustomize';
@@ -280,13 +280,13 @@ export const uiSlice = createSlice({
     closeAboutModal: (state: Draft<UiState>) => {
       state.isAboutModalOpen = false;
     },
-    cancelWalkThrough: (state: Draft<UiState>, action: PayloadAction<WalkThroughCollection>) => {
+    cancelWalkthrough: (state: Draft<UiState>, action: PayloadAction<WalkthroughCollection>) => {
       const collection = action.payload;
       state.walkThrough[collection].currentStep = -1;
     },
-    handleWalkThroughStep: (
+    handleWalkthroughStep: (
       state: Draft<UiState>,
-      action: PayloadAction<{step: number; collection: WalkThroughCollection}>
+      action: PayloadAction<{step: number; collection: WalkthroughCollection}>
     ) => {
       const {step, collection} = action.payload;
       state.walkThrough[collection].currentStep += step;
@@ -323,7 +323,7 @@ export const uiSlice = createSlice({
 });
 
 export const {
-  cancelWalkThrough,
+  cancelWalkthrough,
   closeAboutModal,
   closeClusterDiff,
   closeCreateFileFolderModal,
@@ -340,7 +340,7 @@ export const {
   closeSaveResourcesToFileFolderModal,
   collapseNavSections,
   expandNavSections,
-  handleWalkThroughStep,
+  handleWalkthroughStep,
   highlightItem,
   openAboutModal,
   openClusterDiff,


### PR DESCRIPTION
## Changes

- Rename `WalkThrough` to `Walkthrough`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
