### PR TITLE
fix: remove warning for terminals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ k8sdumps
 /site
 
 electron/env.ts
-
+shared

--- a/electron/app/createWindow.ts
+++ b/electron/app/createWindow.ts
@@ -96,7 +96,6 @@ export const createWindow = (givenPath?: string) => {
 
   const win: BrowserWindow = Splashscreen.initSplashScreen(splashscreenConfig);
   let unsavedResourceCount = 0;
-  let terminalsCount = 0;
 
   if (isDev) {
     win.loadURL('http://localhost:3000/index.html');
@@ -155,7 +154,6 @@ export const createWindow = (givenPath?: string) => {
       let projectName = activeProjectSelector(storeState)?.name;
       setWindowTitle(storeState, win, projectName);
       unsavedResourceCount = unsavedResourcesSelector(storeState).length;
-      terminalsCount = Object.keys(storeState.terminal.terminalsMap).length;
       const segmentClient = getSegmentClient();
 
       if (storeState.config.disableEventTracking) {
@@ -261,7 +259,6 @@ export const createWindow = (givenPath?: string) => {
     const confirmed = askActionConfirmation({
       unsavedResourceCount,
       action: 'close this window',
-      terminalsCount,
     });
 
     if (!confirmed) {

--- a/electron/app/utils.ts
+++ b/electron/app/utils.ts
@@ -184,13 +184,11 @@ export const saveInitialK8sSchema = (userDataDir: string) => {
 export function askActionConfirmation({
   action,
   unsavedResourceCount,
-  terminalsCount,
 }: {
   action: string;
   unsavedResourceCount: number;
-  terminalsCount: number;
 }): boolean {
-  if (!unsavedResourceCount && !terminalsCount) {
+  if (!unsavedResourceCount) {
     return true;
   }
 
@@ -203,11 +201,6 @@ export function askActionConfirmation({
       unsavedResourceCount === 1
         ? 'You have an unsaved resource.\n'
         : `You have ${unsavedResourceCount} unsaved resources.\n`;
-  }
-
-  if (terminalsCount) {
-    message +=
-      terminalsCount === 1 ? 'You have a terminal tab open.' : `You have ${terminalsCount} terminal tabs open.`;
   }
 
   const choice = dialog.showMessageBoxSync({

--- a/src/components/organisms/PageHeader/ProjectSelection.tsx
+++ b/src/components/organisms/PageHeader/ProjectSelection.tsx
@@ -47,7 +47,6 @@ const ProjectSelection = () => {
   const isGitInstalled = useAppSelector(state => state.git.isGitInstalled);
   const previewLoader = useAppSelector(state => state.main.previewLoader);
   const projects = useAppSelector(state => state.config.projects);
-  const terminalsMap = useAppSelector(state => state.terminal.terminalsMap);
   const unsavedResourceCount = useAppSelector(unsavedResourcesSelector).length;
 
   const [filteredProjects, setFilteredProjects] = useState<Project[]>([]);
@@ -94,7 +93,6 @@ const ProjectSelection = () => {
       const confirmed = ipcRenderer.sendSync('confirm-action', {
         unsavedResourceCount,
         action: 'change the active project',
-        terminalsCount: Object.keys(terminalsMap).length,
       });
 
       if (!confirmed) {


### PR DESCRIPTION
## Fixes

- Remove warning if there are terminals open when switching a project or closing the Monokle window

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
