### PR TITLE
feat: git changed files paths and colors

### DIFF
--- a/electron/app/git/git.ts
+++ b/electron/app/git/git.ts
@@ -109,25 +109,17 @@ export async function getChangedFiles(localPath: string, fileMap: FileMapType) {
   const gitFolderPath = await git.revparse({'--show-toplevel': null});
   const currentBranch = (await git.branch()).current;
 
-  const stagedChangedFiles = (await git.diff({'--name-only': null, '--cached': null})).split('\n').filter(el => el);
-  const unstagedChangedFiles = (await git.diff({'--name-only': null})).split('\n').filter(el => el);
-  const unstagedAddedFiles = (await git.raw({'ls-files': null, '-o': null, '--exclude-standard': null}))
-    .split('\n')
-    .filter(el => el);
+  const branchStatus = await git.status({'-z': null, '-uall': null});
+  const files = branchStatus.files;
 
-  const changedFiles = formatGitChangedFiles(
-    {stagedChangedFiles, unstagedChangedFiles: [...unstagedChangedFiles, ...unstagedAddedFiles]},
-    fileMap,
-    projectFolderPath,
-    gitFolderPath
-  );
+  const changedFiles = formatGitChangedFiles(files, fileMap, projectFolderPath, gitFolderPath);
 
   for (let i = 0; i < changedFiles.length; i += 1) {
     let originalContent: string = '';
 
     try {
       // eslint-disable-next-line no-await-in-loop
-      originalContent = await git.show(`${currentBranch}:${changedFiles[i].path}`);
+      originalContent = await git.show(`${currentBranch}:${changedFiles[i].gitPath}`);
     } catch (error) {
       originalContent = '';
     }

--- a/electron/app/git/git.ts
+++ b/electron/app/git/git.ts
@@ -33,6 +33,13 @@ export async function isFolderGitRepo(path: string) {
   }
 }
 
+export async function getRemotePath(localPath: string) {
+  const git: SimpleGit = simpleGit({baseDir: localPath});
+
+  const gitFolderPath = await git.revparse({'--show-toplevel': null});
+  return gitFolderPath;
+}
+
 export async function cloneGitRepo(payload: {localPath: string; repoPath: string}) {
   const {localPath, repoPath} = payload;
   try {

--- a/electron/app/git/ipc.ts
+++ b/electron/app/git/ipc.ts
@@ -12,6 +12,7 @@ import {
   fetchGitRepo,
   getChangedFiles,
   getCurrentBranch,
+  getRemotePath,
   initGitRepo,
   isFolderGitRepo,
   publishLocalBranch,
@@ -104,4 +105,9 @@ ipcMain.on('git.pushChanges', async (event, payload: {localPath: string; branchN
 ipcMain.on('git.setRemote', async (event, payload: {localPath: string; remoteURL: string}) => {
   await setRemote(payload.localPath, payload.remoteURL);
   event.sender.send('git.setRemote.result');
+});
+
+ipcMain.on('git.getRemotePath', async (event, localPath: string) => {
+  const result = await getRemotePath(localPath);
+  event.sender.send('git.getRemotePath.result', result);
 });

--- a/src/components/organisms/GitPane/FileList.styled.tsx
+++ b/src/components/organisms/GitPane/FileList.styled.tsx
@@ -37,13 +37,15 @@ export const FilePath = styled.div`
   font-size: 12px;
 `;
 
-export const FileStatus = styled.div<{$type: 'added' | 'deleted' | 'modified'}>`
+export const FileStatus = styled.div<{$type: 'added' | 'deleted' | 'modified' | 'untracked'}>`
   height: 10px;
   width: 10px;
   border: ${({$type}) =>
-    `1px solid ${$type === 'added' ? Colors.cyan8 : $type === 'deleted' ? Colors.volcano6 : Colors.yellow7}`};
+    `1px solid ${
+      $type === 'added' || $type === 'untracked' ? Colors.cyan8 : $type === 'deleted' ? Colors.volcano6 : Colors.yellow7
+    }`};
   background-color: ${({$type}) =>
-    $type === 'added'
+    $type === 'added' || $type === 'untracked'
       ? rgba(Colors.cyan8, 0.3)
       : $type === 'deleted'
       ? rgba(Colors.volcano6, 0.3)

--- a/src/components/organisms/GitPane/FileList.styled.tsx
+++ b/src/components/organisms/GitPane/FileList.styled.tsx
@@ -2,6 +2,7 @@ import {ListProps, List as RawList} from 'antd';
 
 import {FileOutlined as RawFileOutlined} from '@ant-design/icons';
 
+import {rgba} from 'polished';
 import styled from 'styled-components';
 
 import {GitChangedFile} from '@models/git';
@@ -34,6 +35,22 @@ export const FilePath = styled.div`
   color: ${Colors.grey7};
   margin-left: 4px;
   font-size: 12px;
+`;
+
+export const FileStatus = styled.div<{$type: 'added' | 'deleted' | 'modified'}>`
+  height: 10px;
+  width: 10px;
+  border: ${({$type}) =>
+    `1px solid ${$type === 'added' ? Colors.cyan8 : $type === 'deleted' ? Colors.volcano6 : Colors.yellow7}`};
+  background-color: ${({$type}) =>
+    $type === 'added'
+      ? rgba(Colors.cyan8, 0.3)
+      : $type === 'deleted'
+      ? rgba(Colors.volcano6, 0.3)
+      : rgba(Colors.yellow7, 0.3)};
+  border-radius: 3px;
+  margin-right: 8px;
+  margin-top: 1px;
 `;
 
 export const List = styled((props: ListProps<GitChangedFile>) => <RawList<GitChangedFile> {...props} />)`

--- a/src/components/organisms/GitPane/FileList.tsx
+++ b/src/components/organisms/GitPane/FileList.tsx
@@ -76,6 +76,7 @@ const FileList: React.FC<IProps> = props => {
               <S.FileIcon>
                 <S.FileOutlined $type={item.status} />
               </S.FileIcon>
+              <S.FileStatus $type={!item.modifiedContent ? 'deleted' : !item.originalContent ? 'added' : 'modified'} />
               {item.name}
               <S.FilePath>{item.path}</S.FilePath>
             </S.FileItemData>

--- a/src/components/organisms/GitPane/FileList.tsx
+++ b/src/components/organisms/GitPane/FileList.tsx
@@ -1,7 +1,9 @@
 import {useCallback, useState} from 'react';
 
-import {Checkbox, Dropdown, List, Menu, Space} from 'antd';
+import {Checkbox, Dropdown, List, Menu, Space, Tooltip} from 'antd';
 import {CheckboxChangeEvent} from 'antd/lib/checkbox';
+
+import {TOOLTIP_DELAY} from '@constants/constants';
 
 import {GitChangedFile} from '@models/git';
 
@@ -76,7 +78,10 @@ const FileList: React.FC<IProps> = props => {
               <S.FileIcon>
                 <S.FileOutlined $type={item.status} />
               </S.FileIcon>
-              <S.FileStatus $type={item.type} />
+
+              <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={item.type.charAt(0).toUpperCase() + item.type.slice(1)}>
+                <S.FileStatus $type={item.type} />
+              </Tooltip>
               {item.name}
               <S.FilePath>{item.path}</S.FilePath>
             </S.FileItemData>

--- a/src/components/organisms/GitPane/FileList.tsx
+++ b/src/components/organisms/GitPane/FileList.tsx
@@ -76,7 +76,7 @@ const FileList: React.FC<IProps> = props => {
               <S.FileIcon>
                 <S.FileOutlined $type={item.status} />
               </S.FileIcon>
-              <S.FileStatus $type={!item.modifiedContent ? 'deleted' : !item.originalContent ? 'added' : 'modified'} />
+              <S.FileStatus $type={item.type} />
               {item.name}
               <S.FilePath>{item.path}</S.FilePath>
             </S.FileItemData>

--- a/src/models/git.ts
+++ b/src/models/git.ts
@@ -15,8 +15,10 @@ export type GitChangedFile = {
   modifiedContent: string;
   name: string;
   originalContent: string;
+  gitPath: string;
   path: string;
   status: 'staged' | 'unstaged';
+  type: 'added' | 'deleted' | 'modified';
 };
 
 export type GitSliceState = {

--- a/src/models/git.ts
+++ b/src/models/git.ts
@@ -18,7 +18,7 @@ export type GitChangedFile = {
   gitPath: string;
   path: string;
   status: 'staged' | 'unstaged';
-  type: 'added' | 'deleted' | 'modified';
+  type: 'added' | 'deleted' | 'modified' | 'untracked';
 };
 
 export type GitSliceState = {

--- a/src/redux/thunks/setRootFolder.ts
+++ b/src/redux/thunks/setRootFolder.ts
@@ -104,6 +104,7 @@ export const setRootFolder = createAsyncThunk<
     'git.isFolderGitRepo.result',
     rootFolder
   );
+
   const gitRepo = isFolderGitRepo
     ? await promiseFromIpcRenderer<GitRepo>('git.fetchGitRepo', 'git.fetchGitRepo.result', rootFolder)
     : undefined;

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -42,6 +42,7 @@ enum Colors {
   yellow10 = '#FAFAB5',
   yellow11 = '#C9E75D',
 
+  volcano6 = '#D84A1B',
   volcano7 = '#E87040',
   volcano8 = '#F3956A',
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -38,7 +38,9 @@ export function formatGitChangedFiles(
       modifiedContent,
       name: foundFile?.name || gitFile.path.split('/').pop() || '',
       gitPath: gitFile.path,
-      path: projectFolderPath.startsWith(gitFolderPath) ? filePath : path.join(gitFolderPath, filePath),
+      path: path.join(gitFolderPath, gitFile.path).startsWith(projectFolderPath)
+        ? filePath
+        : path.join(gitFolderPath, filePath),
       originalContent: '',
       type: fileType,
     };

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -30,7 +30,9 @@ export function formatGitChangedFiles(
       modifiedContent = fs.readFileSync(path.join(gitFolderPath, gitFile.path), 'utf8');
     }
 
-    const relativePath = path.dirname(gitFile.path);
+    const relativePath = path.dirname(
+      path.join(gitFolderPath, gitFile.path).replace(`${projectFolderPath}${path.sep}`, '')
+    );
     const filePath = relativePath === '.' ? '' : relativePath;
 
     return {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -4,52 +4,45 @@ import path from 'path';
 import {FileMapType} from '@models/appstate';
 import {GitChangedFile} from '@models/git';
 
+const gitFileType: {[type: string]: 'added' | 'deleted' | 'modified'} = {
+  A: 'added',
+  D: 'deleted',
+  M: 'modified',
+  '?': 'added',
+};
+
 export function formatGitChangedFiles(
-  result: any,
+  files: {path: string; index: string; working_dir: string}[],
   fileMap: FileMapType,
   projectFolderPath: string,
   gitFolderPath: string
 ): GitChangedFile[] {
-  const {unstagedChangedFiles, stagedChangedFiles} = result;
+  const changedFiles: GitChangedFile[] = files.map(gitFile => {
+    const fileType = gitFile.index.trim() ? gitFileType[gitFile.index] : gitFileType[gitFile.working_dir];
 
-  const changedFiles: GitChangedFile[] = [
-    ...stagedChangedFiles.map((file: any) => {
-      const foundFile = Object.values(fileMap).find(
-        f => path.join(projectFolderPath, f.filePath) === path.join(gitFolderPath, file)
-      );
+    const foundFile = Object.values(fileMap).find(
+      f => path.join(projectFolderPath, f.filePath) === path.join(gitFolderPath, gitFile.path)
+    );
 
-      let modifiedContent = foundFile?.text || '';
+    let modifiedContent = foundFile?.text || '';
 
-      if (!modifiedContent && foundFile) {
-        modifiedContent = fs.readFileSync(path.join(projectFolderPath, foundFile.filePath), 'utf8');
-      }
+    if (!modifiedContent && fileType !== 'deleted') {
+      modifiedContent = fs.readFileSync(path.join(gitFolderPath, gitFile.path), 'utf8');
+    }
 
-      return {
-        status: 'staged',
-        modifiedContent,
-        name: foundFile?.name || file.split('/').pop(),
-        path: file,
-      };
-    }),
-    ...unstagedChangedFiles.map((file: any) => {
-      const foundFile = Object.values(fileMap).find(
-        f => path.join(projectFolderPath, f.filePath) === path.join(gitFolderPath, file)
-      );
+    const relativePath = path.dirname(gitFile.path);
+    const filePath = relativePath === '.' ? '' : relativePath;
 
-      let modifiedContent = foundFile?.text || '';
-
-      if (!modifiedContent && foundFile) {
-        modifiedContent = fs.readFileSync(path.join(projectFolderPath, foundFile.filePath), 'utf8');
-      }
-
-      return {
-        status: 'unstaged',
-        modifiedContent,
-        name: foundFile?.name || file.split('/').pop(),
-        path: file,
-      };
-    }),
-  ];
+    return {
+      status: gitFile.index.trim() ? 'staged' : 'unstaged',
+      modifiedContent,
+      name: foundFile?.name || gitFile.path.split('/').pop() || '',
+      gitPath: gitFile.path,
+      path: projectFolderPath.startsWith(gitFolderPath) ? filePath : path.join(gitFolderPath, filePath),
+      originalContent: '',
+      type: fileType,
+    };
+  });
 
   return changedFiles;
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -4,11 +4,11 @@ import path from 'path';
 import {FileMapType} from '@models/appstate';
 import {GitChangedFile} from '@models/git';
 
-const gitFileType: {[type: string]: 'added' | 'deleted' | 'modified'} = {
+const gitFileType: {[type: string]: 'added' | 'deleted' | 'modified' | 'untracked'} = {
   A: 'added',
   D: 'deleted',
   M: 'modified',
-  '?': 'added',
+  '?': 'untracked',
 };
 
 export function formatGitChangedFiles(
@@ -36,7 +36,12 @@ export function formatGitChangedFiles(
     const filePath = relativePath === '.' ? '' : relativePath;
 
     return {
-      status: gitFile.index.trim() ? 'staged' : 'unstaged',
+      status:
+        gitFile.working_dir.trim() && gitFile.index.trim() && gitFile.index !== '?'
+          ? 'staged'
+          : gitFile.working_dir.trim()
+          ? 'unstaged'
+          : 'staged',
       modifiedContent,
       name: foundFile?.name || gitFile.path.split('/').pop() || '',
       gitPath: gitFile.path,


### PR DESCRIPTION
## Changes

- Corresponding colors for added/deleted/modified files
- Absolute + relative paths for files
- Improved getting git changed files ( with `git.status` )

## Fixes

- Monitor when a file is staged/unstaged from outside Monokle when in a subfolder of a git repo as root path

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/191716984-c7258dc8-cc67-4001-a1c6-c8756b2388e4.png)

![image](https://user-images.githubusercontent.com/47887589/191727163-46440459-861d-4c47-82df-5be6805d22da.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
