### PR TITLE
feat: quick preview action when previewing helm/kustomization

### DIFF
--- a/src/navsections/HelmChartSectionBlueprint/HelmChartQuickAction.styled.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartQuickAction.styled.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const QuickActionsContainer = styled.div`
   display: flex;
   align-items: center;
 `;

--- a/src/navsections/HelmChartSectionBlueprint/HelmChartQuickAction.tsx
+++ b/src/navsections/HelmChartSectionBlueprint/HelmChartQuickAction.tsx
@@ -20,6 +20,8 @@ import {QuickActionCompare, QuickActionPreview} from '@components/molecules';
 import {defineHotkey} from '@utils/defineHotkey';
 import {isDefined} from '@utils/filter';
 
+import * as S from './HelmChartQuickAction.styled';
+
 const selectQuickActionData = (state: RootState, itemId: string) => {
   const thisValuesFile = selectHelmValues(state.main, itemId);
   invariant(thisValuesFile, 'values not found');
@@ -79,33 +81,33 @@ const QuickAction = (props: ItemCustomComponentProps) => {
     reloadPreview();
   });
 
-  if (isAnyPreviewing && !isThisPreviewing) {
-    return (
-      <QuickActionCompare
-        isItemSelected={itemInstance.isSelected}
-        from="quick-helm-compare"
-        view={{
-          leftSet: previewingResourceSet,
-          rightSet: {
-            type: 'helm',
-            chartId: thisValuesFile?.helmChartId,
-            valuesId: thisValuesFile?.id,
-          },
-        }}
-      />
-    );
-  }
-
   return (
-    <QuickActionPreview
-      isItemSelected={itemInstance.isSelected}
-      isItemBeingPreviewed={isThisPreviewing}
-      previewTooltip={HelmPreviewTooltip}
-      reloadPreviewTooltip={ReloadHelmPreviewTooltip}
-      exitPreviewTooltip={ExitHelmPreviewTooltip}
-      selectAndPreview={selectAndPreviewHelmValuesFile}
-      reloadPreview={reloadPreview}
-    />
+    <S.QuickActionsContainer>
+      {isAnyPreviewing && !isThisPreviewing && (
+        <QuickActionCompare
+          isItemSelected={itemInstance.isSelected}
+          from="quick-helm-compare"
+          view={{
+            leftSet: previewingResourceSet,
+            rightSet: {
+              type: 'helm',
+              chartId: thisValuesFile?.helmChartId,
+              valuesId: thisValuesFile?.id,
+            },
+          }}
+        />
+      )}
+
+      <QuickActionPreview
+        isItemSelected={itemInstance.isSelected}
+        isItemBeingPreviewed={isThisPreviewing}
+        previewTooltip={HelmPreviewTooltip}
+        reloadPreviewTooltip={ReloadHelmPreviewTooltip}
+        exitPreviewTooltip={ExitHelmPreviewTooltip}
+        selectAndPreview={selectAndPreviewHelmValuesFile}
+        reloadPreview={reloadPreview}
+      />
+    </S.QuickActionsContainer>
   );
 };
 

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationQuickAction.tsx
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationQuickAction.tsx
@@ -19,6 +19,8 @@ import {QuickActionCompare, QuickActionPreview} from '@components/molecules';
 import {defineHotkey} from '@utils/defineHotkey';
 import {isDefined} from '@utils/filter';
 
+import * as S from './KustomizationQuickAction.styled';
+
 const QuickAction = (props: ItemCustomComponentProps) => {
   const {itemInstance} = props;
   const dispatch = useAppDispatch();
@@ -55,35 +57,35 @@ const QuickAction = (props: ItemCustomComponentProps) => {
     reloadPreview();
   });
 
-  if (isAnyPreviewing && !isThisPreviewing) {
-    return (
-      <QuickActionCompare
-        from="quick-kustomize-compare"
-        isItemSelected={itemInstance.isSelected}
-        view={{
-          leftSet: {
-            type: 'kustomize',
-            kustomizationId: previewResourceId,
-          },
-          rightSet: {
-            type: 'kustomize',
-            kustomizationId: itemInstance.id,
-          },
-        }}
-      />
-    );
-  }
-
   return (
-    <QuickActionPreview
-      isItemSelected={itemInstance.isSelected}
-      isItemBeingPreviewed={isItemBeingPreviewed}
-      previewTooltip={KustomizationPreviewTooltip}
-      reloadPreviewTooltip={ReloadKustomizationPreviewTooltip}
-      exitPreviewTooltip={ExitKustomizationPreviewTooltip}
-      selectAndPreview={selectAndPreviewKustomization}
-      reloadPreview={reloadPreview}
-    />
+    <S.Container>
+      {isAnyPreviewing && !isThisPreviewing && (
+        <QuickActionCompare
+          from="quick-kustomize-compare"
+          isItemSelected={itemInstance.isSelected}
+          view={{
+            leftSet: {
+              type: 'kustomize',
+              kustomizationId: previewResourceId,
+            },
+            rightSet: {
+              type: 'kustomize',
+              kustomizationId: itemInstance.id,
+            },
+          }}
+        />
+      )}
+
+      <QuickActionPreview
+        isItemSelected={itemInstance.isSelected}
+        isItemBeingPreviewed={isItemBeingPreviewed}
+        previewTooltip={KustomizationPreviewTooltip}
+        reloadPreviewTooltip={ReloadKustomizationPreviewTooltip}
+        exitPreviewTooltip={ExitKustomizationPreviewTooltip}
+        selectAndPreview={selectAndPreviewKustomization}
+        reloadPreview={reloadPreview}
+      />
+    </S.Container>
   );
 };
 


### PR DESCRIPTION

## Changes

- Bring back quick preview action when already previewing a helm/kustomization

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/185075434-9d8909c5-ecd7-4b0f-a1c8-3a6323397c28.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
