### PR TITLE
fix: kustomization preview empty editor

### DIFF
--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -313,6 +313,8 @@ const Monaco: React.FC<IProps> = props => {
       const resourceContent =
         selectedResource.storage === 'transient'
           ? transientResourceContentMapRef.current[selectedResource.id]
+          : selectedResource.kind === 'Kustomization'
+          ? localResourceContentMapRef.current?.[selectedResource.id]
           : activeResourceContentMapRef.current?.[selectedResource.id];
       if (resourceContent) {
         if (codeRef.current === resourceContent.text) {

--- a/src/components/molecules/Monaco/Monaco.tsx
+++ b/src/components/molecules/Monaco/Monaco.tsx
@@ -349,13 +349,13 @@ const Monaco: React.FC<IProps> = props => {
     isDirtyRef.current = false;
   }, [
     selectedFilePath,
-    selectedResource?.id,
-    selectedResource?.storage,
+    selectedResource,
     codeRef,
     activeResourceContentMapRef,
     transientResourceContentMapRef,
     fileMapRef,
     setCode,
+    localResourceContentMapRef,
   ]);
 
   useEffect(() => {

--- a/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
+++ b/src/navsections/KustomizationSectionBlueprint/KustomizationSectionBlueprint.ts
@@ -2,7 +2,7 @@ import {isInClusterModeSelector} from '@redux/appConfig';
 import {selectResource} from '@redux/reducers/main';
 import {getResourceMetaMapFromState} from '@redux/selectors/resourceMapGetters';
 import {isKustomizationResource} from '@redux/services/kustomize';
-import {isKustomizationPreviewed, isResourceHighlighted, isResourceSelected} from '@redux/services/resource';
+import {isResourceHighlighted, isResourceSelected} from '@redux/services/resource';
 
 import {isResourcePassingFilter} from '@utils/resources';
 
@@ -86,8 +86,7 @@ const KustomizationSectionBlueprint: SectionBlueprint<ResourceMeta<'local'>, Kus
     getName: rawItem => rawItem.name,
     getInstanceId: rawItem => rawItem.id,
     builder: {
-      isSelected: (rawItem, scope) =>
-        isResourceSelected(rawItem, scope.selection) || isKustomizationPreviewed(rawItem, scope.preview),
+      isSelected: (rawItem, scope) => isResourceSelected(rawItem, scope.selection),
       isHighlighted: (rawItem, scope) => isResourceHighlighted(rawItem, scope.highlights),
       isDisabled: (rawItem, scope) =>
         Boolean(


### PR DESCRIPTION
## Fixes

- Show content of kustomization when previewing it
- Don't have kustomization selected in preview if a resource is selected

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
