### PR TITLE
feat: enable sync button

### DIFF
--- a/src/components/organisms/GitPane/BottomActions.tsx
+++ b/src/components/organisms/GitPane/BottomActions.tsx
@@ -50,7 +50,7 @@ const BottomActions: React.FC = () => {
       return true;
     }
 
-    return Boolean(!gitRepo.commits.ahead && !gitRepo.commits.behind);
+    return false;
   }, [gitRepo]);
 
   const pullPushChangesHandler = useCallback(


### PR DESCRIPTION
## Changes

- Disable Sync button only when git repo is not found
- Push button ( from dropdown ) will remain disabled if no local commits are found ( ahead of the remote )

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/195098383-b49bfbae-0379-45e5-b951-f413363c2316.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
