### PR TITLE
fix: close alert after clicking on button and open notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,6 +161,7 @@ const App = () => {
     if (!shouldTriggerTelemetryNotification) {
       return;
     }
+
     dispatch(
       setAlert({
         title: 'Monokle telemetry',
@@ -168,6 +169,7 @@ const App = () => {
         type: AlertEnum.Info,
         extraContentType: ExtraContentType.Telemetry,
         duration: 5,
+        id: 'monokle_telemetry_alert',
       })
     );
   }, [shouldTriggerTelemetryNotification, dispatch]);

--- a/src/components/molecules/NotificationMarkdown/TelemetryButtons.tsx
+++ b/src/components/molecules/NotificationMarkdown/TelemetryButtons.tsx
@@ -37,9 +37,7 @@ export const TelemetryButtons = ({notificationId}: {notificationId?: string}) =>
 
   const handleOk = () => {
     disableTelemetryNotification();
-    if (notificationId) {
-      return;
-    }
+
     store.dispatch(toggleNotifications());
   };
 


### PR DESCRIPTION
## Fixes

-Close alert after clicking on button and open notifications drawer

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
