### PR TITLE
fix: dispose only models not attached to any editor

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -254,7 +254,11 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
       const resource = resourceMap[selectedResourceId];
       if (resource) {
         newCode = resource.text;
-        monaco.editor?.getModels()?.forEach(model => model.dispose());
+        monaco.editor?.getModels()?.forEach(model => {
+          if (!model.isAttachedToEditor()) {
+            model.dispose();
+          }
+        });
         editor?.setModel(monaco.editor.createModel(newCode, 'yaml'));
       }
     } else if (selectedPath && selectedPath !== fileMap[ROOT_FILE_ENTRY].filePath) {
@@ -262,7 +266,11 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
       const fileStats = getFileStats(filePath);
       if (fileStats && fileStats.isFile()) {
         newCode = fs.readFileSync(filePath, 'utf8');
-        monaco.editor?.getModels()?.forEach(model => model.dispose());
+        monaco.editor?.getModels()?.forEach(model => {
+          if (!model.isAttachedToEditor()) {
+            model.dispose();
+          }
+        });
 
         // monaco has no language registered for tpl extension so use yaml instead (as these could be Helm templates)
         if (filePath.toLowerCase().endsWith('.tpl')) {


### PR DESCRIPTION
## Fixes

- Dispose only models that are not attached to any editor

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
