### PR TITLE
fix: consistent YAML parsing/stringification and octal formatting

### DIFF
--- a/src/components/molecules/FormEditor/FormEditor.tsx
+++ b/src/components/molecules/FormEditor/FormEditor.tsx
@@ -9,7 +9,6 @@ import {TemplatesType} from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 import log from 'loglevel';
-import {stringify} from 'yaml';
 
 import {DEFAULT_EDITOR_DEBOUNCE} from '@constants/constants';
 
@@ -27,7 +26,7 @@ import {updateResource} from '@redux/thunks/updateResource';
 import {ErrorPage} from '@components/organisms/ErrorPage/ErrorPage';
 
 import {useStateWithRef} from '@utils/hooks';
-import {parseYamlDocument} from '@utils/yaml';
+import {parseYamlDocument, stringifyK8sResource} from '@utils/yaml';
 
 import {isHelmChartFile} from '@shared/utils';
 import {isEqual} from '@shared/utils/isEqual';
@@ -90,7 +89,7 @@ const FormEditor: React.FC<IProps> = props => {
         return;
       }
 
-      let formString = stringify(formData);
+      let formString = stringifyK8sResource(formData);
 
       if (selectedResource) {
         const content = mergeManifests(selectedResource.text, formString);

--- a/src/components/molecules/ResourceDiff/ResourceDiff.tsx
+++ b/src/components/molecules/ResourceDiff/ResourceDiff.tsx
@@ -6,7 +6,7 @@ import {Button, Switch} from 'antd';
 
 import {ArrowLeftOutlined, ArrowRightOutlined} from '@ant-design/icons';
 
-import {parse, stringify} from 'yaml';
+import {parse} from 'yaml';
 
 import {makeApplyKustomizationText, makeApplyResourceText} from '@constants/makeApplyText';
 
@@ -21,6 +21,7 @@ import useResourceYamlSchema from '@hooks/useResourceYamlSchema';
 import {useWindowSize} from '@utils/hooks';
 import {KUBESHOP_MONACO_THEME} from '@utils/monaco';
 import {removeIgnoredPathsFromResourceObject} from '@utils/resources';
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {Icon} from '@monokle/components';
 import {K8sResource} from '@shared/models/k8sResource';
@@ -74,7 +75,7 @@ const ResourceDiff = (props: {
 
   // TODO: can't we just use localResource.text here?
   const localResourceText = useMemo(() => {
-    return stringify(localResource.object, {sortMapEntries: true});
+    return stringifyK8sResource(localResource.object, {sortMapEntries: true});
   }, [localResource]);
 
   const cleanClusterResourceText = useMemo(() => {
@@ -84,7 +85,7 @@ const ResourceDiff = (props: {
     const originalClusterResourceContent = parse(clusterResourceText);
     const cleanClusterResourceContent = removeIgnoredPathsFromResourceObject(originalClusterResourceContent);
 
-    return stringify(cleanClusterResourceContent, {sortMapEntries: true});
+    return stringifyK8sResource(cleanClusterResourceContent, {sortMapEntries: true});
   }, [clusterResourceText, shouldDiffIgnorePaths]);
 
   const areResourcesDifferent = useMemo(() => {

--- a/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
+++ b/src/components/molecules/SaveResourcesToFileFolderModal/SaveResourcesToFileFolderModal.tsx
@@ -9,7 +9,6 @@ import {isEmpty} from 'lodash';
 import micromatch from 'micromatch';
 import path from 'path';
 import util from 'util';
-import {stringify} from 'yaml';
 
 import {YAML_DOCUMENT_DELIMITER} from '@constants/constants';
 
@@ -26,6 +25,7 @@ import {useFileExplorer} from '@hooks/useFileExplorer';
 
 import {useRefSelector} from '@utils/hooks';
 import {removeIgnoredPathsFromResourceObject} from '@utils/resources';
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {ROOT_FILE_ENTRY} from '@shared/constants/fileEntry';
 import {AlertEnum} from '@shared/models/alert';
@@ -220,7 +220,7 @@ const SaveResourcesToFileFolderModal: React.FC = () => {
         // TODO: this should probably become a thunk that can get the resource content from the store
         // because it would be nicer to not require us to have the entire resourceContentMapByStorage in this component
         const cleanResourceContent = removeIgnoredPathsFromResourceObject(resource.object);
-        let resourceText = stringify(cleanResourceContent, {sortMapEntries: true});
+        let resourceText = stringifyK8sResource(cleanResourceContent, {sortMapEntries: true});
 
         if (savingDestination === 'appendToFile') {
           if (resourceText.trim().endsWith(YAML_DOCUMENT_DELIMITER)) {

--- a/src/components/organisms/ClusterResourceDiffModal/ClusterResourceDiffModal.tsx
+++ b/src/components/organisms/ClusterResourceDiffModal/ClusterResourceDiffModal.tsx
@@ -8,8 +8,6 @@ import {Button, Select, Skeleton, Switch} from 'antd';
 
 import {ArrowLeftOutlined, ArrowRightOutlined} from '@ant-design/icons';
 
-import {stringify} from 'yaml';
-
 import {ClusterName, makeApplyKustomizationText, makeApplyResourceText} from '@constants/makeApplyText';
 
 import {isInClusterModeSelector, kubeConfigContextColorSelector, kubeConfigContextSelector} from '@redux/appConfig';
@@ -26,6 +24,7 @@ import {ModalConfirmWithNamespaceSelect} from '@molecules';
 
 import {KUBESHOP_MONACO_THEME} from '@utils/monaco';
 import {removeIgnoredPathsFromResourceObject} from '@utils/resources';
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {AlertEnum, AlertType} from '@shared/models/alert';
 import {K8sResource} from '@shared/models/k8sResource';
@@ -90,10 +89,10 @@ const ClusterResourceDiffModal = () => {
     }
 
     if (!shouldDiffIgnorePaths) {
-      return stringify(targetResource.object, {sortMapEntries: true});
+      return stringifyK8sResource(targetResource.object, {sortMapEntries: true});
     }
 
-    return stringify(removeIgnoredPathsFromResourceObject(targetResource.object, targetResource.namespace), {
+    return stringifyK8sResource(removeIgnoredPathsFromResourceObject(targetResource.object, targetResource.namespace), {
       sortMapEntries: true,
     });
   }, [isDiffModalVisible, shouldDiffIgnorePaths, targetResource]);
@@ -168,7 +167,7 @@ const ClusterResourceDiffModal = () => {
     }
 
     setSelectedMatchingResourceId(resourceId);
-    setMatchingResourceText(stringify(matchingLocalResources[resourceId].object, {sortMapEntries: true}));
+    setMatchingResourceText(stringifyK8sResource(matchingLocalResources[resourceId].object, {sortMapEntries: true}));
   };
 
   const handleApply = () => {
@@ -230,7 +229,7 @@ const ClusterResourceDiffModal = () => {
       if (foundResource) {
         hasLocalMatchingResource = true;
         setSelectedMatchingResourceId(foundResource.id);
-        setMatchingResourceText(stringify(foundResource.object, {sortMapEntries: true}));
+        setMatchingResourceText(stringifyK8sResource(foundResource.object, {sortMapEntries: true}));
       }
     } else if (targetResource.namespace === 'default') {
       const foundResource = Object.values(matchingLocalResources).filter(
@@ -240,21 +239,23 @@ const ClusterResourceDiffModal = () => {
       if (foundResource) {
         hasLocalMatchingResource = true;
         setSelectedMatchingResourceId(foundResource.id);
-        setMatchingResourceText(stringify(foundResource.object, {sortMapEntries: true}));
+        setMatchingResourceText(stringifyK8sResource(foundResource.object, {sortMapEntries: true}));
       } else {
         const foundResourceWithoutNamespace = Object.values(matchingLocalResources).filter(r => !r.namespace)[0];
 
         if (foundResourceWithoutNamespace) {
           hasLocalMatchingResource = true;
           setSelectedMatchingResourceId(foundResourceWithoutNamespace.id);
-          setMatchingResourceText(stringify(foundResourceWithoutNamespace.object, {sortMapEntries: true}));
+          setMatchingResourceText(stringifyK8sResource(foundResourceWithoutNamespace.object, {sortMapEntries: true}));
         }
       }
     }
 
     if (!hasLocalMatchingResource) {
       setSelectedMatchingResourceId(Object.keys(matchingLocalResources)[0]);
-      setMatchingResourceText(stringify(Object.values(matchingLocalResources)[0].object, {sortMapEntries: true}));
+      setMatchingResourceText(
+        stringifyK8sResource(Object.values(matchingLocalResources)[0].object, {sortMapEntries: true})
+      );
     }
 
     setHasDiffModalLoaded(true);

--- a/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
+++ b/src/components/organisms/LocalResourceDiffModal/LocalResourceDiffModal.tsx
@@ -9,7 +9,6 @@ import {Button, Select, Skeleton, Switch} from 'antd';
 import {ArrowLeftOutlined, ArrowRightOutlined} from '@ant-design/icons';
 
 import {flatten} from 'lodash';
-import {stringify} from 'yaml';
 
 import {
   ClusterName,
@@ -38,6 +37,7 @@ import {ModalConfirm, ModalConfirmWithNamespaceSelect} from '@components/molecul
 import {useWindowSize} from '@utils/hooks';
 import {KUBESHOP_MONACO_THEME} from '@utils/monaco';
 import {removeIgnoredPathsFromResourceObject} from '@utils/resources';
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {getResourceKindHandler} from '@src/kindhandlers';
 
@@ -198,7 +198,7 @@ const DiffModal = () => {
     const newDiffContentObject = removeIgnoredPathsFromResourceObject(
       matchingResourcesById[selectedMatchingResourceId]
     );
-    const cleanDiffContentString = stringify(newDiffContentObject, {sortMapEntries: true});
+    const cleanDiffContentString = stringifyK8sResource(newDiffContentObject, {sortMapEntries: true});
     return cleanDiffContentString;
   }, [
     isDiffModalVisible,
@@ -292,7 +292,7 @@ const DiffModal = () => {
           hasClusterMatchingResource = true;
           setSelectedMathingResourceId(foundResourceFromCluster.metadata.uid);
           setDefaultNamespace(foundResourceFromCluster.metadata.namespace);
-          setMatchingResourceText(stringify(foundResourceFromCluster, {sortMapEntries: true}));
+          setMatchingResourceText(stringifyK8sResource(foundResourceFromCluster, {sortMapEntries: true}));
         }
       } else if (resourceFilter.namespaces) {
         const foundResourceFromCluster = resourcesFromCluster.find(r =>
@@ -302,20 +302,20 @@ const DiffModal = () => {
           hasClusterMatchingResource = true;
           setSelectedMathingResourceId(foundResourceFromCluster.metadata.uid);
           setDefaultNamespace(foundResourceFromCluster.metadata.namespace);
-          setMatchingResourceText(stringify(foundResourceFromCluster, {sortMapEntries: true}));
+          setMatchingResourceText(stringifyK8sResource(foundResourceFromCluster, {sortMapEntries: true}));
         }
       }
 
       if (!hasClusterMatchingResource) {
         setSelectedMathingResourceId(resourcesFromCluster[0].metadata.uid);
         setDefaultNamespace(resourcesFromCluster[0].metadata.namespace);
-        setMatchingResourceText(stringify(resourcesFromCluster[0], {sortMapEntries: true}));
+        setMatchingResourceText(stringifyK8sResource(resourcesFromCluster[0], {sortMapEntries: true}));
       }
 
       setHasDiffModalLoaded(true);
     };
 
-    setTargetResourceText(stringify(targetResource.object, {sortMapEntries: true}));
+    setTargetResourceText(stringifyK8sResource(targetResource.object, {sortMapEntries: true}));
     getClusterResources();
   }, [
     kubeConfigContext,

--- a/src/redux/services/__test__/yaml.test.ts
+++ b/src/redux/services/__test__/yaml.test.ts
@@ -1,0 +1,15 @@
+import {parseYamlDocument, stringifyK8sResource} from '@utils/yaml';
+
+test('handle octal values in schema', () => {
+  let yaml =
+    'kind: Deployment\n' +
+    'spec:\n' +
+    '  template:\n' +
+    '    spec:\n' +
+    '      volumes:\n' +
+    '        - secret:\n' +
+    '            defaultMode: 0644\n';
+
+  let obj = parseYamlDocument(yaml).toJS();
+  expect(stringifyK8sResource(obj)).toEqual(yaml);
+});

--- a/src/redux/services/manifest-utils.ts
+++ b/src/redux/services/manifest-utils.ts
@@ -1,7 +1,7 @@
 import log from 'loglevel';
-import {Document, LineCounter, ParsedNode, Scalar, isMap, isPair, isScalar, isSeq, parseDocument, visit} from 'yaml';
+import {Document, LineCounter, ParsedNode, Scalar, isMap, isPair, isScalar, isSeq, visit} from 'yaml';
 
-import {parseAllYamlDocuments} from '@utils/yaml';
+import {parseAllYamlDocuments, parseYamlDocument} from '@utils/yaml';
 
 import {K8sObject} from '@shared/models/k8s';
 
@@ -19,8 +19,8 @@ function copyValueIfMissing(templateDoc: Document.Parsed<ParsedNode>, path: read
  */
 
 export function mergeManifests(template: string, values: string) {
-  const templateDoc = parseDocument(template);
-  const valuesDoc = parseDocument(values);
+  const templateDoc = parseYamlDocument(template);
+  const valuesDoc = parseYamlDocument(values);
 
   const pathsToRemove: any[] = [];
 

--- a/src/redux/services/transientResource.ts
+++ b/src/redux/services/transientResource.ts
@@ -1,9 +1,8 @@
 import {v4 as uuidv4} from 'uuid';
-import {stringify} from 'yaml';
 
 import {addMultipleResources, addResource} from '@redux/reducers/main';
 
-import {parseYamlDocument} from '@utils/yaml';
+import {parseYamlDocument, stringifyK8sResource} from '@utils/yaml';
 
 import {getResourceKindHandler} from '@src/kindhandlers';
 
@@ -58,7 +57,7 @@ export function createTransientResource(
       };
     }
 
-    newResourceText = stringify(newResourceObject);
+    newResourceText = stringifyK8sResource(newResourceObject);
   } else {
     newResourceText = createDefaultResourceText(input);
     newResourceObject = parseYamlDocument(newResourceText).toJS();
@@ -102,7 +101,7 @@ export function createMultipleTransientResources(
           namespace: input.namespace,
         },
       };
-      resourceText = stringify(resourceObject);
+      resourceText = stringifyK8sResource(resourceObject);
     } else {
       resourceText = createDefaultResourceText(input);
       resourceObject = parseYamlDocument(resourceText).toJS();

--- a/src/redux/thunks/applyMultipleResources.ts
+++ b/src/redux/thunks/applyMultipleResources.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import log from 'loglevel';
-import {stringify} from 'yaml';
 
 import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
@@ -8,6 +7,8 @@ import {setAlert} from '@redux/reducers/alert';
 import {doesTextStartWithYamlDocumentDelimiter} from '@redux/services/resource';
 import {applyYamlToCluster} from '@redux/thunks/applyYaml';
 import {removeNamespaceFromCluster} from '@redux/thunks/utils';
+
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {AlertEnum, AlertType} from '@shared/models/alert';
 import {AppDispatch} from '@shared/models/appDispatch';
@@ -35,7 +36,7 @@ const applyMultipleResources = async (
         delete resourceObject.metadata.namespace;
       }
 
-      return stringify(resourceObject);
+      return stringifyK8sResource(resourceObject);
     })
     .reduce<string>((fullYaml, currentText) => {
       if (doesTextStartWithYamlDocumentDelimiter(currentText)) {

--- a/src/redux/thunks/applyResource.ts
+++ b/src/redux/thunks/applyResource.ts
@@ -2,7 +2,6 @@ import {createAsyncThunk} from '@reduxjs/toolkit';
 
 import _, {cloneDeep} from 'lodash';
 import log from 'loglevel';
-import {stringify} from 'yaml';
 
 import {currentConfigSelector, kubeConfigContextSelector} from '@redux/appConfig';
 import {setAlert} from '@redux/reducers/alert';
@@ -16,6 +15,7 @@ import {updateResource} from '@redux/thunks/updateResource';
 import {getResourceFromCluster, removeNamespaceFromCluster} from '@redux/thunks/utils';
 
 import {errorAlert, successAlert} from '@utils/alert';
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {AlertEnum, AlertType} from '@shared/models/alert';
 import {AppDispatch} from '@shared/models/appDispatch';
@@ -48,7 +48,7 @@ function applyK8sResource(
   }
 
   return applyYamlToCluster({
-    yaml: stringify(resourceObject),
+    yaml: stringifyK8sResource(resourceObject),
     context,
     kubeconfig,
     namespace,
@@ -137,7 +137,7 @@ export async function applyResource(
           if (options?.isInClusterMode && kubeconfigPath) {
             getResourceFromCluster(resourceMeta, kubeconfigPath, context).then(resourceFromCluster => {
               delete resourceFromCluster?.metadata?.managedFields;
-              const updatedResourceText = stringify(resourceFromCluster, {sortMapEntries: true});
+              const updatedResourceText = stringifyK8sResource(resourceFromCluster, {sortMapEntries: true});
               if (resourceContentMapByStorage.cluster[resourceFromCluster?.metadata?.uid]) {
                 dispatch(
                   updateResource({

--- a/src/redux/thunks/renameResource.ts
+++ b/src/redux/thunks/renameResource.ts
@@ -1,6 +1,6 @@
-import {stringify} from 'yaml';
-
 import {updateResource} from '@redux/thunks/updateResource';
+
+import {stringifyK8sResource} from '@utils/yaml';
 
 import {isIncomingRef} from '@monokle/validation';
 import {AppDispatch} from '@shared/models/appDispatch';
@@ -25,7 +25,7 @@ export const renameResource = (
       name: newResourceName,
     },
   };
-  const newResourceText = stringify(newResourceObject);
+  const newResourceText = stringifyK8sResource(newResourceObject);
   if (shouldUpdateRefs && resource.refs) {
     resource.refs.forEach(ref => {
       if (!isIncomingRef(ref.type) || !(ref.target?.type === 'resource' && ref.target.resourceId)) {

--- a/src/redux/thunks/utils.ts
+++ b/src/redux/thunks/utils.ts
@@ -5,6 +5,8 @@ import {stringify} from 'yaml';
 
 import {YAML_DOCUMENT_DELIMITER_NEW_LINE} from '@constants/constants';
 
+import {stringifyK8sResource} from '@utils/yaml';
+
 import {getResourceKindHandler} from '@src/kindhandlers';
 
 import {AlertEnum} from '@shared/models/alert';
@@ -25,7 +27,7 @@ export function getK8sObjectsAsYaml(items: any[], kind?: string, apiVersion?: st
         return `apiVersion: ${apiVersion}\nkind: ${kind}\n${stringify(item)}`;
       }
 
-      return stringify(item);
+      return stringifyK8sResource(item);
     })
     .join(YAML_DOCUMENT_DELIMITER_NEW_LINE);
 }

--- a/src/utils/crds.ts
+++ b/src/utils/crds.ts
@@ -1,6 +1,7 @@
 import log from 'loglevel';
 import path from 'path';
-import {parseAllDocuments} from 'yaml';
+
+import {parseAllYamlDocuments} from '@utils/yaml';
 
 import {createFolder, deleteFile, doesPathExist, writeFile} from '@shared/utils/fileSystem';
 
@@ -10,7 +11,7 @@ export async function saveCRD(crdsDir: string, crdContent: string) {
     await createFolder(crdsDir);
   }
   try {
-    const documents = parseAllDocuments(crdContent);
+    const documents = parseAllYamlDocuments(crdContent);
     for (let i = 0; i < documents.length; i += 1) {
       const doc = documents[i];
       const json = doc.toJSON();

--- a/src/utils/yaml.ts
+++ b/src/utils/yaml.ts
@@ -1,11 +1,12 @@
-import {LineCounter, parseAllDocuments, parseDocument, stringify} from 'yaml';
+import {Document, LineCounter, parseAllDocuments, parseDocument, stringify} from 'yaml';
+import {CreateNodeOptions, DocumentOptions, ParseOptions, SchemaOptions, ToStringOptions} from 'yaml/dist/options';
 
 /**
  * Wrapper that ensures consistent options
  */
 
 export function parseYamlDocument(text: string, lineCounter?: LineCounter) {
-  return parseDocument(text, {lineCounter, uniqueKeys: false, strict: false});
+  return parseDocument(text, {lineCounter, uniqueKeys: false, strict: false, schema: 'yaml-1.1'});
 }
 
 /**
@@ -13,11 +14,80 @@ export function parseYamlDocument(text: string, lineCounter?: LineCounter) {
  */
 
 export function parseAllYamlDocuments(text: string, lineCounter?: LineCounter) {
-  return parseAllDocuments(text, {lineCounter, uniqueKeys: false, strict: false});
+  return parseAllDocuments(text, {lineCounter, uniqueKeys: false, strict: false, schema: 'yaml-1.1'});
+}
+
+function containsPodSpec(kind: string) {
+  return ['Deployment', 'DaemonSet', 'Job', 'ReplicaSet', 'StatefulSet', 'ReplicationController'].indexOf(kind) !== -1;
+}
+
+function setOctalFormat(mode: any) {
+  if (mode && mode.format !== 'OCT') {
+    mode.format = 'OCT';
+  }
+}
+
+function setModePropertiesToOctal(node: any) {
+  if (node) {
+    setOctalFormat(node.get('defaultMode', true));
+    node.get('items')?.items.forEach((item: any) => {
+      if (item && item.get) {
+        setOctalFormat(item.get('mode', true));
+      }
+    });
+  }
+}
+
+/**
+ * Finds nested Volume properties that should be set to OCT format - see
+ * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#volume-v1-core
+ */
+function setOctalFormatForVolumeModeProperties(volumes: any) {
+  if (volumes?.items) {
+    volumes.items.forEach((v: any) => {
+      setModePropertiesToOctal(v.get('secret'));
+      setModePropertiesToOctal(v.get('configMap'));
+
+      let projectedNode = v.get('projected');
+      if (projectedNode) {
+        setOctalFormat(projectedNode.get('defaultMode', true));
+        projectedNode.get('sources')?.items.forEach((item: any) => {
+          setModePropertiesToOctal(v.get('secret'));
+          setModePropertiesToOctal(v.get('configMap'));
+          setModePropertiesToOctal(v.get('downwardAPI'));
+        });
+      }
+
+      setOctalFormat(v.get('downwardAPI')?.get('mode', true));
+    });
+  }
+}
+
+export function stringifyK8sResource(
+  object: any,
+  options?: DocumentOptions & SchemaOptions & ParseOptions & CreateNodeOptions & ToStringOptions
+) {
+  // special handling for octal values in Volumes in PodSpecs
+  if (containsPodSpec(object.kind)) {
+    let doc = new Document(object, {schema: 'yaml-1.1'});
+
+    // @ts-ignore
+    setOctalFormatForVolumeModeProperties(doc.get('spec')?.get('template')?.get('spec')?.get('volumes'));
+    return doc.toString(options);
+  }
+  if (object.kind === 'Pod') {
+    let doc = new Document(object, {schema: 'yaml-1.1'});
+
+    // @ts-ignore
+    setOctalFormatForVolumeModeProperties(doc.get('spec')?.get('volumes'));
+    return doc.toString(options);
+  }
+
+  return stringify(object, options);
 }
 
 export function jsonToYaml(resource: any): string {
-  return stringify(resource, {
+  return stringifyK8sResource(resource, {
     // In plain mode, scalar value `yes` and `no` are parsed as booleans
     // though most often they are intended as string scalars.
     defaultStringType: 'QUOTE_DOUBLE',


### PR DESCRIPTION
This PR fixes #3393 by ensuring consistent yaml parsing/stringification and special handling for PodSpec/Volume related properties

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [X] added a test
