### PR TITLE
fix: git changelist for nested folder projects

### DIFF
--- a/electron/app/git/git.ts
+++ b/electron/app/git/git.ts
@@ -1,6 +1,8 @@
 import {promises as fs} from 'fs';
 import {SimpleGit, simpleGit} from 'simple-git';
 
+import {ROOT_FILE_ENTRY} from '@constants/constants';
+
 import {FileMapType} from '@models/appstate';
 import {GitRepo} from '@models/git';
 
@@ -94,11 +96,18 @@ export async function initGitRepo(localPath: string) {
 export async function getChangedFiles(localPath: string, fileMap: FileMapType) {
   const git: SimpleGit = simpleGit({baseDir: localPath});
 
+  const projectFolderPath = fileMap[ROOT_FILE_ENTRY].filePath;
+  const gitFolderPath = await git.revparse({'--show-toplevel': null});
   const currentBranch = (await git.branch()).current;
   const stagedChangedFiles = (await git.diff({'--name-only': null, '--staged': null})).split('\n').filter(el => el);
   const unstagedChangedFiles = (await git.diff({'--name-only': null})).split('\n').filter(el => el);
 
-  const changedFiles = formatGitChangedFiles({stagedChangedFiles, unstagedChangedFiles}, fileMap);
+  const changedFiles = formatGitChangedFiles(
+    {stagedChangedFiles, unstagedChangedFiles},
+    fileMap,
+    projectFolderPath,
+    gitFolderPath
+  );
 
   for (let i = 0; i < changedFiles.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -3,12 +3,19 @@ import path from 'path';
 import {FileMapType} from '@models/appstate';
 import {GitChangedFile} from '@models/git';
 
-export function formatGitChangedFiles(result: any, fileMap: FileMapType): GitChangedFile[] {
+export function formatGitChangedFiles(
+  result: any,
+  fileMap: FileMapType,
+  projectFolderPath: string,
+  gitFolderPath: string
+): GitChangedFile[] {
   const {unstagedChangedFiles, stagedChangedFiles} = result;
 
   const changedFiles: GitChangedFile[] = [
     ...stagedChangedFiles.map((file: any) => {
-      const foundFile = Object.values(fileMap).find(f => f.filePath.substring(1) === file.replaceAll('/', path.sep));
+      const foundFile = Object.values(fileMap).find(
+        f => path.join(projectFolderPath, f.filePath) === path.join(gitFolderPath, file)
+      );
 
       return {
         status: 'staged',
@@ -18,7 +25,9 @@ export function formatGitChangedFiles(result: any, fileMap: FileMapType): GitCha
       };
     }),
     ...unstagedChangedFiles.map((file: any) => {
-      const foundFile = Object.values(fileMap).find(f => f.filePath.substring(1) === file.replaceAll('/', path.sep));
+      const foundFile = Object.values(fileMap).find(
+        f => path.join(projectFolderPath, f.filePath) === path.join(gitFolderPath, file)
+      );
 
       return {
         status: 'unstaged',


### PR DESCRIPTION
## Fixes

- Fixed Git Changelist which was returning the `modifiedContent` and `name` properties undefined when you're opening a subfolder of a Git repository as a project in Monokle.

