### PR TITLE
refactor: tree item tooltip overlay style

### DIFF
--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -8,7 +8,7 @@ import {ExclamationCircleOutlined, EyeOutlined} from '@ant-design/icons';
 
 import path from 'path';
 
-import {ROOT_FILE_ENTRY} from '@constants/constants';
+import {LONGER_TOOLTIP_DELAY, ROOT_FILE_ENTRY} from '@constants/constants';
 import hotkeys from '@constants/hotkeys';
 
 import {useAppSelector} from '@redux/hooks';
@@ -297,7 +297,12 @@ const TreeItem: React.FC<TreeItemProps> = props => {
   return (
     <ContextMenu overlay={<Menu items={menuItems} />} triggerOnRightClick>
       <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
-        <Tooltip overlayStyle={tooltipOverlayStyle} mouseEnterDelay={2.0} title={absolutePath} placement="bottom">
+        <Tooltip
+          overlayStyle={tooltipOverlayStyle}
+          mouseEnterDelay={LONGER_TOOLTIP_DELAY}
+          title={absolutePath}
+          placement="bottom"
+        >
           <S.TitleWrapper>
             <S.TreeTitleText>{title as React.ReactNode}</S.TreeTitleText>
             {canPreview(relativePath) && (

--- a/src/components/organisms/FileTreePane/TreeItem.tsx
+++ b/src/components/organisms/FileTreePane/TreeItem.tsx
@@ -8,7 +8,7 @@ import {ExclamationCircleOutlined, EyeOutlined} from '@ant-design/icons';
 
 import path from 'path';
 
-import {ROOT_FILE_ENTRY, TOOLTIP_DELAY} from '@constants/constants';
+import {ROOT_FILE_ENTRY} from '@constants/constants';
 import hotkeys from '@constants/hotkeys';
 
 import {useAppSelector} from '@redux/hooks';
@@ -81,6 +81,20 @@ const TreeItem: React.FC<TreeItemProps> = props => {
 
   const relativePath = isRoot ? getBasename(path.normalize(treeKey)) : treeKey;
   const absolutePath = isRoot ? root.filePath : path.join(root.filePath, treeKey);
+
+  const tooltipOverlayStyle = useMemo(() => {
+    const style: Record<string, string> = {
+      fontSize: '12px',
+      wordBreak: 'break-all',
+      wordWrap: 'normal',
+    };
+
+    if (isMatchItem) {
+      style['display'] = 'none';
+    }
+
+    return style;
+  }, [isMatchItem]);
 
   useHotkeys(
     defineHotkey(hotkeys.DELETE_RESOURCE.key),
@@ -283,12 +297,7 @@ const TreeItem: React.FC<TreeItemProps> = props => {
   return (
     <ContextMenu overlay={<Menu items={menuItems} />} triggerOnRightClick>
       <S.TreeTitleWrapper onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
-        <Tooltip
-          overlayStyle={isMatchItem ? {display: 'none'} : {}}
-          mouseEnterDelay={TOOLTIP_DELAY}
-          title={absolutePath}
-          placement="bottom"
-        >
+        <Tooltip overlayStyle={tooltipOverlayStyle} mouseEnterDelay={2.0} title={absolutePath} placement="bottom">
           <S.TitleWrapper>
             <S.TreeTitleText>{title as React.ReactNode}</S.TreeTitleText>
             {canPreview(relativePath) && (

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -11,6 +11,7 @@ export const ROOT_FILE_ENTRY = '<root>';
 export const APP_MIN_WIDTH = 800;
 export const APP_MIN_HEIGHT = 600;
 export const TOOLTIP_DELAY = 1.0;
+export const LONGER_TOOLTIP_DELAY = 2.0;
 export const TOOLTIP_K8S_SELECTION = 'Select which kubernetes schema version to use for validation';
 export const ERROR_MSG_FALLBACK = 'Looks like something unexpected went wrong. Please try again later.';
 export const REF_PATH_SEPARATOR = '#';


### PR DESCRIPTION
## Changes

- Smaller font-size for tooltip text ( 12 px )
- Break chars instead of words
- 2 seconds delay before showing the tooltip, instead of 1 second

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/183612322-b432dda1-5073-4955-92fa-18b2b404dd66.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
