### PR TITLE
feat: terminal name for pod shell

### DIFF
--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
@@ -35,6 +35,11 @@ export const PlusCircleFilled = styled(RawPlusCircleFilled)`
   cursor: pointer;
 `;
 
+export const PodNamespaceLabel = styled.span`
+  font-style: italic;
+  color: ${Colors.grey6};
+`;
+
 export const Tab = styled.div<{$selected: boolean}>`
   display: flex;
   align-items: center;
@@ -44,6 +49,12 @@ export const Tab = styled.div<{$selected: boolean}>`
   color: ${({$selected}) => ($selected ? Colors.blue6 : rgba(Colors.whitePure, 0.85))};
   font-weight: 600;
   ${({$selected}) => ($selected ? `border-bottom: 2px solid ${Colors.blue6}` : '')};
+`;
+
+export const TabName = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
 `;
 
 export const Tabs = styled.div`

--- a/src/components/organisms/TerminalPane/TerminalPane.tsx
+++ b/src/components/organisms/TerminalPane/TerminalPane.tsx
@@ -150,7 +150,7 @@ const TerminalPane: React.FC<IProps> = props => {
   }, [terminalId, terminalToKill]);
 
   useEffect(() => {
-    if (!terminalRef.current) {
+    if (!terminalRef.current || terminalRef.current.options.fontSize === settings.fontSize) {
       return;
     }
 

--- a/src/models/terminal.ts
+++ b/src/models/terminal.ts
@@ -1,7 +1,10 @@
+import {K8sResource} from './k8sresource';
+
 interface TerminalType {
   id: string;
   isRunning: boolean;
   defaultCommand?: string;
+  pod?: K8sResource;
 }
 
 interface TerminalSettingsType {

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenu.tsx
@@ -152,7 +152,7 @@ const ResourceKindContextMenu = (props: ItemCustomComponentProps) => {
 
     const newTerminalId = uuidv4();
     dispatch(setSelectedTerminal(newTerminalId));
-    dispatch(addTerminal({id: newTerminalId, isRunning: false, defaultCommand: shellCommand}));
+    dispatch(addTerminal({id: newTerminalId, isRunning: false, defaultCommand: shellCommand, pod: resource}));
   };
 
   const menuItems = [

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenuWrapper.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindContextMenuWrapper.tsx
@@ -118,7 +118,7 @@ const ResourceKindContextMenuWrapper = (props: ItemCustomComponentProps) => {
 
     const newTerminalId = uuidv4();
     dispatch(setSelectedTerminal(newTerminalId));
-    dispatch(addTerminal({id: newTerminalId, isRunning: false, defaultCommand: shellCommand}));
+    dispatch(addTerminal({id: newTerminalId, isRunning: false, defaultCommand: shellCommand, pod: resource}));
   };
 
   const menuItems = [


### PR DESCRIPTION
## Changes

- Show pod name and namespace in terminal when opening a shell into a pod


## Screenshots

![image](https://user-images.githubusercontent.com/47887589/182602970-271582c4-5054-4460-8562-7dbe5e10cb1a.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
