### PR TITLE
fix: don't show 0 when there are no recent searches

### DIFF
--- a/src/components/organisms/SearchPane/SearchPane.tsx
+++ b/src/components/organisms/SearchPane/SearchPane.tsx
@@ -298,7 +298,8 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
                   </p>
                 </S.MatchText>
               )}
-              {recentSearch.length && !searchQuery && !isFindingMatches && (
+
+              {recentSearch.length && !searchQuery && !isFindingMatches ? (
                 <RecentSearch
                   recentSearch={recentSearch}
                   handleClick={query => {
@@ -306,7 +307,8 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
                     findMatches(query);
                   }}
                 />
-              )}
+              ) : null}
+
               {searchQuery && !searchTree.length && !isFindingMatches && 'No matches found'}
             </S.RootFolderText>
             {isFindingMatches && <S.Skeleton active />}
@@ -388,6 +390,7 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
               ) : (
                 'No matches found'
               )}
+
               {replaceQuery && (
                 <S.ButtonContainer>
                   <Button type="primary" onClick={replaceCurrentSelection} disabled={!currentMatchNode}>
@@ -399,6 +402,7 @@ const SearchPane: React.FC<{height: number}> = ({height}) => {
                 </S.ButtonContainer>
               )}
             </S.RootFolderText>
+
             {isFindingMatches && <S.Skeleton active />}
           </S.TreeContainer>
         </TabPane>


### PR DESCRIPTION
## Fixes

- Don't show number 0 when there are no recent searches in `SearchPane`

## Screenshots

Without fix:

![image](https://user-images.githubusercontent.com/47887589/191195242-d8ffe9ff-393a-41d2-8075-99001aa98e05.png)

With fix:

![image](https://user-images.githubusercontent.com/47887589/191195279-3a934376-49d5-4e37-bc10-9fa2938ef690.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
