### PR TITLE
chore: remove bulk cluster connection notifications on access check

### DIFF
--- a/electron/app/KubeConfigManager.ts
+++ b/electron/app/KubeConfigManager.ts
@@ -54,16 +54,18 @@ const handleKubeServiceMessage = (message: AnyAction) => {
         dispatchToAllWindows({type: 'config/setAccessLoading', payload: true});
         dispatchToAllWindows({type: 'config/addNamespaceToContext', payload: clusterAccess});
       })
-      .catch(() => {
-        dispatchToAllWindows({
-          type: 'alert/setAlert',
-          payload: {
-            type: AlertEnum.Warning,
-            title: 'Cluster Watcher Error',
-            message:
-              "We're unable to watch for namespaces changes in your cluster. This may be due to a lack of permissions.",
-          },
-        });
+      .catch((e: any) => {
+        if (e.code !== 'CLUSTER_ACCESS_FAILED') {
+          dispatchToAllWindows({
+            type: 'alert/setAlert',
+            payload: {
+              type: AlertEnum.Warning,
+              title: 'Cluster Watcher Error',
+              message:
+                "We're unable to watch for namespaces changes in your cluster. This may be due to a lack of permissions.",
+            },
+          });
+        }
         dispatchToAllWindows({type: 'config/setAccessLoading', payload: false});
       });
   }

--- a/src/components/organisms/SettingsPane/Settings/Settings.tsx
+++ b/src/components/organisms/SettingsPane/Settings/Settings.tsx
@@ -5,8 +5,6 @@ import {Button, Checkbox, Form, Input, InputNumber, InputRef, Select, Tooltip} f
 import {CheckboxChangeEvent} from 'antd/lib/checkbox';
 import {useForm} from 'antd/lib/form/Form';
 
-import {ReloadOutlined} from '@ant-design/icons';
-
 import _ from 'lodash';
 import log from 'loglevel';
 
@@ -309,23 +307,20 @@ export const Settings = ({
           </S.Heading>
 
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={KubeconfigPathTooltip}>
-            <Input
+            <Input.Search
               ref={inputRef}
               onClick={() => focusInput()}
               value={currentKubeConfig}
               onChange={onUpdateKubeconfig}
               disabled={isEditingDisabled}
+              loading={!isKubeConfigBrowseSettingsOpen}
             />
           </Tooltip>
 
           <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={BrowseKubeconfigTooltip} placement="right">
-            {isKubeConfigBrowseSettingsOpen ? (
-              <S.Button onClick={openFileSelect} disabled={isEditingDisabled}>
-                Browse
-              </S.Button>
-            ) : (
-              <ReloadOutlined style={{padding: '1em'}} spin />
-            )}
+            <S.Button onClick={openFileSelect} disabled={isEditingDisabled || !isKubeConfigBrowseSettingsOpen}>
+              Browse
+            </S.Button>
           </Tooltip>
           <S.HiddenInput type="file" onChange={onSelectFile} ref={fileInput} />
         </S.Div>

--- a/src/shared/utils/kubeclient.ts
+++ b/src/shared/utils/kubeclient.ts
@@ -125,7 +125,12 @@ export const getKubeAccess = async (namespace: string, currentContext: string): 
   if (hasErrors) {
     const errors = result.stderr;
     log.error(`get cluster access errors ${errors}`);
-    throw new Error(`Couldn't get cluster access for namespaces. Errors: ${JSON.stringify(errors)}`);
+    // Shall we create CustomErrors to handle different error types?
+    const clusterAccessError = new Error(
+      `Couldn't get cluster access for namespaces. Errors: ${JSON.stringify(errors)}`
+    );
+    (clusterAccessError as any).code = 'CLUSTER_ACCESS_FAILED';
+    throw clusterAccessError;
   }
   const stdout = result.stdout;
   if (typeof stdout !== 'string') {


### PR DESCRIPTION
This PR throws a custom error on Cluster Connection error on the namespace access check and it doesn't throw notifications for every namespace. So hopefully it will not bother the users.

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
