### PR TITLE
fix: ignore file/folder contained in filter when in preview mode

### DIFF
--- a/src/components/molecules/ResourceFilter/ResourceFilter.tsx
+++ b/src/components/molecules/ResourceFilter/ResourceFilter.tsx
@@ -13,7 +13,7 @@ import {ResetFiltersTooltip} from '@constants/tooltips';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {updateResourceFilter} from '@redux/reducers/main';
 import {openFiltersPresetModal, toggleResourceFilters} from '@redux/reducers/ui';
-import {knownResourceKindsSelector} from '@redux/selectors';
+import {isInPreviewModeSelector, knownResourceKindsSelector} from '@redux/selectors';
 
 import {KeyValueInput} from '@atoms';
 
@@ -44,13 +44,14 @@ const ResourceFilter = () => {
 
   const [allNamespaces] = useNamespaces({extra: ['all', 'default']});
 
-  const knownResourceKinds = useAppSelector(knownResourceKindsSelector);
   const areFiltersDisabled = useAppSelector(
     state => Boolean(state.main.checkedResourceIds.length) || Boolean(state.main.clusterDiff.selectedMatches.length)
   );
   const fileMap = useAppSelector(state => state.main.fileMap);
   const filtersMap = useAppSelector(state => state.main.resourceFilter);
+  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
   const isPaneWideEnough = useAppSelector(state => windowWidth * state.ui.paneConfiguration.navPane > 330);
+  const knownResourceKinds = useAppSelector(knownResourceKindsSelector);
   const resourceMap = useAppSelector(state => state.main.resourceMap);
 
   const allResourceKinds = useMemo(() => {
@@ -309,7 +310,7 @@ const ResourceFilter = () => {
         <S.FieldLabel>Contained in file/folder:</S.FieldLabel>
         <S.SelectStyled
           defaultValue={ROOT_OPTIONS}
-          disabled={areFiltersDisabled}
+          disabled={isInPreviewMode || areFiltersDisabled}
           showSearch
           value={fileOrFolderContainedIn || ROOT_OPTIONS}
           onChange={updateFileOrFolderContainedIn}

--- a/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/K8sResourceSectionBlueprint.ts
@@ -5,9 +5,10 @@ import {ResourceFilterType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 import {SectionBlueprint} from '@models/navigator';
 import {ResourceKindHandler} from '@models/resourcekindhandler';
+import {RootState} from '@models/rootstate';
 
 import {checkMultipleResourceIds, uncheckMultipleResourceIds} from '@redux/reducers/main';
-import {activeResourcesSelector} from '@redux/selectors';
+import {activeResourcesSelector, isInPreviewModeSelector} from '@redux/selectors';
 
 import {isResourcePassingFilter} from '@utils/resources';
 
@@ -92,6 +93,7 @@ export type K8sResourceScopeType = {
   activeResources: K8sResource[];
   resourceFilter: ResourceFilterType;
   checkedResourceIds: string[];
+  state: RootState;
 };
 
 export const K8S_RESOURCE_SECTION_NAME = navSectionNames.K8S_RESOURCES;
@@ -110,6 +112,7 @@ const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScop
       activeResources: activeResourcesSelector(state),
       resourceFilter: state.main.resourceFilter,
       checkedResourceIds: state.main.checkedResourceIds,
+      state,
     };
   },
   builder: {
@@ -123,7 +126,9 @@ const K8sResourceSectionBlueprint: SectionBlueprint<K8sResource, K8sResourceScop
       return (
         scope.isFolderOpen &&
         (scope.activeResources.length === 0 ||
-          scope.activeResources.every(resource => !isResourcePassingFilter(resource, scope.resourceFilter)))
+          scope.activeResources.every(
+            resource => !isResourcePassingFilter(resource, scope.resourceFilter, isInPreviewModeSelector(scope.state))
+          ))
       );
     },
     makeCheckable: scope => {

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
@@ -4,6 +4,7 @@ import {ResourceFilterType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 import {SectionBlueprint} from '@models/navigator';
 import {ResourceKindHandler} from '@models/resourcekindhandler';
+import {RootState} from '@models/rootstate';
 
 import {
   checkMultipleResourceIds,
@@ -12,7 +13,7 @@ import {
   uncheckMultipleResourceIds,
   uncheckResourceId,
 } from '@redux/reducers/main';
-import {activeResourcesSelector} from '@redux/selectors';
+import {activeResourcesSelector, isInPreviewModeSelector} from '@redux/selectors';
 import {isUnsavedResource} from '@redux/services/resource';
 
 import {isResourcePassingFilter} from '@utils/resources';
@@ -33,6 +34,7 @@ export type ResourceKindScopeType = {
   selectedResourceId: string | undefined;
   selectedPath: string | undefined;
   checkedResourceIds: string[];
+  state: RootState;
 };
 
 export function makeResourceKindNavSection(
@@ -51,6 +53,7 @@ export function makeResourceKindNavSection(
         selectedResourceId: state.main.selectedResourceId,
         selectedPath: state.main.selectedPath,
         checkedResourceIds: state.main.checkedResourceIds,
+        state,
       };
     },
     builder: {
@@ -105,7 +108,12 @@ export function makeResourceKindNavSection(
         isHighlighted: rawItem => rawItem.isHighlighted,
         isDirty: rawItem => isUnsavedResource(rawItem),
         isVisible: (rawItem, scope) => {
-          const isPassingFilter = isResourcePassingFilter(rawItem, scope.resourceFilter);
+          const isPassingFilter = isResourcePassingFilter(
+            rawItem,
+            scope.resourceFilter,
+            isInPreviewModeSelector(scope.state)
+          );
+
           return isPassingFilter;
         },
         isCheckable: () => true,

--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -76,11 +76,12 @@ export const filteredResourceSelector = createSelector(
 );
 
 export const filteredResourceMapSelector = createSelector(
-  (state: RootState) => state.main.resourceMap,
-  (state: RootState) => state.main.resourceFilter,
-  (resourceMap, filter) =>
+  (state: RootState) => state,
+  state =>
     _.keyBy(
-      Object.values(resourceMap).filter(resource => isResourcePassingFilter(resource, filter)),
+      Object.values(state.main.resourceMap).filter(resource =>
+        isResourcePassingFilter(resource, state.main.resourceFilter, isInPreviewModeSelector(state))
+      ),
       'id'
     )
 );

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -19,7 +19,7 @@ export function makeResourceNameKindNamespaceIdentifier(partialResource: {
   }`;
 }
 
-export function isResourcePassingFilter(resource: K8sResource, filters: ResourceFilterType) {
+export function isResourcePassingFilter(resource: K8sResource, filters: ResourceFilterType, isInPreviewMode?: boolean) {
   if (
     filters.names &&
     filters.names.length &&
@@ -27,18 +27,25 @@ export function isResourcePassingFilter(resource: K8sResource, filters: Resource
   ) {
     return false;
   }
+
   if (filters.kinds?.length && !filters.kinds?.includes(resource.kind)) {
     return false;
   }
+
   if (filters.namespace) {
     const resourceNamespace = resource.namespace || 'default';
     if (resourceNamespace !== filters.namespace) {
       return false;
     }
   }
-  if (filters.fileOrFolderContainedIn && !resource.filePath.startsWith(filters.fileOrFolderContainedIn)) {
+  if (
+    !isInPreviewMode &&
+    filters.fileOrFolderContainedIn &&
+    !resource.filePath.startsWith(filters.fileOrFolderContainedIn)
+  ) {
     return false;
   }
+
   if (filters.labels && Object.keys(filters.labels).length > 0) {
     const resourceLabels = resource.content?.metadata?.labels;
     const templateLabels = resource.content?.spec?.template?.metadata?.labels;


### PR DESCRIPTION
## Fixes

- Ignore `file/folder container in` filter when in preview mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/183830977-e04a5e05-7181-4748-8dfb-07c661230eea.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
