### PR TITLE
refactor: age/status info

### DIFF
--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.styled.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.styled.tsx
@@ -1,3 +1,5 @@
+import {Tag as RawTag} from 'antd';
+
 import {InfoCircleOutlined as RawInfoCircleOutlined} from '@ant-design/icons';
 
 import styled from 'styled-components';
@@ -7,4 +9,18 @@ import Colors from '@styles/Colors';
 export const InfoCircleOutlined = styled(RawInfoCircleOutlined)<{$isSelected: boolean}>`
   color: ${props => (props.$isSelected ? Colors.blackPure : Colors.blue9)};
   padding: 0 5px;
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: ${Colors.grey9};
+`;
+
+export const Tag = styled(RawTag)`
+  color: ${Colors.yellow8};
+  background: rgba(252, 255, 130, 0.15);
+  border-radius: 4px;
+  margin: 0;
 `;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.styled.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.styled.tsx
@@ -1,12 +1,12 @@
 import {Tag as RawTag} from 'antd';
 
-import {InfoCircleOutlined as RawInfoCircleOutlined} from '@ant-design/icons';
+import {InfoCircleFilled as RawInfoCircleFilled} from '@ant-design/icons';
 
 import styled from 'styled-components';
 
 import Colors from '@styles/Colors';
 
-export const InfoCircleOutlined = styled(RawInfoCircleOutlined)<{$isSelected: boolean}>`
+export const InfoCircleFilled = styled(RawInfoCircleFilled)<{$isSelected: boolean}>`
   color: ${props => (props.$isSelected ? Colors.blackPure : Colors.blue9)};
   padding: 0 5px;
 `;
@@ -18,9 +18,25 @@ export const InfoContainer = styled.div`
   color: ${Colors.grey9};
 `;
 
-export const Tag = styled(RawTag)`
+export const Tag = styled(RawTag)<{$status?: 'Active' | 'Running' | 'Closed'}>`
   color: ${Colors.yellow8};
   background: rgba(252, 255, 130, 0.15);
   border-radius: 4px;
   margin: 0;
+
+  ${({$status}) => {
+    if ($status === 'Closed') {
+      return `
+        color: ${Colors.grey8};
+        background: rgba(172, 172, 172, 0.15);
+      `;
+    }
+
+    if ($status === 'Active') {
+      return `
+        color: ${Colors.green7};
+        background: rgba(142, 212, 96, 0.15);
+      `;
+    }
+  }}
 `;

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.tsx
@@ -49,13 +49,13 @@ export const ResourceKindInformation = (props: ItemCustomComponentProps) => {
 
           {statusInfo && (
             <>
-              <span>Status</span> <S.Tag>{statusInfo}</S.Tag>
+              <span>Status</span> <S.Tag $status={statusInfo}>{statusInfo}</S.Tag>
             </>
           )}
         </S.InfoContainer>
       }
     >
-      <S.InfoCircleOutlined $isSelected={itemInstance.isSelected} />
+      <S.InfoCircleFilled $isSelected={itemInstance.isSelected} />
     </Tooltip>
   );
 };

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.tsx
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindInformation.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useMemo} from 'react';
 
 import {Tooltip} from 'antd';
 
@@ -14,29 +14,48 @@ export const ResourceKindInformation = (props: ItemCustomComponentProps) => {
   const {itemInstance} = props;
   const resource = useAppSelector(state => state.main.resourceMap[itemInstance.id]);
 
-  const getInformation = useCallback(() => {
-    let text;
-    if (resource && resource.content && resource.content.metadata) {
-      text = DateTime.fromISO(resource.content.metadata.creationTimestamp).toRelative()?.replace(' ago', '');
+  const ageInfo = useMemo(() => {
+    if (!resource?.content?.metadata) {
+      return '';
     }
 
-    if (text && resource.content?.status?.phase) {
-      text = `${text} | `;
-    }
-
-    if (resource.content?.status?.phase) {
-      text = `${text}${resource.content.status.phase}`;
-    }
-    return text;
+    return DateTime.fromISO(resource.content.metadata.creationTimestamp).toRelative()?.replace(' ago', '');
   }, [resource]);
 
-  if (!resource) {
+  const statusInfo = useMemo(() => {
+    if (!resource?.content?.status?.phase) {
+      return '';
+    }
+
+    return resource.content.status.phase;
+  }, [resource]);
+
+  if (!resource || (!ageInfo && !statusInfo)) {
     return null;
   }
 
-  return getInformation() ? (
-    <Tooltip placement="top" title={getInformation()}>
+  return (
+    <Tooltip
+      placement="top"
+      title={
+        <S.InfoContainer>
+          {ageInfo && (
+            <>
+              Age <S.Tag>{ageInfo}</S.Tag>
+            </>
+          )}
+
+          {ageInfo && statusInfo && '|'}
+
+          {statusInfo && (
+            <>
+              <span>Status</span> <S.Tag>{statusInfo}</S.Tag>
+            </>
+          )}
+        </S.InfoContainer>
+      }
+    >
       <S.InfoCircleOutlined $isSelected={itemInstance.isSelected} />
     </Tooltip>
-  ) : null;
+  );
 };

--- a/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
+++ b/src/navsections/K8sResourceSectionBlueprint/ResourceKindSectionBlueprint.ts
@@ -139,7 +139,7 @@ export function makeResourceKindNavSection(
         contextMenuWrapper: {component: ResourceKindContextMenuWrapper},
         contextMenu: {component: ResourceKindContextMenu, options: {isVisibleOnHover: true}},
         isCheckVisibleOnHover: true,
-        information: {component: ResourceKindInformation},
+        information: {component: ResourceKindInformation, options: {isVisibleOnHover: true}},
       },
     },
   };

--- a/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
+++ b/src/navsections/UnknownResourceSectionBlueprint/UnknownResourceSectionBlueprint.ts
@@ -89,7 +89,7 @@ const UnknownResourceSectionBlueprint: SectionBlueprint<K8sResource, UnknownReso
       contextMenu: {component: ResourceKindContextMenu, options: {isVisibleOnHover: true}},
       prefix: {component: ResourceKindPrefix},
       suffix: {component: ResourceKindSuffix},
-      information: {component: ResourceKindInformation},
+      information: {component: ResourceKindInformation, options: {isVisibleOnHover: true}},
     },
   },
 };

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -71,9 +71,11 @@ enum Colors {
   blue10 = '#B7E3FA',
   geekblue4 = '#203175',
 
+  green5 = '#3c8618',
   green6 = '#49AA19',
   green7 = '#6ABE39', // Polar Green
-  green8 = '#6F9412',
+  green8 = '#8fd460',
+  green9 = '#b2e58b',
   green10 = '#3E4F13', // Dark Green
 
   highlightGreen = '#33BCB7',


### PR DESCRIPTION
## Changes

- Refactor Age/Status info
- Different colors for `Closed`, `Running` and `Active` status
- Filled info icon

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/183878076-47ddf6e7-be41-4035-ae02-c9828f6b5b1b.png)

![image](https://user-images.githubusercontent.com/47887589/183878113-8b8f4796-2f10-423b-b06e-30c91aebcb60.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
