### PR TITLE
fix: validation for k8s schema

### DIFF
--- a/src/components/molecules/FormEditor/FormWidgets/ApiGroupSelection.tsx
+++ b/src/components/molecules/FormEditor/FormWidgets/ApiGroupSelection.tsx
@@ -39,6 +39,8 @@ export const ApiGroupSelection = (params: any) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  // TODO: 2.0+ this is not reactive, it will only be called once
+  // we need to get the registered kinds from the state and populate an array of kind handlers
   useEffect(() => {
     setApiGroups(
       uniq(

--- a/src/redux/reducers/appConfig.ts
+++ b/src/redux/reducers/appConfig.ts
@@ -1,6 +1,6 @@
 import {ipcRenderer} from 'electron';
 
-import {Draft, PayloadAction, createAsyncThunk, createSlice} from '@reduxjs/toolkit';
+import {Draft, PayloadAction, createAsyncThunk, createSlice, isAnyOf} from '@reduxjs/toolkit';
 
 import flatten from 'flat';
 import {existsSync, mkdirSync} from 'fs';
@@ -21,13 +21,16 @@ import {
   writeProjectConfigFile,
 } from '@redux/services/projectConfig';
 import {monitorProjectConfigFile} from '@redux/services/projectConfigMonitor';
+import {getResourceKindSchema} from '@redux/services/schema';
 import {setRootFolder} from '@redux/thunks/setRootFolder';
 import {createNamespace, removeNamespaceFromCluster} from '@redux/thunks/utils';
+import {VALIDATOR} from '@redux/validation/validator';
 
 import {promiseFromIpcRenderer} from '@utils/promises';
 
-import {readSavedCrdKindHandlers} from '@src/kindhandlers';
+import {ResourceKindHandlers, readSavedCrdKindHandlers} from '@src/kindhandlers';
 
+import {CustomSchema} from '@monokle/validation';
 import {init as sentryInit} from '@sentry/electron/renderer';
 import {PREDEFINED_K8S_VERSION} from '@shared/constants/k8s';
 import {ClusterColors} from '@shared/models/cluster';
@@ -591,6 +594,31 @@ export const crdsPathChangedListener: AppListenerFn = listen => {
         (window as any).monokleUserCrdsDir = crdsDir;
         readSavedCrdKindHandlers(crdsDir);
       }
+    },
+  });
+};
+
+export const k8sVersionSchemaListener: AppListenerFn = listen => {
+  listen({
+    matcher: isAnyOf(setOpenProject.fulfilled),
+    effect: async (action, {getState}) => {
+      const state = getState().config;
+      const k8sVersion = state.projectConfig?.k8sVersion || state.k8sVersion;
+      const userDataDir = state.userDataDir;
+      if (!userDataDir) {
+        return;
+      }
+
+      const schemas: CustomSchema[] = ResourceKindHandlers.filter(h => !h.isCustom).map(kindHandler => {
+        const schema = getResourceKindSchema(kindHandler.kind, k8sVersion, userDataDir);
+        return {
+          apiVersion: kindHandler.clusterApiVersion,
+          kind: kindHandler.kind,
+          schema,
+        };
+      });
+
+      await VALIDATOR.bulkRegisterCustomSchemas(schemas);
     },
   });
 };

