### PR TITLE
fix: default project settings when no active project

### DIFF
--- a/src/components/organisms/SettingsManager/SettingsManager.tsx
+++ b/src/components/organisms/SettingsManager/SettingsManager.tsx
@@ -79,10 +79,10 @@ const SettingsManager: React.FC = () => {
   };
 
   useEffect(() => {
-    if (previewingCluster) {
+    if (previewingCluster || !activeProject) {
       setActiveTab(SettingsPanel.DefaultProjectSettings);
     }
-  }, [previewingCluster]);
+  }, [activeProject, previewingCluster]);
 
   const changeProjectConfig = (config: ProjectConfig) => {
     dispatch(updateProjectConfig({config, fromConfigFile: false}));


### PR DESCRIPTION
## Fixes

- Set default project settings when there is no active project

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/208866599-a96a4445-86e3-40cf-b32f-1cfb1c73c55a.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
