### PR TITLE
fix: bring back create namespace option

### DIFF
--- a/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
+++ b/src/components/molecules/ModalConfirmWithNamespaceSelect/ModalConfirmWithNamespaceSelect.tsx
@@ -133,7 +133,7 @@ const ModalConfirmWithNamespaceSelect: React.FC<IProps> = props => {
           value={selectedOption}
         >
           <Radio value="existing">Use existing namespace</Radio>
-          {hasOneNamespaceWithFullAccess && <Radio value="create">Create namespace</Radio>}
+          <Radio value="create">Create namespace</Radio>
           <Radio value="none">None</Radio>
         </Radio.Group>
 


### PR DESCRIPTION
## Fixes

- Have the create namespace option on deploying a resource modal

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/183605227-35be222a-cb10-4ce2-9f2a-f72e8a8bb18d.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
