### PR TITLE
fix: improved handling of invalid Chart.yaml

### DIFF
--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -274,13 +274,18 @@ export function processHelmChartFolder(
 
 export function getHelmChartName(chartFilePath: string) {
   const fileText = fs.readFileSync(chartFilePath, 'utf8');
-  const fileContent = parse(fileText);
+  try {
+    const fileContent = parse(fileText);
 
-  if (typeof fileContent?.name !== 'string') {
-    return `Unamed Chart: ${path.dirname(chartFilePath)}`;
+    if (typeof fileContent?.name !== 'string') {
+      return `Unnamed Chart: ${path.dirname(chartFilePath)}`;
+    }
+
+    return fileContent.name;
+  } catch (e: any) {
+    log.warn(`failed to parse Helm Chart at ${chartFilePath}`);
+    return `Invalid Chart: ${path.dirname(chartFilePath)}`;
   }
-
-  return fileContent.name;
 }
 
 /**


### PR DESCRIPTION
This PR fixes handling of invalid Chart.yaml files - but still needs improvements in regard to rendering performance of the Helm panel when loading the helm/helm repo - see #2260 

@devcatalin can you look into the performance - you can perhaps use this branch for improving?