--- a/src/redux/services/resource.ts
+++ b/src/redux/services/resource.ts
@@ -339,9 +339,7 @@ export function extractK8sResources<
         }
 
         log.warn(
-          `Ignoring document ${docIndex} in ${JSON.stringify(origin)} origin due to ${doc.errors.length} error(s)`,
-          documents[docIndex],
-          splitDocs && docIndex < splitDocs.length ? splitDocs[docIndex] : ''
+          `Ignoring document ${docIndex} in ${JSON.stringify(origin)} origin due to ${doc.errors.length} error(s)`
         );
       } else {
         if (doc.warnings.length > 0) {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -11,7 +11,7 @@ import {formSlice} from './forms';
 import {gitSlice} from './git';
 import {combineListeners, listenerMiddleware} from './listeners/base';
 import {alertSlice} from './reducers/alert';
-import {configSlice, crdsPathChangedListener} from './reducers/appConfig';
+import {configSlice, crdsPathChangedListener, k8sVersionSchemaListener} from './reducers/appConfig';
 import {extensionSlice} from './reducers/extension';
 import {mainSlice} from './reducers/main';
 import {imageListParserListener} from './reducers/main/mainListeners';
@@ -40,6 +40,7 @@ combineListeners([
   compareListeners.compareListener,
   compareListeners.filterListener,
   removedTerminalListener,
+  k8sVersionSchemaListener,
   crdsPathChangedListener,
   ...validationListeners,
   imageListParserListener,

--- a/src/redux/validation/validation.worker.ts
+++ b/src/redux/validation/validation.worker.ts
@@ -4,8 +4,6 @@ import {WorkerMessage, matchWorkerEvent} from '@utils/worker';
 import {ResourceParser, SchemaLoader, createDefaultMonokleValidator} from '@monokle/validation';
 
 import {
-  BulkRegisterCustomSchemaMessage,
-  BulkRegisterCustomSchemaMessageType,
   LoadValidationMessage,
   LoadValidationMessageType,
   RegisterCustomSchemaMessage,
@@ -48,12 +46,13 @@ onmessage = async event => {
 
   handleEvent<RegisterCustomSchemaMessage>(event, RegisterCustomSchemaMessageType, async () => {
     const {input} = data as RegisterCustomSchemaMessage;
-    await VALIDATOR.registerCustomSchema(input.schema);
-  });
-
-  handleEvent<BulkRegisterCustomSchemaMessage>(event, BulkRegisterCustomSchemaMessageType, async () => {
-    const {input} = data as BulkRegisterCustomSchemaMessage;
-    await Promise.all(input.schemas.map(schema => VALIDATOR.registerCustomSchema(schema)));
+    try {
+      await VALIDATOR.registerCustomSchema(input.schema);
+    } catch {
+      // we cannot use loglevel here because this is a worker
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to register custom schema for ${input.schema.apiVersion}/${input.schema.kind}`);
+    }
   });
 };
 

--- a/src/redux/validation/validation.worker.ts
+++ b/src/redux/validation/validation.worker.ts
@@ -4,8 +4,12 @@ import {WorkerMessage, matchWorkerEvent} from '@utils/worker';
 import {ResourceParser, SchemaLoader, createDefaultMonokleValidator} from '@monokle/validation';
 
 import {
+  BulkRegisterCustomSchemaMessage,
+  BulkRegisterCustomSchemaMessageType,
   LoadValidationMessage,
   LoadValidationMessageType,
+  RegisterCustomSchemaMessage,
+  RegisterCustomSchemaMessageType,
   RunValidationMessage,
   RunValidationMessageType,
 } from './validation.worker.types';
@@ -40,6 +44,16 @@ onmessage = async event => {
     const {input} = data as RunValidationMessage;
     const response = await VALIDATOR.validate({resources: input.resources, incremental: input.incremental});
     return {response};
+  });
+
+  handleEvent<RegisterCustomSchemaMessage>(event, RegisterCustomSchemaMessageType, async () => {
+    const {input} = data as RegisterCustomSchemaMessage;
+    await VALIDATOR.registerCustomSchema(input.schema);
+  });
+
+  handleEvent<BulkRegisterCustomSchemaMessage>(event, BulkRegisterCustomSchemaMessageType, async () => {
+    const {input} = data as BulkRegisterCustomSchemaMessage;
+    await Promise.all(input.schemas.map(schema => VALIDATOR.registerCustomSchema(schema)));
   });
 };
 

--- a/src/redux/validation/validation.worker.types.ts
+++ b/src/redux/validation/validation.worker.types.ts
@@ -5,6 +5,7 @@ import {Config, CustomSchema, Incremental, Resource, ValidationResponse} from '@
 export const LoadValidationMessageType = 'loadValidation' as const;
 export const RunValidationMessageType = 'runValidation' as const;
 export const RegisterCustomSchemaMessageType = 'registerCustomSchema' as const;
+export const BulkRegisterCustomSchemaMessageType = 'bulkRegisterCustomSchema' as const;
 
 export interface LoadValidationMessage extends WorkerMessage {
   type: typeof LoadValidationMessageType;
@@ -30,7 +31,13 @@ export interface RegisterCustomSchemaMessage extends WorkerMessage {
   input: {
     schema: CustomSchema;
   };
-  output: {
-    response: void;
+  output: void;
+}
+
+export interface BulkRegisterCustomSchemaMessage extends WorkerMessage {
+  type: typeof BulkRegisterCustomSchemaMessageType;
+  input: {
+    schemas: CustomSchema[];
   };
+  output: void;
 }

--- a/src/redux/validation/validation.worker.types.ts
+++ b/src/redux/validation/validation.worker.types.ts
@@ -5,7 +5,6 @@ import {Config, CustomSchema, Incremental, Resource, ValidationResponse} from '@
 export const LoadValidationMessageType = 'loadValidation' as const;
 export const RunValidationMessageType = 'runValidation' as const;
 export const RegisterCustomSchemaMessageType = 'registerCustomSchema' as const;
-export const BulkRegisterCustomSchemaMessageType = 'bulkRegisterCustomSchema' as const;
 
 export interface LoadValidationMessage extends WorkerMessage {
   type: typeof LoadValidationMessageType;
@@ -30,14 +29,6 @@ export interface RegisterCustomSchemaMessage extends WorkerMessage {
   type: typeof RegisterCustomSchemaMessageType;
   input: {
     schema: CustomSchema;
-  };
-  output: void;
-}
-
-export interface BulkRegisterCustomSchemaMessage extends WorkerMessage {
-  type: typeof BulkRegisterCustomSchemaMessageType;
-  input: {
-    schemas: CustomSchema[];
   };
   output: void;
 }

--- a/src/redux/validation/validator.ts
+++ b/src/redux/validation/validator.ts
@@ -5,6 +5,7 @@ import {createWorkerEventPromise} from '@utils/worker';
 import {MonokleValidator, SchemaLoader, createDefaultMonokleValidator} from '@monokle/validation';
 
 import {
+  BulkRegisterCustomSchemaMessage,
   LoadValidationMessage,
   LoadValidationMessageType,
   RegisterCustomSchemaMessage,
@@ -44,6 +45,15 @@ class ValidationWorker {
   runValidation(input: RunValidationMessage['input']) {
     return createWorkerEventPromise<RunValidationMessage['output']>({
       type: RunValidationMessageType,
+      worker: this.#worker,
+      input,
+    });
+  }
+
+  async bulkRegisterCustomSchemas(input: BulkRegisterCustomSchemaMessage['input']) {
+    await Promise.all(input.schemas.map(schema => this.#validator.registerCustomSchema(schema)));
+    return createWorkerEventPromise<BulkRegisterCustomSchemaMessage['output']>({
+      type: RegisterCustomSchemaMessageType,
       worker: this.#worker,
       input,
     });

--- a/src/redux/validation/validator.ts
+++ b/src/redux/validation/validator.ts
@@ -1,11 +1,12 @@
+import log from 'loglevel';
+
 import {RESOURCE_PARSER} from '@redux/parsing/resourceParser';
 
 import {createWorkerEventPromise} from '@utils/worker';
 
-import {MonokleValidator, SchemaLoader, createDefaultMonokleValidator} from '@monokle/validation';
+import {CustomSchema, MonokleValidator, SchemaLoader, createDefaultMonokleValidator} from '@monokle/validation';
 
 import {
-  BulkRegisterCustomSchemaMessage,
   LoadValidationMessage,
   LoadValidationMessageType,
   RegisterCustomSchemaMessage,
@@ -50,17 +51,16 @@ class ValidationWorker {
     });
   }
 
-  async bulkRegisterCustomSchemas(input: BulkRegisterCustomSchemaMessage['input']) {
-    await Promise.all(input.schemas.map(schema => this.#validator.registerCustomSchema(schema)));
-    return createWorkerEventPromise<BulkRegisterCustomSchemaMessage['output']>({
-      type: RegisterCustomSchemaMessageType,
-      worker: this.#worker,
-      input,
-    });
+  async bulkRegisterCustomSchemas(schemas: CustomSchema[]) {
+    await Promise.all(schemas.map(schema => this.registerCustomSchema(schema)));
   }
 
   async registerCustomSchema(input: RegisterCustomSchemaMessage['input']) {
-    await this.#validator.registerCustomSchema(input.schema);
+    try {
+      await this.#validator.registerCustomSchema(input.schema);
+    } catch {
+      log.warn(`Failed to register custom schema for ${input.schema.apiVersion}/${input.schema.kind}`);
+    }
     return createWorkerEventPromise<RegisterCustomSchemaMessage['output']>({
       type: RegisterCustomSchemaMessageType,
       worker: this.#worker,


### PR DESCRIPTION
- adds a listener on `setOpenProject`
- loops through all the core kind handlers to get the schemas
- registers the schemas in the validator