### PR TITLE
fix: add support for external patch refs

### DIFF
--- a/src/redux/services/kustomize.ts
+++ b/src/redux/services/kustomize.ts
@@ -114,6 +114,7 @@ function extractPatches(
   let patches = getScalarNodes(kustomization, patchPath);
   patches
     .filter(refNode => refNode.node.type === 'PLAIN')
+    .filter(refNode => !isExternalResourceRef(refNode))
     .forEach((refNode: NodeWrapper) => {
       let kpath = path.join(path.parse(kustomization.filePath).dir, refNode.nodeValue());
       const fileEntry = fileMap[kpath];


### PR DESCRIPTION
This PR fixes

<img width="804" alt="image" src="https://user-images.githubusercontent.com/1917063/206845198-0b48de25-e8fc-470d-98e9-1c404537e584.png">


## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
