### PR TITLE
refactor: change left menu badge background color

### DIFF
--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.styled.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.styled.tsx
@@ -2,13 +2,14 @@ import {Badge as RawBadge} from 'antd';
 
 import styled from 'styled-components';
 
-import {BackgroundColors, PanelColors} from '@styles/Colors';
+import Colors, {BackgroundColors, PanelColors} from '@styles/Colors';
 
 export const Badge = styled(RawBadge)`
   & .ant-badge-dot {
     top: 6px;
     right: 6px;
     z-index: 100;
+    background-color: ${Colors.geekblue6} !important;
   }
 
   & .ant-badge-count {
@@ -16,6 +17,7 @@ export const Badge = styled(RawBadge)`
     right: 5px;
     z-index: 100;
     padding: 0px 4px;
+    background-color: ${Colors.geekblue6} !important;
   }
 
   & .ant-badge-count-sm {

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -76,6 +76,7 @@ enum Colors {
   blue9 = '#8DCFF8',
   blue10 = '#B7E3FA',
   geekblue4 = '#203175',
+  geekblue6 = '#2B4ACB',
   geekblue7 = '#5273E0',
   blue1000 = '#7F9EF3',
 


### PR DESCRIPTION
## Changes

- Left menu badge background color

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/196882651-6f8516fb-2ac0-4af2-8eaa-9d12cc54d94f.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
