### PR TITLE
refactor: warnings/errors dropdown padding

### DIFF
--- a/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
+++ b/src/components/organisms/NavigatorPane/WarningAndErrorsDisplay.styled.tsx
@@ -30,9 +30,17 @@ export const Icon = styled(RawIcon)<{$type: 'warning' | 'error'}>`
 
 export const StyledMenu = styled(Menu)`
   max-height: 400px;
-  padding: 4px 0;
+  padding: 0;
   border-right: none;
   overflow-y: scroll;
+
+  & .ant-dropdown-menu-item {
+    padding: 2px 8px;
+
+    &.ant-dropdown-menu-item-active {
+      background: transparent;
+    }
+  }
 `;
 
 export const StyledMenuItem = styled(Menu.Item)`

--- a/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
+++ b/src/components/organisms/NavigatorPane/WarningsAndErrorsDisplay.tsx
@@ -52,20 +52,25 @@ const RefDropdownMenu = (props: RefDropdownMenuProps) => {
 
   const dispatch = useAppDispatch();
 
-  return (
-    <S.StyledMenu>
-      {warnings.map(warning => (
-        <S.StyledMenuItem key={warning.id} onClick={() => dispatch(selectK8sResource({resourceId: warning.id}))}>
-          {warning.namespace && <Tag>{warning.namespace}</Tag>}
-          <span>{warning.name}</span>
-          <S.WarningCountContainer $type={type}>
-            <S.Icon $type={type} name={type} /> {warning.count}
-          </S.WarningCountContainer>
-          <S.WarningKindLabel>{warning.type}</S.WarningKindLabel>
-        </S.StyledMenuItem>
-      ))}
-    </S.StyledMenu>
+  const menuItems = useMemo(
+    () =>
+      warnings.map(warning => ({
+        key: warning.id,
+        label: (
+          <S.StyledMenuItem key={warning.id} onClick={() => dispatch(selectK8sResource({resourceId: warning.id}))}>
+            {warning.namespace && <Tag>{warning.namespace}</Tag>}
+            <span>{warning.name}</span>
+            <S.WarningCountContainer $type={type}>
+              <S.Icon $type={type} name={type} /> {warning.count}
+            </S.WarningCountContainer>
+            <S.WarningKindLabel>{warning.type}</S.WarningKindLabel>
+          </S.StyledMenuItem>
+        ),
+      })),
+    [dispatch, type, warnings]
   );
+
+  return <S.StyledMenu items={menuItems} />;
 };
 
 function WarningsAndErrorsDisplay() {


### PR DESCRIPTION
## Changes

- Add padding to warning/errors dropdown
- Use Antd Menu `items` prop instead of deprecated `children`

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/184308133-38eb1fb8-bed8-4989-a93e-045a2cb5bc1a.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
