### PR TITLE
fix: show editor for empty files

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -242,7 +242,7 @@ const Monaco = (props: {diffSelectedResource: () => void; applySelection: () => 
   };
 
   useEffect(() => {
-    if (!firstCodeLoadedOnEditor && code) {
+    if (!firstCodeLoadedOnEditor) {
       setFirstCodeLoadedOnEditor(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Fixes

- Show editor for files that are empty

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
