### PR TITLE
refactor: cluster selection size

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
@@ -143,7 +143,7 @@ export const ClusterContainer = styled.div`
   border: none;
   border-radius: 4px;
   line-height: 28px !important;
-  min-width: 340px;
+  min-width: 250px;
 
   & .ant-btn[disabled] {
     background: transparent !important;
@@ -191,8 +191,12 @@ export const ClusterStatus = styled.div<{isHalfBordered?: boolean}>`
   background: ${Colors.grey3b};
   border: none;
 
-  @media ${Device.laptop} {
-    min-width: 340px;
+  @media ${Device.laptopM} {
+    min-width: 220px;
+  }
+
+  @media ${Device.laptopL} {
+    min-width: 280px;
   }
 `;
 


### PR DESCRIPTION
## Changes

- 220px when device screen is bigger than 1270px
- 280px when device screen is bigger than 1440px

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
