### PR TITLE
fix: Show link to docs on any unauthorized notification errors.

### DIFF
--- a/src/components/molecules/NotificationMarkdown/NotificationMarkdown.tsx
+++ b/src/components/molecules/NotificationMarkdown/NotificationMarkdown.tsx
@@ -12,6 +12,7 @@ import store from '@redux/store';
 
 import {TelemetryButtons} from '@molecules/NotificationMarkdown/TelemetryButtons';
 
+import enhanceErrorMessage from '@utils/notification';
 import {openUrlInExternalBrowser} from '@utils/shell';
 
 import NotificationModalTitle from './NotificationModalTitle';
@@ -46,7 +47,7 @@ const NotificationMarkdown: React.FC<NotificationProps> = props => {
     Modal[type]({
       content: (
         <S.NotificationModalContent>
-          <ReactMarkdown>{message}</ReactMarkdown>
+          <ReactMarkdown>{enhanceErrorMessage(message)}</ReactMarkdown>
         </S.NotificationModalContent>
       ),
       title: (

--- a/src/components/organisms/MessageBox/MessageBox.tsx
+++ b/src/components/organisms/MessageBox/MessageBox.tsx
@@ -27,6 +27,20 @@ const MessageBox: React.FC = () => {
     [alert]
   );
 
+  const modify = (title: string) => {
+    const wordsArray = title.split(' ');
+    const unauthIndex = wordsArray.indexOf('UNAUTHORIZED');
+
+    if (unauthIndex === -1) {
+      return title;
+    }
+
+    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our troubleshooting guide for cluster connections in our documentation https://kubeshop.github.io/monokle/cluster-issues for steps on how to resolve this issue.\n\n
+      
+    Error:\n
+    ${title}`;
+  };
+
   useEffect(() => {
     if (!alert) {
       return;
@@ -36,7 +50,7 @@ const MessageBox: React.FC = () => {
       // @ts-ignore
       notification[notificationType]({
         key: alert.id,
-        message: alert.title,
+        message: modify(alert.title),
         description: <NotificationMarkdown notification={alert} type={notificationType} />,
         duration: alert.duration || 4,
       });

--- a/src/components/organisms/MessageBox/MessageBox.tsx
+++ b/src/components/organisms/MessageBox/MessageBox.tsx
@@ -29,20 +29,6 @@ const MessageBox: React.FC = () => {
     [alert]
   );
 
-  const modify = (title: string) => {
-    const wordsArray = title.split(' ');
-    const unauthIndex = wordsArray.indexOf('UNAUTHORIZED');
-
-    if (unauthIndex === -1) {
-      return title;
-    }
-
-    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our troubleshooting guide for cluster connections in our documentation https://kubeshop.github.io/monokle/cluster-issues for steps on how to resolve this issue.\n\n
-      
-    Error:\n
-    ${title}`;
-  };
-
   useEffect(() => {
     if (!alert) {
       return;

--- a/src/components/organisms/MessageBox/MessageBox.tsx
+++ b/src/components/organisms/MessageBox/MessageBox.tsx
@@ -9,6 +9,8 @@ import {clearAlert} from '@redux/reducers/alert';
 
 import {NotificationMarkdown} from '@molecules';
 
+import enhanceErrorMessage from '../../../utils/notification';
+
 const MessageBox: React.FC = () => {
   const dispatch = useAppDispatch();
   const alert = useAppSelector(state => state.alert.alert);
@@ -27,20 +29,6 @@ const MessageBox: React.FC = () => {
     [alert]
   );
 
-  const modify = (title: string) => {
-    const wordsArray = title.split(' ');
-    const unauthIndex = wordsArray.indexOf('UNAUTHORIZED');
-
-    if (unauthIndex === -1) {
-      return title;
-    }
-
-    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our troubleshooting guide for cluster connections in our documentation https://kubeshop.github.io/monokle/cluster-issues for steps on how to resolve this issue.\n\n
-      
-    Error:\n
-    ${title}`;
-  };
-
   useEffect(() => {
     if (!alert) {
       return;
@@ -50,7 +38,7 @@ const MessageBox: React.FC = () => {
       // @ts-ignore
       notification[notificationType]({
         key: alert.id,
-        message: modify(alert.title),
+        message: enhanceErrorMessage(alert.title),
         description: <NotificationMarkdown notification={alert} type={notificationType} />,
         duration: alert.duration || 4,
       });

--- a/src/components/organisms/NotificationsManager/Notification.tsx
+++ b/src/components/organisms/NotificationsManager/Notification.tsx
@@ -48,6 +48,20 @@ const Notification: React.FC<NotificationProps> = props => {
     setCopyToClipboardState(true);
   };
 
+  const modify = (title1: string) => {
+    const wordsArray = title1.split(' ');
+    const unauthIndex = wordsArray.indexOf('UNAUTHORIZED');
+
+    if (unauthIndex === -1) {
+      return title1;
+    }
+
+    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our troubleshooting guide for cluster connections in our documentation https://kubeshop.github.io/monokle/cluster-issues for steps on how to resolve this issue.\n\n
+      
+    Error:\n
+    ${title1}`;
+  };
+
   return (
     <S.NotificationContainer $isNew={!hasSeen} $type={type} key={notification.id}>
       <S.DateSpan>
@@ -60,7 +74,7 @@ const Notification: React.FC<NotificationProps> = props => {
           <S.CopyOutlined onClick={onCopyToClipboard} />
         </Tooltip>
         <S.MessageBodyContainer>
-          <S.TitleSpan>{title}</S.TitleSpan>
+          <S.TitleSpan>{modify(title)}</S.TitleSpan>
           <S.MessageSpan>
             <NotificationMarkdown notification={notification} type={notificationType} />
           </S.MessageSpan>

--- a/src/components/organisms/NotificationsManager/Notification.tsx
+++ b/src/components/organisms/NotificationsManager/Notification.tsx
@@ -56,7 +56,7 @@ const Notification: React.FC<NotificationProps> = props => {
       return title1;
     }
 
-    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our troubleshooting guide for cluster connections in our documentation https://kubeshop.github.io/monokle/cluster-issues for steps on how to resolve this issue.\n\n
+    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our [troubleshooting guide for cluster connections in our documentation](https://kubeshop.github.io/monokle/cluster-issues/) for steps on how to resolve this issue.\n\n
       
     Error:\n
     ${title1}`;

--- a/src/components/organisms/NotificationsManager/Notification.tsx
+++ b/src/components/organisms/NotificationsManager/Notification.tsx
@@ -12,6 +12,8 @@ import {NotificationMarkdown} from '@molecules';
 
 import {useCopyToClipboard} from '@hooks/useCopyToClipboard';
 
+import enhanceErrorMessage from '@utils/notification';
+
 import * as S from './Notification.styled';
 
 type NotificationProps = {
@@ -48,20 +50,6 @@ const Notification: React.FC<NotificationProps> = props => {
     setCopyToClipboardState(true);
   };
 
-  const modify = (title1: string) => {
-    const wordsArray = title1.split(' ');
-    const unauthIndex = wordsArray.indexOf('UNAUTHORIZED');
-
-    if (unauthIndex === -1) {
-      return title1;
-    }
-
-    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our [troubleshooting guide for cluster connections in our documentation](https://kubeshop.github.io/monokle/cluster-issues/) for steps on how to resolve this issue.\n\n
-      
-    Error:\n
-    ${title1}`;
-  };
-
   return (
     <S.NotificationContainer $isNew={!hasSeen} $type={type} key={notification.id}>
       <S.DateSpan>
@@ -74,7 +62,7 @@ const Notification: React.FC<NotificationProps> = props => {
           <S.CopyOutlined onClick={onCopyToClipboard} />
         </Tooltip>
         <S.MessageBodyContainer>
-          <S.TitleSpan>{modify(title)}</S.TitleSpan>
+          <S.TitleSpan>{enhanceErrorMessage(title)}</S.TitleSpan>
           <S.MessageSpan>
             <NotificationMarkdown notification={notification} type={notificationType} />
           </S.MessageSpan>

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,0 +1,14 @@
+const enhanceErrorMessage = (message: string) => {
+  const isUnauthorizedError = message.toLowerCase().includes('unauthorized');
+
+  if (!isUnauthorizedError) {
+    return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our [troubleshooting guide for cluster connections in our documentation](https://kubeshop.github.io/monokle/cluster-issues/) for steps on how to resolve this issue.\n\n
+      
+        Error:\n
+        ${message}`;
+  }
+
+  return message;
+};
+
+export default enhanceErrorMessage;

--- a/src/utils/notification.ts
+++ b/src/utils/notification.ts
@@ -1,7 +1,7 @@
 const enhanceErrorMessage = (message: string) => {
   const isUnauthorizedError = message.toLowerCase().includes('unauthorized');
 
-  if (!isUnauthorizedError) {
+  if (isUnauthorizedError) {
     return `We're sorry, it looks like you're not authorized to connect to this cluster. Please take a look at our [troubleshooting guide for cluster connections in our documentation](https://kubeshop.github.io/monokle/cluster-issues/) for steps on how to resolve this issue.\n\n
       
         Error:\n


### PR DESCRIPTION
## Changes

Whenever a notification message contains the word "unauthorized", i've replaced that with the text given in the issue #3016 

## Checklist

- [x] tested locally
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test
