### PR TITLE
feat: fetch namespace cluster resources

### DIFF
--- a/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {ButtonProps, Button as RawButton, Divider as RawDivider} from 'antd';
+import {ButtonProps, Button as RawButton, Divider as RawDivider, Select as RawSelect} from 'antd';
 
 import {ClusterOutlined as RawClusterOutlined, DownOutlined as RawDownOutlined} from '@ant-design/icons';
 import {
@@ -256,4 +256,17 @@ export const PreviewMode = styled.div<{
   font-weight: 700;
   font-size: 12px;
   letter-spacing: 0.05em;
+`;
+
+export const Select = styled(RawSelect)`
+  margin-left: 10px;
+  background: ${Colors.grey3b};
+  border-radius: 4px;
+  width: 150px;
+  color: ${Colors.whitePure};
+
+  & .ant-select-selector {
+    border: none !important;
+    height: 28px !important;
+  }
 `;

--- a/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
@@ -268,5 +268,9 @@ export const Select = styled(RawSelect)`
   & .ant-select-selector {
     border: none !important;
     height: 28px !important;
+
+    & .ant-select-selection-item {
+      pointer-events: none;
+    }
   }
 `;

--- a/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.styled.tsx
@@ -262,7 +262,7 @@ export const Select = styled(RawSelect)`
   margin-left: 10px;
   background: ${Colors.grey3b};
   border-radius: 4px;
-  width: 150px;
+  width: 175px;
   color: ${Colors.whitePure};
 
   & .ant-select-selector {

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -204,7 +204,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
     <S.ClusterContainer id="ClusterContainer">
       {(activeProject || previewingCluster) && (
         <>
-          {!isPreviewLoading && isInPreviewMode && size.width > 946 && (
+          {!isPreviewLoading && isInPreviewMode && size.width > 1350 && (
             <S.PreviewMode
               $isInPreviewMode={isInPreviewMode}
               $previewType={previewType}
@@ -218,7 +218,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
             </S.PreviewMode>
           )}
 
-          <S.ClusterStatus isHalfBordered={!isPreviewLoading && isInPreviewMode && size.width > 946}>
+          <S.ClusterStatus isHalfBordered={!isPreviewLoading && isInPreviewMode && size.width > 950}>
             {isKubeConfigPathValid && (
               <>
                 <S.ClusterOutlined />
@@ -274,8 +274,8 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
                 }}
               >
                 <Select.Option key="<all>" value="<all>">{`<all>`}</Select.Option>
-                <Select.Option key="cluster-scoped" value="cluster-scoped">
-                  Cluster scoped
+                <Select.Option key="<not-namespaced>" value="<not-namespaced>">
+                  {`<not-namespaced>`}
                 </Select.Option>
 
                 {namespaces.map(ns => (

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -274,6 +274,10 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
                 }}
               >
                 <Select.Option key="<all>" value="<all>">{`<all>`}</Select.Option>
+                <Select.Option key="cluster-scoped" value="cluster-scoped">
+                  Cluster scoped
+                </Select.Option>
+
                 {namespaces.map(ns => (
                   <Select.Option key={ns} value={ns}>
                     {ns}

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -19,6 +19,7 @@ import {highlightItem, toggleSettings, toggleStartProjectPane} from '@redux/redu
 import {
   activeProjectSelector,
   currentClusterAccessSelector,
+  isInClusterModeSelector,
   isInPreviewModeSelector,
   kubeConfigContextColorSelector,
   kubeConfigContextSelector,
@@ -43,6 +44,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
   const highlightedItems = useAppSelector(state => state.ui.highlightedItems);
   const isClusterSelectorVisible = useAppSelector(state => state.config.isClusterSelectorVisible);
   const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const isKubeConfigPathValid = useAppSelector(kubeConfigPathValidSelector);
   const isStartProjectPaneVisible = useAppSelector(state => state.ui.isStartProjectPaneVisible);
   const isAccessLoading = useAppSelector(state => state.config?.isAccessLoading);
@@ -262,12 +264,13 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
       <>
         {isKubeConfigPathValid && (activeProject || previewingCluster) && (
           <>
-            {previewingCluster && (
+            {isInClusterMode && (
               <S.Select
                 value={clusterPreviewNamepsace}
                 showSearch
                 onChange={namespace => {
                   dispatch(setClusterPreviewNamespace(namespace as string));
+                  restartPreview(kubeConfigContext, 'cluster', dispatch);
                 }}
               >
                 <Select.Option key="<all>" value="<all>">{`<all>`}</Select.Option>

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -8,6 +8,7 @@ import {LoadingOutlined} from '@ant-design/icons';
 
 import {TOOLTIP_DELAY} from '@constants/constants';
 import hotkeys from '@constants/hotkeys';
+import {ClusterNamespaceTooltip} from '@constants/tooltips';
 
 import {K8sResource} from '@models/k8sresource';
 import {HighlightItems} from '@models/ui';
@@ -265,25 +266,27 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
         {isKubeConfigPathValid && (activeProject || previewingCluster) && (
           <>
             {isInClusterMode && (
-              <S.Select
-                value={clusterPreviewNamespace}
-                showSearch
-                onChange={namespace => {
-                  dispatch(setClusterPreviewNamespace(namespace as string));
-                  restartPreview(kubeConfigContext, 'cluster', dispatch);
-                }}
-              >
-                <Select.Option key="<all>" value="<all>">{`<all>`}</Select.Option>
-                <Select.Option key="<not-namespaced>" value="<not-namespaced>">
-                  {`<not-namespaced>`}
-                </Select.Option>
-
-                {namespaces.map(ns => (
-                  <Select.Option key={ns} value={ns}>
-                    {ns}
+              <Tooltip placement="left" mouseEnterDelay={TOOLTIP_DELAY} title={ClusterNamespaceTooltip}>
+                <S.Select
+                  value={clusterPreviewNamespace}
+                  showSearch
+                  onChange={namespace => {
+                    dispatch(setClusterPreviewNamespace(namespace as string));
+                    restartPreview(kubeConfigContext, 'cluster', dispatch);
+                  }}
+                >
+                  <Select.Option key="<all>" value="<all>">{`<all>`}</Select.Option>
+                  <Select.Option key="<not-namespaced>" value="<not-namespaced>">
+                    {`<not-namespaced>`}
                   </Select.Option>
-                ))}
-              </S.Select>
+
+                  {namespaces.map(ns => (
+                    <Select.Option key={ns} value={ns}>
+                      {ns}
+                    </Select.Option>
+                  ))}
+                </S.Select>
+              </Tooltip>
             )}
 
             <S.Button

--- a/src/components/organisms/PageHeader/ClusterSelection.tsx
+++ b/src/components/organisms/PageHeader/ClusterSelection.tsx
@@ -40,7 +40,7 @@ import * as S from './ClusterSelection.styled';
 const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) => {
   const dispatch = useAppDispatch();
   const activeProject = useAppSelector(activeProjectSelector);
-  const clusterPreviewNamepsace = useAppSelector(state => state.config.clusterPreviewNamespace);
+  const clusterPreviewNamespace = useAppSelector(state => state.config.clusterPreviewNamespace);
   const highlightedItems = useAppSelector(state => state.ui.highlightedItems);
   const isClusterSelectorVisible = useAppSelector(state => state.config.isClusterSelectorVisible);
   const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
@@ -266,7 +266,7 @@ const ClusterSelection = ({previewResource}: {previewResource?: K8sResource}) =>
           <>
             {isInClusterMode && (
               <S.Select
-                value={clusterPreviewNamepsace}
+                value={clusterPreviewNamespace}
                 showSearch
                 onChange={namespace => {
                   dispatch(setClusterPreviewNamespace(namespace as string));

--- a/src/constants/tooltips.tsx
+++ b/src/constants/tooltips.tsx
@@ -26,6 +26,7 @@ export const ClusterDiffDisabledInClusterPreviewTooltip =
 export const ClusterDiffDisabledTooltip = 'Browse for a folder to enable the Cluster Compare';
 export const ClusterDiffSaveTooltip = 'Replace local resource with cluster version';
 export const ClusterDiffTooltip = 'Compare your local resources with resources in your configured cluster';
+export const ClusterNamespaceTooltip = 'Selected cluster namespace';
 export const CollapseTreeTooltip = 'Collapse all folders';
 export const CommitTooltip = 'Commit to the main branch';
 export const DeletePreviewConfigurationTooltip = 'Are you sure you want to delete this Preview Configuration?';

--- a/src/models/appconfig.ts
+++ b/src/models/appconfig.ts
@@ -160,6 +160,7 @@ interface AppConfig {
     [name: string]: ClusterColors;
   };
   fileExplorerSortOrder: FileExplorerSortOrder;
+  clusterPreviewNamespace: string;
 }
 
 export type {AppConfig};

--- a/src/redux/initialState.ts
+++ b/src/redux/initialState.ts
@@ -125,6 +125,7 @@ const initialAppConfigState: AppConfig = {
   clusterAccess: [],
   isAccessLoading: false,
   kubeConfigContextsColors: electronStore.get('appConfig.kubeConfigContextsColors') || {},
+  clusterPreviewNamespace: electronStore.get('appConfig.clusterPreviewNamespace') || 'default',
 };
 
 const initialAlertState: AlertState = {};

--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -545,6 +545,10 @@ export const configSlice = createSlice({
         log.warn("Couldn't initialize Sentry.");
       }
     },
+    setClusterPreviewNamespace: (state: Draft<AppConfig>, action: PayloadAction<string>) => {
+      state.clusterPreviewNamespace = action.payload;
+      electronStore.set('appConfig.clusterPreviewNamespace', action.payload);
+    },
   },
   extraReducers: builder => {
     builder.addCase(setRootFolder.fulfilled, (state, action) => {
@@ -589,14 +593,17 @@ export const {
   changeProjectsRootPath,
   createProject,
   handleFavoriteTemplate,
+  initRendererSentry,
   removeNamespaceFromContext,
   setAccessLoading,
   setAutoZoom,
+  setClusterPreviewNamespace,
   setCurrentContext,
   setFilterObjects,
   setKubeConfig,
   setKubeConfigContextColor,
   setUserDirs,
+  toggleEditorPlaceholderVisiblity,
   toggleErrorReporting,
   toggleEventTracking,
   toggleProjectPin,
@@ -617,7 +624,5 @@ export const {
   updateTextSize,
   updateTheme,
   updateUsingKubectlProxy,
-  toggleEditorPlaceholderVisiblity,
-  initRendererSentry,
 } = configSlice.actions;
 export default configSlice.reducer;

--- a/src/redux/reducers/main.ts
+++ b/src/redux/reducers/main.ts
@@ -1226,6 +1226,7 @@ export const mainSlice = createSlice({
     builder.addCase(updateFileEntry.fulfilled, (state, action) => {
       return action.payload;
     });
+
     builder.addCase(updateFileEntries.fulfilled, (state, action) => {
       return action.payload;
     });

--- a/src/redux/services/clusterResourceWatcher.ts
+++ b/src/redux/services/clusterResourceWatcher.ts
@@ -9,7 +9,7 @@ import {ResourceMapType} from '@models/appstate';
 import {K8sResource} from '@models/k8sresource';
 import {ResourceKindHandler} from '@models/resourcekindhandler';
 
-import {deleteClusterResource, setIsClusterConnected, updateClusterResource} from '@redux/reducers/main';
+import {deleteClusterResource, setIsClusterConnected} from '@redux/reducers/main';
 
 import {jsonToYaml} from '@utils/yaml';
 
@@ -113,11 +113,11 @@ const watchResource = async (
             await watchResource(dispatch, handler, kubeConfig, previewResources, handler.kindPlural);
           }
         }
-        dispatch(updateClusterResource(resource));
+        // dispatch(updateClusterResource(resource));
         return;
       }
       if (type === 'MODIFIED') {
-        dispatch(updateClusterResource(resource));
+        // dispatch(updateClusterResource(resource));
         return;
       }
       if (type === 'DELETED') {

--- a/src/redux/services/preview.ts
+++ b/src/redux/services/preview.ts
@@ -7,68 +7,26 @@ import {
   startPreviewLoader,
   stopPreviewLoader,
 } from '@redux/reducers/main';
-import {previewCluster, repreviewCluster} from '@redux/thunks/previewCluster';
 import {previewHelmValuesFile} from '@redux/thunks/previewHelmValuesFile';
 import {previewKustomization} from '@redux/thunks/previewKustomization';
 import {runPreviewConfiguration} from '@redux/thunks/runPreviewConfiguration';
+import {startClusterPreview} from '@redux/thunks/startClusterPreview';
 
-import {closeKubectlProxy, openKubectlProxy} from '@utils/commands/kubectl';
-import electronStore from '@utils/electronStore';
+import {closeKubectlProxy} from '@utils/commands/kubectl';
 import {trackEvent} from '@utils/telemetry';
 
 import {disconnectFromCluster} from './clusterResourceWatcher';
 import {previewSavedCommand} from './previewCommand';
 
-const PROXY_PORT_REGEX = /127.0.0.1:[0-9]+/;
-
-const startClusterPreview = async (clusterContext: string, dispatch: AppDispatch, isRestart?: boolean) => {
-  // TODO: if we convert the *startPreview* function to a thunk, then we could get this from the state instead
-  const shouldUseKubectlProxy = electronStore.get('appConfig.useKubectlProxy');
-
-  if (!shouldUseKubectlProxy) {
-    if (isRestart) {
-      dispatch(repreviewCluster({context: clusterContext}));
-    } else {
-      dispatch(previewCluster({context: clusterContext}));
-    }
-    return;
-  }
-
-  // TODO: if the listener has not been called in 10 seconds, then stop the preview and send an error notification
-  const kubectlProxyListener = (event: any) => {
-    if (event.type === 'error' || event.type === 'exit') {
-      stopPreview(dispatch);
-      return;
-    }
-
-    if (event.type === 'stdout' && event.result && event.result.data) {
-      const proxyPortMatches = PROXY_PORT_REGEX.exec(event.result.data);
-      const proxyPortString = proxyPortMatches?.[0]?.split(':')[1];
-      const proxyPort = proxyPortString ? parseInt(proxyPortString, 10) : undefined;
-
-      if (!proxyPort) {
-        return;
-      }
-
-      if (isRestart) {
-        dispatch(repreviewCluster({context: clusterContext, port: proxyPort}));
-      } else {
-        dispatch(previewCluster({context: clusterContext, port: proxyPort}));
-      }
-    }
-  };
-
-  openKubectlProxy(kubectlProxyListener);
-};
-
 export const startPreview = (targetId: string, type: PreviewType, dispatch: AppDispatch) => {
   dispatch(clearPreviewAndSelectionHistory());
   dispatch(startPreviewLoader({previewType: type, targetId}));
+
   if (type === 'kustomization') {
     dispatch(previewKustomization(targetId));
   }
   if (type === 'cluster') {
-    startClusterPreview(targetId, dispatch);
+    dispatch(startClusterPreview({clusterContext: targetId}));
   }
   if (type === 'helm') {
     dispatch(previewHelmValuesFile(targetId));
@@ -89,7 +47,7 @@ export const restartPreview = (targetId: string, type: PreviewType, dispatch: Ap
     dispatch(previewKustomization(targetId));
   }
   if (type === 'cluster') {
-    startClusterPreview(targetId, dispatch, true);
+    dispatch(startClusterPreview({clusterContext: targetId, isRestart: true}));
   }
   if (type === 'helm') {
     dispatch(previewHelmValuesFile(targetId));

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -63,10 +63,24 @@ const previewClusterHandler = async (payload: {context: string; port?: number}, 
       kc = proxyKubeConfig;
     }
 
-    const results =
-      clusterAccess && clusterAccess.length > 0
-        ? await Promise.all(clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace)))
-        : await getNonCustomClusterObjects(kc);
+    let results: PromiseSettledResult<string>[];
+
+    if (clusterAccess && clusterAccess.length) {
+      const foundDefaultNamespace = clusterAccess.find(ca => ca.namespace === 'default');
+
+      if (foundDefaultNamespace) {
+        results = await getNonCustomClusterObjects(kc, 'default');
+      } else {
+        results = await getNonCustomClusterObjects('kc', clusterAccess[0].namespace);
+      }
+    } else {
+      results = await getNonCustomClusterObjects(kc);
+    }
+
+    // const results =
+    //   clusterAccess && clusterAccess.length > 0
+    //     ? await Promise.all(clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace)))
+    //     : await getNonCustomClusterObjects(kc);
 
     const resources = flatten(results);
 

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -13,6 +13,7 @@ import {AppDispatch} from '@models/appdispatch';
 import {K8sResource} from '@models/k8sresource';
 import {RootState} from '@models/rootstate';
 
+import {setClusterPreviewNamespace} from '@redux/reducers/appConfig';
 import {SetPreviewDataPayload} from '@redux/reducers/main';
 import {currentClusterAccessSelector, currentConfigSelector, kubeConfigPathSelector} from '@redux/selectors';
 import {startWatchingResources} from '@redux/services/clusterResourceWatcher';
@@ -71,14 +72,15 @@ const previewClusterHandler = async (payload: {context: string; port?: number}, 
         results = await Promise.all(
           clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace))
         );
-      }
-
-      const foundNamespace = clusterAccess.find(ca => ca.namespace === clusterPreviewNamespace);
-
-      if (foundNamespace) {
-        results = await getNonCustomClusterObjects(kc, clusterPreviewNamespace);
       } else {
-        results = await getNonCustomClusterObjects('kc', clusterAccess[0].namespace);
+        const foundNamespace = clusterAccess.find(ca => ca.namespace === clusterPreviewNamespace);
+
+        if (foundNamespace) {
+          results = await getNonCustomClusterObjects(kc, clusterPreviewNamespace);
+        } else {
+          results = await getNonCustomClusterObjects('kc', clusterAccess[0].namespace);
+          thunkAPI.dispatch(setClusterPreviewNamespace(clusterAccess[0].namespace));
+        }
       }
     } else {
       results = await getNonCustomClusterObjects(kc);

--- a/src/redux/thunks/previewCluster.ts
+++ b/src/redux/thunks/previewCluster.ts
@@ -32,7 +32,7 @@ const getNonCustomClusterObjects = async (kc: any, namespace?: string, allNamesp
       .filter(
         handler =>
           !handler.isCustom &&
-          (allNamespaces ? true : namespace === 'cluster-scoped' ? !handler.isNamespaced : handler.isNamespaced)
+          (allNamespaces ? true : namespace === '<not-namespaced>' ? !handler.isNamespaced : handler.isNamespaced)
       )
       .map(resourceKindHandler =>
         resourceKindHandler
@@ -82,7 +82,7 @@ const previewClusterHandler = async (payload: {context: string; port?: number}, 
           clusterAccess.map((ca: ClusterAccess) => getNonCustomClusterObjects(kc, ca.namespace, true))
         );
       } else {
-        if (currentNamespace !== 'cluster-scoped' && !foundNamespace) {
+        if (currentNamespace !== '<not-namespaced>' && !foundNamespace) {
           currentNamespace = clusterAccess[0].namespace;
           thunkAPI.dispatch(setClusterPreviewNamespace(currentNamespace));
         }
@@ -268,7 +268,11 @@ async function loadCustomResourceObjects(
         const kindHandler = getResourceKindHandler(crd.content.spec.names?.kind);
         if (
           kindHandler &&
-          (allNamespaces ? true : namespace === 'cluster-scoped' ? !kindHandler.isNamespaced : kindHandler.isNamespaced)
+          (allNamespaces
+            ? true
+            : namespace === '<not-namespaced>'
+            ? !kindHandler.isNamespaced
+            : kindHandler.isNamespaced)
         ) {
           return kindHandler.listResourcesInCluster(kc, {namespace}, crd).then(response =>
             // @ts-ignore

--- a/src/redux/thunks/previewKustomization.ts
+++ b/src/redux/thunks/previewKustomization.ts
@@ -25,10 +25,7 @@ import {trackEvent} from '@utils/telemetry';
 export const previewKustomization = createAsyncThunk<
   SetPreviewDataPayload,
   string,
-  {
-    dispatch: AppDispatch;
-    state: RootState;
-  }
+  {dispatch: AppDispatch; state: RootState}
 >('main/previewKustomization', async (resourceId, thunkAPI) => {
   const startTime = new Date().getTime();
   const state = thunkAPI.getState().main;

--- a/src/redux/thunks/startClusterPreview.ts
+++ b/src/redux/thunks/startClusterPreview.ts
@@ -1,0 +1,61 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+
+import {AppDispatch} from '@models/appdispatch';
+import {RootState} from '@models/rootstate';
+
+import {stopPreview} from '@redux/services/preview';
+
+import {openKubectlProxy} from '@utils/commands/kubectl';
+
+import {previewCluster, repreviewCluster} from './previewCluster';
+
+export type StartClusterPreviewPayload = {
+  clusterContext: string;
+  isRestart?: boolean;
+};
+
+const PROXY_PORT_REGEX = /127.0.0.1:[0-9]+/;
+
+export const startClusterPreview = createAsyncThunk<
+  void,
+  StartClusterPreviewPayload,
+  {dispatch: AppDispatch; state: RootState}
+>('main/startClusterPreview', async (payload, thunkAPI) => {
+  const {clusterContext, isRestart} = payload;
+
+  const shouldUseKubectlProxy = thunkAPI.getState().config.useKubectlProxy;
+
+  if (!shouldUseKubectlProxy) {
+    if (isRestart) {
+      thunkAPI.dispatch(repreviewCluster({context: clusterContext}));
+    } else {
+      thunkAPI.dispatch(previewCluster({context: clusterContext}));
+    }
+  }
+
+  // TODO: if the listener has not been called in 10 seconds, then stop the preview and send an error notification
+  const kubectlProxyListener = (event: any) => {
+    if (event.type === 'error' || event.type === 'exit') {
+      stopPreview(thunkAPI.dispatch);
+      return;
+    }
+
+    if (event.type === 'stdout' && event.result && event.result.data) {
+      const proxyPortMatches = PROXY_PORT_REGEX.exec(event.result.data);
+      const proxyPortString = proxyPortMatches?.[0]?.split(':')[1];
+      const proxyPort = proxyPortString ? parseInt(proxyPortString, 10) : undefined;
+
+      if (!proxyPort) {
+        return;
+      }
+
+      if (isRestart) {
+        thunkAPI.dispatch(repreviewCluster({context: clusterContext, port: proxyPort}));
+      } else {
+        thunkAPI.dispatch(previewCluster({context: clusterContext, port: proxyPort}));
+      }
+    }
+  };
+
+  openKubectlProxy(kubectlProxyListener);
+});

--- a/src/redux/thunks/startClusterPreview.ts
+++ b/src/redux/thunks/startClusterPreview.ts
@@ -31,6 +31,8 @@ export const startClusterPreview = createAsyncThunk<
     } else {
       thunkAPI.dispatch(previewCluster({context: clusterContext}));
     }
+
+    return;
   }
 
   // TODO: if the listener has not been called in 10 seconds, then stop the preview and send an error notification

--- a/src/utils/electronStore.ts
+++ b/src/utils/electronStore.ts
@@ -28,6 +28,9 @@ const schema = {
       kubeConfigContextsColors: {
         type: 'object',
       },
+      clusterPreviewNamespace: {
+        type: 'string',
+      },
       hasDeletedDefaultTemplatesPlugin: {
         type: 'boolean',
       },
@@ -289,6 +292,7 @@ const defaults = {
   },
   appConfig: {
     kubeConfigContextsColors: {},
+    clusterPreviewNamespace: 'default',
     useKubectlProxy: false,
     isClusterSelectorVisible: true,
     loadLastProjectOnStartup: false,


### PR DESCRIPTION
## Changes

- When loading the cluster, fetch the resources with the namespace the same as the one currently selected

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/211025743-5becf9f7-f323-4b78-97d4-ce694544c843.png)

![image](https://user-images.githubusercontent.com/47887589/211027085-e103b1b8-bf1c-42c2-b764-e268f02691ca.png)

![image](https://user-images.githubusercontent.com/47887589/211025788-c38b1617-7666-4c86-8e77-0b0ccde7d2ce.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
