### PR TITLE
fix: being able to select folders as files

### DIFF
--- a/src/hooks/fileTreeHooks/useFileSelect.tsx
+++ b/src/hooks/fileTreeHooks/useFileSelect.tsx
@@ -12,7 +12,11 @@ export const useFileSelect = () => {
 
   const onFileSelect = (selectedKeysValue: React.Key[], info: any) => {
     const nodeKey = info.node.parentKey || info.node.key;
-    const {isExcluded, isSupported, isTextExtension, isLine} = info.node;
+    const {isExcluded, isFolder, isSupported, isTextExtension, isLine} = info.node;
+
+    if (isFolder) {
+      return;
+    }
 
     if (!nodeKey.startsWith(fileOrFolderContainedInFilter || '')) {
       return;


### PR DESCRIPTION
## Fixes

- No longer being able to select a folder as a file

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
