### PR TITLE
fix: git compare resource content

### DIFF
--- a/electron/app/git/git.ts
+++ b/electron/app/git/git.ts
@@ -316,7 +316,7 @@ export async function pullChanges(localPath: string) {
   }
 }
 
-export async function getCommitResources(localPath: string, branchName: string, commitHash: string) {
+export async function getCommitResources(localPath: string, commitHash: string) {
   const git: SimpleGit = simpleGit({baseDir: localPath});
   let resources: K8sResource[] = [];
 
@@ -330,7 +330,7 @@ export async function getCommitResources(localPath: string, branchName: string, 
     // get the content of the file found in current branch
     try {
       // eslint-disable-next-line no-await-in-loop
-      content = await git.show(`${branchName}:${filesPaths[i]}`);
+      content = await git.show(`${commitHash}:${filesPaths[i]}`);
     } catch (e) {
       content = '';
     }

--- a/electron/app/git/ipc.ts
+++ b/electron/app/git/ipc.ts
@@ -15,8 +15,8 @@ import {
   getCommitResources,
   getCommitsCount,
   getCurrentBranch,
-  getGitRepoInfo,
   getGitRemoteUrl,
+  getGitRepoInfo,
   getRemotePath,
   initGitRepo,
   isFolderGitRepo,
@@ -143,13 +143,10 @@ ipcMain.on('git.pullChanges', async (event, localPath: string) => {
   event.sender.send('git.pullChanges.result', result);
 });
 
-ipcMain.on(
-  'git.getCommitResources',
-  async (event, payload: {localPath: string; branchName: string; commitHash: string}) => {
-    const result = await getCommitResources(payload.localPath, payload.branchName, payload.commitHash);
-    event.sender.send('git.getCommitResources.result', result);
-  }
-);
+ipcMain.on('git.getCommitResources', async (event, payload: {localPath: string; commitHash: string}) => {
+  const result = await getCommitResources(payload.localPath, payload.commitHash);
+  event.sender.send('git.getCommitResources.result', result);
+});
 
 ipcMain.on('git.getBranchCommits', async (event, payload: {localPath: string; branchName: string}) => {
   const result = await getBranchCommits(payload.localPath, payload.branchName);

--- a/src/redux/services/compare/fetchResources.ts
+++ b/src/redux/services/compare/fetchResources.ts
@@ -82,14 +82,13 @@ function fetchLocalResources(state: RootState, options: LocalResourceSet): K8sRe
 }
 
 async function fetchGitResources(state: RootState, options: GitResourceSet): Promise<K8sResource[]> {
-  const {branchName, commitHash = ''} = options;
+  const {commitHash = ''} = options;
 
   const resources: K8sResource[] = await promiseFromIpcRenderer(
     'git.getCommitResources',
     'git.getCommitResources.result',
     {
       localPath: state.config.selectedProjectRootFolder,
-      branchName,
       commitHash,
     }
   );


### PR DESCRIPTION
## Fixes

- Show content of resources from the commit hash not branch name

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
