### PR TITLE
feat: terminal tabs horizontal scrolling + popconfirm

### DIFF
--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
@@ -61,6 +61,10 @@ export const Tab = styled.div<{$selected: boolean}>`
   color: ${({$selected}) => ($selected ? Colors.blue6 : rgba(Colors.whitePure, 0.85))};
   font-weight: 600;
   ${({$selected}) => ($selected ? `border-bottom: 2px solid ${Colors.blue6}` : '')};
+
+  &:first-child {
+    margin-left: 10px;
+  }
 `;
 
 export const TabName = styled.div`
@@ -69,11 +73,11 @@ export const TabName = styled.div`
   gap: 5px;
 `;
 
-export const Tabs = styled.div`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0px 20px;
+export const Tabs = styled.div<{$count: number}>`
+  display: grid;
+  grid-template-columns: ${({$count}) => `repeat(${$count + 1}, max-content)`};
+  grid-column-gap: 20px;
+  overflow-x: auto;
 `;
 
 export const TabsActions = styled.div`
@@ -86,5 +90,6 @@ export const TabsContainer = styled.div`
   display: flex;
   justify-content: space-between;
   border-bottom: ${AppBorders.sectionDivider};
-  padding: 0px 10px;
+  padding-right: 10px;
+  gap: 10px;
 `;

--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
@@ -1,3 +1,5 @@
+import {Popconfirm as RawPopconfirm} from 'antd';
+
 import {
   CaretDownFilled as RawCaretDownFilled,
   CloseOutlined as RawCloseOutlined,
@@ -50,6 +52,10 @@ export const PlusCircleFilled = styled(RawPlusCircleFilled)`
 export const PodNamespaceLabel = styled.span`
   font-style: italic;
   color: ${Colors.grey6};
+`;
+
+export const Popconfirm = styled(RawPopconfirm)`
+  z-index: 10000;
 `;
 
 export const Tab = styled.div<{$selected: boolean}>`

--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
 import {useMeasure} from 'react-use';
 
-import {Dropdown, Tooltip} from 'antd';
+import {Dropdown, Popconfirm, Tooltip} from 'antd';
 
 import {v4 as uuidv4} from 'uuid';
 
@@ -98,13 +98,27 @@ const BottomPaneManager: React.FC = () => {
 
               {renderTerminalName(terminal, index)}
 
-              <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={KillTerminalTooltip}>
-                <S.CloseOutlined
-                  onClick={e => {
-                    e.stopPropagation();
+              <Tooltip mouseEnterDelay={TOOLTIP_DELAY} placement="bottom" title={KillTerminalTooltip}>
+                <Popconfirm
+                  placement="top"
+                  title={`Are you sure you want to kill ${
+                    terminal.pod ? `${terminal.pod.name} terminal` : `Terminal ${index ? `(${index + 1})` : ''}`
+                  }?`}
+                  okText="Yes"
+                  onConfirm={e => {
+                    e?.stopPropagation();
                     setTerminalToKill(terminal.id);
                   }}
-                />
+                  onCancel={e => {
+                    e?.stopPropagation();
+                  }}
+                >
+                  <S.CloseOutlined
+                    onClick={e => {
+                      e.stopPropagation();
+                    }}
+                  />
+                </Popconfirm>
               </Tooltip>
             </S.Tab>
           ))}
@@ -129,14 +143,12 @@ const BottomPaneManager: React.FC = () => {
         </S.TabsActions>
       </S.TabsContainer>
 
-      {Object.values(terminalsMap).map((terminal, index) => (
+      {Object.values(terminalsMap).map(terminal => (
         <TerminalPane
           key={terminal.id}
           height={height - tabsContainerHeight}
-          index={index}
           terminal={terminal}
           terminalToKill={terminalToKill}
-          removeTerminalToKillId={() => setTerminalToKill('')}
         />
       ))}
     </S.BottomPaneManagerContainer>

--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.tsx
@@ -87,7 +87,7 @@ const BottomPaneManager: React.FC = () => {
   return (
     <S.BottomPaneManagerContainer ref={bottomPaneManagerRef}>
       <S.TabsContainer ref={tabsContainerRef}>
-        <S.Tabs>
+        <S.Tabs $count={Object.keys(terminalsMap).length}>
           {Object.values(terminalsMap).map((terminal, index) => (
             <S.Tab
               key={terminal.id}

--- a/src/components/organisms/TerminalPane/TerminalPane.tsx
+++ b/src/components/organisms/TerminalPane/TerminalPane.tsx
@@ -2,10 +2,6 @@ import {ipcRenderer} from 'electron';
 
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 
-import {Modal} from 'antd';
-
-import {ExclamationCircleOutlined} from '@ant-design/icons';
-
 import {IDisposable, Terminal} from 'xterm';
 import {FitAddon} from 'xterm-addon-fit';
 
@@ -22,17 +18,15 @@ import * as S from './TerminalPane.styled';
 
 interface IProps {
   height: number;
-  index: number;
   terminal: TerminalType;
   terminalToKill: string;
-  removeTerminalToKillId: () => void;
 }
 
 const TerminalPane: React.FC<IProps> = props => {
   const {
-    terminal: {defaultCommand, id: terminalId, pod, shell},
+    terminal: {defaultCommand, id: terminalId, shell},
   } = props;
-  const {height, index: terminalIndex, terminalToKill, removeTerminalToKillId} = props;
+  const {height, terminalToKill} = props;
 
   const dispatch = useAppDispatch();
   const bottomPaneHeight = useAppSelector(state => state.ui.paneConfiguration.bottomPaneHeight);
@@ -139,25 +133,7 @@ const TerminalPane: React.FC<IProps> = props => {
       return;
     }
 
-    const name = pod ? `${pod.name} terminal` : `Terminal ${terminalIndex ? `(${terminalIndex + 1})` : ''}`;
-
-    Modal.confirm({
-      title: `Are you sure you want to kill ${name}?`,
-      icon: <ExclamationCircleOutlined />,
-      okText: 'Yes',
-      onOk() {
-        return new Promise(resolve => {
-          ipcRenderer.send('shell.ptyProcessKill', {terminalId});
-          resolve({});
-        });
-      },
-      onCancel() {
-        terminalRef.current?.focus();
-        removeTerminalToKillId();
-      },
-    });
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ipcRenderer.send('shell.ptyProcessKill', {terminalId});
   }, [terminalId, terminalToKill]);
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@ code {
 }
 
 .reflex-container.horizontal > .reflex-splitter {
-  height: 2px;
+  height: 1px;
   background-color: #262626;
   border: 0px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -382,6 +382,7 @@ div.monokleEditorErrorRefGlyphClass.monokleEditorUnsatisfiedRefGlyphClass::after
 
 ::-webkit-scrollbar {
   width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
## Changes

- Have a popconfirm for killing a terminal instead of a modal
- Add horizontal scrolling when there are multiple terminals opened

## How to test it

-

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/183633957-b41da1de-d712-4821-a1d5-327a7e64c135.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
