### PR TITLE
refactor: disable helm/kustomize in compare&sync

### DIFF
--- a/src/components/organisms/CompareModal/ResourceSetSelector/ClusterContextSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/ClusterContextSelect.tsx
@@ -28,7 +28,13 @@ export const ClusterContextSelect: React.FC<Props> = ({side}) => {
   );
   return (
     <S.SelectColor>
-      <Select onChange={handleSelect} placeholder="Choose context…" value={currentContext?.name} style={{width: 160}}>
+      <Select
+        defaultOpen
+        onChange={handleSelect}
+        placeholder="Choose context…"
+        value={currentContext?.name}
+        style={{width: 160}}
+      >
         {allContexts.map(context => {
           return (
             <Select.Option key={context.name} value={context.name}>

--- a/src/components/organisms/CompareModal/ResourceSetSelector/GitSelect/GitBranchSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/GitSelect/GitBranchSelect.tsx
@@ -29,6 +29,7 @@ const GitBranchSelect: React.FC<IProps> = ({side}) => {
   return (
     <S.SelectColor>
       <Select
+        defaultOpen
         onChange={handleSelect}
         placeholder="Choose Branch..."
         value={currentGitBranch?.name}

--- a/src/components/organisms/CompareModal/ResourceSetSelector/HelmSelect/HelmChartSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/HelmSelect/HelmChartSelect.tsx
@@ -28,7 +28,13 @@ export const HelmChartSelect: React.FC<Props> = ({side}) => {
   );
   return (
     <S.SelectColor>
-      <Select onChange={handleSelect} placeholder="Choose Chart…" value={currentHelmChart?.id} style={{width: 160}}>
+      <Select
+        defaultOpen
+        onChange={handleSelect}
+        placeholder="Choose Chart…"
+        value={currentHelmChart?.id}
+        style={{width: 160}}
+      >
         {allHelmCharts.map(chart => {
           return (
             <Select.Option key={chart.id} value={chart.id}>

--- a/src/components/organisms/CompareModal/ResourceSetSelector/HelmSelect/HelmValuesOrConfigSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/HelmSelect/HelmValuesOrConfigSelect.tsx
@@ -42,6 +42,7 @@ export const HelmValuesOrConfigSelect: React.FC<Props> = ({side}) => {
   return (
     <S.SelectColor>
       <Select
+        defaultOpen
         placeholder="Select values…"
         onSelect={handleSelect}
         value={currentHelmValuesOrConfig?.id}

--- a/src/components/organisms/CompareModal/ResourceSetSelector/KustomizeSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/KustomizeSelect.tsx
@@ -29,6 +29,7 @@ export const KustomizeSelect: React.FC<Props> = ({side}) => {
   return (
     <S.SelectColor>
       <Select
+        defaultOpen
         onChange={id => handleSelect(id as string)}
         placeholder="Choose Kustomization…"
         value={currentKustomization?.id}

--- a/src/components/organisms/CompareModal/ResourceSetSelector/ResourceSetTypeSelect.tsx
+++ b/src/components/organisms/CompareModal/ResourceSetSelector/ResourceSetTypeSelect.tsx
@@ -5,6 +5,7 @@ import {Select} from 'antd';
 import {ResourceSet, resourceSetSelected, selectResourceSet} from '@redux/compare';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {kubeConfigPathValidSelector} from '@redux/selectors';
+import {isKustomizationResource} from '@redux/services/kustomize';
 
 import * as S from './ResourceSetSelectColor.styled';
 
@@ -15,8 +16,12 @@ type Props = {
 export const ResourceSetTypeSelect: React.FC<Props> = ({side}) => {
   const dispatch = useAppDispatch();
   const isGitDisabled = useAppSelector(state => Boolean(!state.git.repo));
-  const resourceSet = useAppSelector(state => selectResourceSet(state.compare, side));
+  const isHelmDisabled = useAppSelector(state => !Object.values(state.main.helmChartMap).length);
   const isKubeConfigPathValid = useAppSelector(kubeConfigPathValidSelector);
+  const isKustomizeDisabled = useAppSelector(
+    state => !Object.values(state.main.resourceMap).filter(r => isKustomizationResource(r)).length
+  );
+  const resourceSet = useAppSelector(state => selectResourceSet(state.compare, side));
 
   const handleSelectType = useCallback(
     (type: ResourceSet['type']) => {
@@ -37,8 +42,12 @@ export const ResourceSetTypeSelect: React.FC<Props> = ({side}) => {
         <Select.Option value="cluster" disabled={!isKubeConfigPathValid}>
           Cluster
         </Select.Option>
-        <Select.Option value="helm">Helm Preview</Select.Option>
-        <Select.Option value="kustomize">Kustomize Preview</Select.Option>
+        <Select.Option disabled={isHelmDisabled} value="helm">
+          Helm Preview
+        </Select.Option>
+        <Select.Option disabled={isKustomizeDisabled} value="kustomize">
+          Kustomize Preview
+        </Select.Option>
         <Select.Option disabled={isGitDisabled} value="git">
           Git
         </Select.Option>


### PR DESCRIPTION
## Changes

- Disable kustomize/helm preview options if there are no results found
- Default open of the dropdowns ( except for the git commits dropdown as we select by default the latest commit )

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
