### PR TITLE
fix: config selectors re-rendering

### DIFF
--- a/src/redux/selectors.ts
+++ b/src/redux/selectors.ts
@@ -11,6 +11,7 @@ import {Colors} from '@shared/styles/colors';
 import {isDefined} from '@shared/utils/filter';
 
 import {getResourceMetaMapFromState} from './selectors/resourceMapGetters';
+import {createDeepEqualSelector} from './selectors/utils';
 import {isKustomizationResource} from './services/kustomize';
 import {mergeConfigs, populateProjectConfig} from './services/projectConfig';
 
@@ -159,9 +160,7 @@ export const isInPreviewModeSelectorNew = createSelector(
   }
 );
 
-// TODO: is this recomputin each time the state.config changes?
-// should we use the deep euqality check?
-export const currentConfigSelector = createSelector(
+export const currentConfigSelector = createDeepEqualSelector(
   (state: RootState) => state.config,
   config => {
     const applicationConfig: ProjectConfig = populateProjectConfig(config);
@@ -170,15 +169,15 @@ export const currentConfigSelector = createSelector(
   }
 );
 
-export const settingsSelector = createSelector(currentConfigSelector, currentConfig => {
+export const settingsSelector = createDeepEqualSelector(currentConfigSelector, currentConfig => {
   return currentConfig.settings || {};
 });
 
-export const scanExcludesSelector = createSelector(currentConfigSelector, currentConfig => {
+export const scanExcludesSelector = createDeepEqualSelector(currentConfigSelector, currentConfig => {
   return currentConfig.scanExcludes || [];
 });
 
-export const fileIncludesSelector = createSelector(currentConfigSelector, currentConfig => {
+export const fileIncludesSelector = createDeepEqualSelector(currentConfigSelector, currentConfig => {
   currentConfig.fileIncludes || [];
 });
 


### PR DESCRIPTION
The `currentConfigSelector` always returns a new object because of the `mergeConfig` function, so we should use the deep equal selector to check if it's outpus has actually changed, otherwise it will re-render components even if it doesn't change.
All other selectors that depend on the currentConfigSelector must also be deeply compared.