### PR TITLE
refactor: change default font-family to Inter

### DIFF
--- a/public/Splashscreen.css
+++ b/public/Splashscreen.css
@@ -1,5 +1,5 @@
 body {
-  font-family: 'Source Sans Pro', sans-serif;
+  font-family: 'Inter', sans-serif;
   background-color: black;
 }
 @keyframes loading-dots-1 {

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro&family=Inter&display=swap" rel="stylesheet" />
     <title>Monokle</title>
   </head>
   <body>

--- a/src/components/atoms/MonoPaneTitle/MonoPaneTitle.tsx
+++ b/src/components/atoms/MonoPaneTitle/MonoPaneTitle.tsx
@@ -15,8 +15,8 @@ const MonoPaneTitle = styled(Text)`
     padding: 13px 4px 13px 16px;
     text-transform: uppercase;
     font-size: 14px;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+      sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     font-variant: tabular-nums;
     font-style: normal;
     font-weight: 600;

--- a/src/components/molecules/Logs/Logs.styled.ts
+++ b/src/components/molecules/Logs/Logs.styled.ts
@@ -13,15 +13,15 @@ export const LogContainer = styled.div`
 `;
 
 export const LogText = styled(Text)`
-    display: block;
-    margin-bottom: 0;
-    padding: 4px;
-    font-size: 14px;
-    font-family: '-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';'
-    font-variant: tabular-nums;
-    font-style: normal;
-    font-weight: 600;
-    line-height: 24px;
-    color: ${Colors.grey8};
+  display: block;
+  margin-bottom: 0;
+  padding: 4px;
+  font-size: 14px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  font-variant: tabular-nums;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 24px;
+  color: ${Colors.grey8};
 `;

--- a/src/components/organisms/FileTreePane/styled.tsx
+++ b/src/components/organisms/FileTreePane/styled.tsx
@@ -10,8 +10,8 @@ export const FileTreeContainer = styled.div`
   height: 100%;
 
   & .ant-tree {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+      sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     font-variant: tabular-nums;
     font-size: 12px;
     font-style: normal;

--- a/src/components/organisms/KeyboardShortcuts/BoardKeys/BoardKeys.styled.tsx
+++ b/src/components/organisms/KeyboardShortcuts/BoardKeys/BoardKeys.styled.tsx
@@ -16,7 +16,7 @@ export const StyledShortCell = styled.div`
 `;
 
 export const StyledKey = styled.div`
-  display: flex
+  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/src/components/organisms/SearchPane/styled.tsx
+++ b/src/components/organisms/SearchPane/styled.tsx
@@ -13,8 +13,6 @@ export const FileTreeContainer = styled.div`
   height: 100%;
 
   & .ant-tree {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     font-variant: tabular-nums;
     font-size: 12px;
     font-style: normal;

--- a/src/index.css
+++ b/src/index.css
@@ -2,8 +2,8 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
+    'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -185,7 +185,7 @@ div.monokleEditorErrorRefGlyphClass.monokleEditorUnsatisfiedRefGlyphClass::after
 }
 
 .monokleEditorLastModifiedLineInlineClass {
-  background-color: #263EA0;
+  background-color: #263ea0;
   transition: 500ms;
 }
 


### PR DESCRIPTION
## Changes

- Change default font-family to `Inter`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
