### PR TITLE
fix: show ellipsis + hover full name for project name

### DIFF
--- a/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.styled.tsx
@@ -197,4 +197,10 @@ export const TableColumnName = styled.div`
   display: flex;
   align-items: center;
   gap: 6px;
+
+  & span:nth-child(2) {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
 `;

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -217,7 +217,8 @@ const ProjectSelection = () => {
 
               return (
                 <S.TableColumnName>
-                  {isGitRepo ? <S.GitProjectIcon name="git-project" /> : <S.FolderOutlined />} {name}
+                  {isGitRepo ? <S.GitProjectIcon name="git-project" /> : <S.FolderOutlined />}
+                  <span title={name}>{name}</span>
                 </S.TableColumnName>
               );
             }}


### PR DESCRIPTION
## Fixes

- Ellipsis for project name when too long

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/195612707-a1983e82-5255-4a19-8340-9e26e4629cb2.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
