### PR TITLE
feat: toggle terminal pane hotkey

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -3,7 +3,7 @@
 Monokle currently supports the following keyboard shortcuts:
 
 - Cluster Preview: Ctrl/Cmd I
-- Settings: Ctrl/Cmd P
+- Settings: Ctrl/Cmd , (Comma)
 - Exit Preview: ESC
 - Browse Folder: Ctrl/Cmd O
 - Refresh Folder: Ctrl/Cmd F5
@@ -20,6 +20,7 @@ Monokle currently supports the following keyboard shortcuts:
 - Open Kustomization Tab: Ctrl/Cmd Shift K
 - Open Helm Tab: Ctrl/Cmd Shift H
 - Open Validation Tab: Ctrl/Cmd Shift V
+- Open Terminal Pane: Ctrl/Cmd ` (Backtick)
 - Reset Resource Filters: Ctrl/Cmd ALT R
 - Open Quick Search: Ctrl/Cmd SHIFT P
 - Zoom In: Ctrl/Cmd =

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -12,6 +12,7 @@ import {
   openNewResourceWizard,
   openQuickSearchActionsPopup,
   setActiveTab,
+  setLeftBottomMenuSelection,
   setLeftMenuSelection,
   toggleRightMenu,
   toggleSettings,
@@ -184,6 +185,19 @@ const HotKeysHandler = () => {
       diffSelectedResource();
     },
     [diffSelectedResource, isKubeConfigPathValid]
+  );
+
+  useHotkeys(
+    hotkeys.TOGGLE_TERMINAL_PANE.key,
+    () => {
+      if (uiState.leftMenu.bottomSelection === 'terminal') {
+        dispatch(setLeftBottomMenuSelection(null));
+      } else {
+        dispatch(setLeftBottomMenuSelection('terminal'));
+      }
+    },
+    {enableOnTags: ['TEXTAREA']},
+    [uiState.leftMenu.bottomSelection]
   );
 
   useHotkeys(

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -10,6 +10,7 @@ import {
   HelmTabTooltip,
   KustomizeTabTooltip,
   TemplatesTabTooltip,
+  TerminalPaneTooltip,
   ValidationTabTooltip,
 } from '@constants/tooltips';
 
@@ -122,7 +123,7 @@ const PaneManagerLeftMenu: React.FC = () => {
     <S.Container id="LeftToolbar" $isLeftActive={isActive}>
       <S.IconsContainer>
         <PaneTooltip
-          show={!leftActive || !(leftMenuSelection === 'file-explorer')}
+          show={!leftActive || leftMenuSelection !== 'file-explorer'}
           title={<FileExplorerTabTooltip />}
           placement="right"
         >
@@ -144,7 +145,7 @@ const PaneManagerLeftMenu: React.FC = () => {
         </PaneTooltip>
 
         <PaneTooltip
-          show={!leftActive || !(leftMenuSelection === 'kustomize-pane')}
+          show={!leftActive || leftMenuSelection !== 'kustomize-pane'}
           title={<KustomizeTabTooltip />}
           placement="right"
         >
@@ -173,7 +174,7 @@ const PaneManagerLeftMenu: React.FC = () => {
 
         <Walkthrough placement="rightTop" step="kustomizeHelm" collection="novice">
           <PaneTooltip
-            show={!leftActive || !(leftMenuSelection === 'helm-pane')}
+            show={!leftActive || leftMenuSelection !== 'helm-pane'}
             title={<HelmTabTooltip />}
             placement="right"
           >
@@ -200,7 +201,7 @@ const PaneManagerLeftMenu: React.FC = () => {
         <FeatureFlag name="ImagesPane">
           <Walkthrough placement="leftTop" collection="release" step="images">
             <PaneTooltip
-              show={!leftActive || !(leftMenuSelection === 'images-pane')}
+              show={!leftActive || leftMenuSelection !== 'images-pane'}
               title="View Images"
               placement="right"
             >
@@ -216,7 +217,7 @@ const PaneManagerLeftMenu: React.FC = () => {
           </Walkthrough>
         </FeatureFlag>
         <PaneTooltip
-          show={!leftActive || !(leftMenuSelection === 'templates-pane')}
+          show={!leftActive || leftMenuSelection !== 'templates-pane'}
           title={TemplatesTabTooltip}
           placement="right"
         >
@@ -236,7 +237,7 @@ const PaneManagerLeftMenu: React.FC = () => {
           </MenuButton>
         </PaneTooltip>
         <PaneTooltip
-          show={!leftActive || !(leftMenuSelection === 'validation-pane')}
+          show={!leftActive || leftMenuSelection !== 'validation-pane'}
           title={<ValidationTabTooltip />}
           placement="right"
         >
@@ -250,7 +251,7 @@ const PaneManagerLeftMenu: React.FC = () => {
             <MenuIcon iconName="validation" active={isActive} isSelected={checkIsTabSelected('validation-pane')} />
           </MenuButton>
         </PaneTooltip>
-        <PaneTooltip show={!leftActive || !(leftMenuSelection === 'search')} title="Advanced Search" placement="right">
+        <PaneTooltip show={!leftActive || leftMenuSelection !== 'search'} title="Advanced Search" placement="right">
           <MenuButton
             isSelected={checkIsTabSelected('search')}
             isActive={isActive}
@@ -265,15 +266,21 @@ const PaneManagerLeftMenu: React.FC = () => {
 
       <S.IconsContainer>
         <FeatureFlag name="Terminal">
-          <MenuButton
-            id="terminal"
-            isSelected={checkIsBottomTabSelected('terminal')}
-            isActive={isActive}
-            onClick={onTerminalSelectionHandler}
-            disabled={!activeProject}
+          <PaneTooltip
+            show={!leftActive || leftMenuBottomSelection !== 'terminal'}
+            title={<TerminalPaneTooltip />}
+            placement="right"
           >
-            <MenuIcon iconName="terminal" active={isActive} isSelected />
-          </MenuButton>
+            <MenuButton
+              id="terminal"
+              isSelected={checkIsBottomTabSelected('terminal')}
+              isActive={isActive}
+              onClick={onTerminalSelectionHandler}
+              disabled={!activeProject}
+            >
+              <MenuIcon iconName="terminal" active={isActive} isSelected />
+            </MenuButton>
+          </PaneTooltip>
         </FeatureFlag>
       </S.IconsContainer>
     </S.Container>

--- a/src/constants/hotkeys.ts
+++ b/src/constants/hotkeys.ts
@@ -68,7 +68,7 @@ export const hotkeys = createHotkeys({
     category: 'tool',
   },
   OPEN_NEW_RESOURCE_WIZARD: {
-    name: 'Open new Resource Wizard',
+    name: 'Open New Resource Wizard',
     key: 'ctrl+n, cmd+n',
     category: 'navigation',
   },
@@ -105,6 +105,11 @@ export const hotkeys = createHotkeys({
   OPEN_VALIDATION_TAB: {
     name: 'Open Validation Tab',
     key: 'ctrl+shift+v, command+shift+v',
+    category: 'navigation',
+  },
+  TOGGLE_TERMINAL_PANE: {
+    name: 'Toggle Terminal Pane',
+    key: 'ctrl+`, command+`',
     category: 'navigation',
   },
   RESET_RESOURCE_FILTERS: {

--- a/src/constants/tooltips.tsx
+++ b/src/constants/tooltips.tsx
@@ -82,3 +82,4 @@ export const ReloadFolderTooltip = () => (
 export const ResetFiltersTooltip = () => <HotkeyLabel text="Reset Filters" name="RESET_RESOURCE_FILTERS" />;
 export const SettingsTooltip = () => <HotkeyLabel text="Open Settings" name="TOGGLE_SETTINGS" />;
 export const ValidationTabTooltip = () => <HotkeyLabel text="View Validation" name="OPEN_VALIDATION_TAB" />;
+export const TerminalPaneTooltip = () => <HotkeyLabel text="View Terminal" name="TOGGLE_TERMINAL_PANE" />;


### PR DESCRIPTION
## Changes

- Add hotkey for terminal pane toggle - Ctrl/Cmd + ` ( screenshot 2 )
- Add tooltip for terminal menu option ( screenshot 1 )

## Fixes

- Update hotkey for setting toggle on docs

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/182368235-19bd39a7-1372-46ae-8e47-adb266d8283a.png)

![image](https://user-images.githubusercontent.com/47887589/182368296-847420c7-a0d7-437c-b7fe-1d5ef838dc91.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
