### PR TITLE
feat: remove repo name directory if cloning fails

### DIFF
--- a/src/components/organisms/CompareModal/CompareModalSelecting.tsx
+++ b/src/components/organisms/CompareModal/CompareModalSelecting.tsx
@@ -35,7 +35,7 @@ export const CompareModalSelecting: React.FC = () => {
         <S.ListRow>
           <Col span={10}>
             {left.loading ? (
-              <Skeleton />
+              <Skeleton active />
             ) : left.error ? (
               <ErrorFigure onRetry={() => handleRetry('left')} />
             ) : (
@@ -52,7 +52,7 @@ export const CompareModalSelecting: React.FC = () => {
           ) : right.error ? (
             <ErrorFigure onRetry={() => handleRetry('right')} />
           ) : (
-            <Skeleton />
+            <Skeleton active />
           )}
         </S.FloatingFigure>
       </>

--- a/src/components/organisms/CompareModal/CompareModalSelecting.tsx
+++ b/src/components/organisms/CompareModal/CompareModalSelecting.tsx
@@ -67,7 +67,7 @@ export const CompareModalSelecting: React.FC = () => {
 
           <Col span={10}>
             {right.loading ? (
-              <div>loading...</div>
+              <Skeleton active />
             ) : right.error ? (
               <ErrorFigure onRetry={() => handleRetry('right')} />
             ) : (
@@ -84,7 +84,7 @@ export const CompareModalSelecting: React.FC = () => {
           ) : left.error ? (
             <ErrorFigure onRetry={() => handleRetry('left')} />
           ) : (
-            <p>loading..</p>
+            <Skeleton active />
           )}
         </S.FloatingFigure>
       </>

--- a/src/components/organisms/GitCloneModal/GitCloneModal.tsx
+++ b/src/components/organisms/GitCloneModal/GitCloneModal.tsx
@@ -48,13 +48,14 @@ const GitCloneModal: React.FC = () => {
 
       const {localPath, repoURL} = values;
       const repoName = repoURL.split('/').pop();
+      const localGitPath = `${localPath}${sep}${repoName}`;
 
       if (!doesPathExist(localPath)) {
         fs.mkdirSync(localPath, {recursive: true});
       }
 
       promiseFromIpcRenderer('git.cloneGitRepo', 'git.cloneGitRepo.result', {
-        localPath: `${localPath}${sep}${repoName}`,
+        localPath: localGitPath,
         repoPath: repoURL,
       }).then(result => {
         setLoading(false);
@@ -66,6 +67,10 @@ const GitCloneModal: React.FC = () => {
             content: <div>{result.error}</div>,
             zIndex: 100000,
           });
+
+          if (doesPathExist(localGitPath)) {
+            fs.rmdirSync(localGitPath, {recursive: true});
+          }
         } else {
           dispatch(setCreateProject({rootFolder: `${localPath}${sep}${repoName}`}));
         }


### PR DESCRIPTION
## Changes

- Remove the folder that is created when cloning a repo if the cloning fails

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
