### PR TITLE
Fixed blog's broken link in 1.13 release notes.

### DIFF
--- a/resources/releaseNotes/1.13/1.13.md
+++ b/resources/releaseNotes/1.13/1.13.md
@@ -5,4 +5,4 @@ We can't wait for you to try our newest features!
   - Resource validation while in browsing the cluster
   - Edit the YAML and redeploy to the cluster
 - Enhanced Monokle's Compare & Sync feature with the addition of subfolder comparison
-- For more info about these new features and additional updates [read our in depth blog post →](https://kubeshop.io/blog/monokle-1-13-0-release)
+- For more info about these new features and additional updates [read our in depth blog post →](https://monokle.io/blog/monokle-1-13-release)


### PR DESCRIPTION
This PR fixes https://github.com/kubeshop/monokle/issues/2922 by updating the blog post link in the 1.13 release notes.

## Changes

-

## Fixes
https://github.com/kubeshop/monokle/issues/2922
-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [X] updated the docs
- [ ] added a test
