### PR TITLE
refactor: show scale/restart only in cluster mode

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPaneHeader.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPaneHeader.tsx
@@ -21,7 +21,7 @@ import {K8sResource} from '@models/k8sresource';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {openPreviewConfigurationEditor} from '@redux/reducers/main';
 import {openSaveResourcesToFileFolderModal} from '@redux/reducers/ui';
-import {knownResourceKindsSelector, kubeConfigPathValidSelector} from '@redux/selectors';
+import {isInClusterModeSelector, knownResourceKindsSelector, kubeConfigPathValidSelector} from '@redux/selectors';
 import {isHelmTemplateFile, isHelmValuesFile} from '@redux/services/helm';
 import {isKustomizationPatch, isKustomizationResource} from '@redux/services/kustomize';
 import {startPreview} from '@redux/services/preview';
@@ -55,6 +55,7 @@ const ActionsPaneHeader: React.FC<IProps> = props => {
   const resourceMap = useAppSelector(state => state.main.resourceMap);
   const selectedImage = useAppSelector(state => state.main.selectedImage);
   const selectedPath = useAppSelector(state => state.main.selectedPath);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const isKubeConfigPathValid = useAppSelector(kubeConfigPathValidSelector);
   const selectedPreviewConfigurationId = useAppSelector(state => state.main.selectedPreviewConfigurationId);
   const selectedPreviewConfiguration = useAppSelector(state => {
@@ -244,8 +245,13 @@ const ActionsPaneHeader: React.FC<IProps> = props => {
         )}
 
         <S.ButtonContainer>
-          <Scale />
-          <Restart />
+          {isInClusterMode && (
+            <>
+              <Scale />
+              <Restart />
+            </>
+          )}
+
           <Tooltip
             mouseEnterDelay={TOOLTIP_DELAY}
             title={isKubeConfigPathValid ? deployTooltip : KubeConfigNoValid}

--- a/src/components/organisms/ActionsPane/Restart/Restart.tsx
+++ b/src/components/organisms/ActionsPane/Restart/Restart.tsx
@@ -9,7 +9,7 @@ import {RestartTooltip} from '@constants/tooltips';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {
-  isInPreviewModeSelector,
+  isInClusterModeSelector,
   kubeConfigContextSelector,
   kubeConfigPathSelector,
   selectedResourceSelector,
@@ -18,14 +18,15 @@ import {restartPreview} from '@redux/services/preview';
 import restartDeployment from '@redux/services/restartDeployment';
 
 const Restart = () => {
-  const currentResource = useAppSelector(selectedResourceSelector);
-  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
-  const currentContext = useAppSelector(kubeConfigContextSelector);
-  const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
   const dispatch = useAppDispatch();
+  const currentContext = useAppSelector(kubeConfigContextSelector);
+  const currentResource = useAppSelector(selectedResourceSelector);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
+  const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
+
   const {name, namespace, kind} = currentResource || {};
 
-  const isBtnEnabled = useMemo(() => kind === 'Deployment' && isInPreviewMode, [kind, isInPreviewMode]);
+  const isBtnEnabled = useMemo(() => kind === 'Deployment' && isInClusterMode, [kind, isInClusterMode]);
 
   const handleClick = () => {
     Modal.confirm({

--- a/src/components/organisms/ActionsPane/Scale/Scale.tsx
+++ b/src/components/organisms/ActionsPane/Scale/Scale.tsx
@@ -8,7 +8,7 @@ import {ScaleTooltip} from '@constants/tooltips';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {closeScaleModal, openScaleModal} from '@redux/reducers/ui';
 import {
-  isInPreviewModeSelector,
+  isInClusterModeSelector,
   kubeConfigContextSelector,
   kubeConfigPathSelector,
   selectedResourceSelector,
@@ -18,21 +18,23 @@ import scaleDeployment from '@redux/services/scaleDeployment';
 
 const Scale = () => {
   const dispatch = useAppDispatch();
-  const currentResource = useAppSelector(selectedResourceSelector);
-  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
-  const isScaleModalOpen = useAppSelector(state => state.ui.isScaleModalOpen);
-  const defaultReplica = currentResource?.content?.spec?.replicas;
-  const [replicas, setReplicas] = useState<number>(defaultReplica);
-  const [scaling, toggleScaling] = useState(false);
   const currentContext = useAppSelector(kubeConfigContextSelector);
+  const currentResource = useAppSelector(selectedResourceSelector);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
+  const isScaleModalOpen = useAppSelector(state => state.ui.isScaleModalOpen);
+
   const kubeConfigPath = useAppSelector(kubeConfigPathSelector);
   const {name, namespace, kind} = currentResource || {};
 
-  const isBtnEnabled = useMemo(() => kind === 'Deployment' && isInPreviewMode, [kind, isInPreviewMode]);
+  const isBtnEnabled = useMemo(() => kind === 'Deployment' && isInClusterMode, [kind, isInClusterMode]);
+  const defaultReplica = useMemo(() => currentResource?.content?.spec?.replicas, [currentResource]);
 
-  useEffect(() => {
-    setReplicas(defaultReplica);
-  }, [currentResource, defaultReplica]);
+  const [replicas, setReplicas] = useState<number>(defaultReplica);
+  const [scaling, toggleScaling] = useState(false);
+
+  const handleCancel = () => {
+    dispatch(closeScaleModal());
+  };
 
   const handleScaleOk = async () => {
     if (name && namespace) {
@@ -44,9 +46,9 @@ const Scale = () => {
     dispatch(closeScaleModal());
   };
 
-  const handleCancel = () => {
-    dispatch(closeScaleModal());
-  };
+  useEffect(() => {
+    setReplicas(defaultReplica);
+  }, [defaultReplica]);
 
   return (
     <>


### PR DESCRIPTION
## Changes

- Show scale/restart buttons only in cluster mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/184313330-56442afd-23ce-4f65-98c2-c2ad85d5d8ec.png)

![image](https://user-images.githubusercontent.com/47887589/184313462-f3622729-976f-4fc5-ad0e-fd247aa991df.png)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
