### PR TITLE
fix: remove watchers when reloading resources

### DIFF
--- a/src/components/molecules/ResourceGraphTab/ResourceGraphTab.tsx
+++ b/src/components/molecules/ResourceGraphTab/ResourceGraphTab.tsx
@@ -1,10 +1,9 @@
 import {useCallback, useMemo} from 'react';
 
-import {useAppDispatch, useAppSelector} from '@redux/hooks';
+import {useAppDispatch} from '@redux/hooks';
 import {selectImage, selectResource} from '@redux/reducers/main';
 import {setExplorerSelectedSection} from '@redux/reducers/ui';
 import {
-  activeResourceStorageSelector,
   useActiveResourceContentMap,
   useActiveResourceMetaMap,
   useResourceContentMap,
@@ -21,7 +20,6 @@ import {RuleLevel} from '@monokle/validation';
 
 const ResourceGraphTab: React.FC = () => {
   const dispatch = useAppDispatch();
-  const activeStorage = useAppSelector(activeResourceStorageSelector);
   const selectedResource = useSelectedResource();
   const activeResoureMetaMap = useActiveResourceMetaMap();
   const activeResoureContentMap = useActiveResourceContentMap();

--- a/src/redux/reducers/main/mainSlice.ts
+++ b/src/redux/reducers/main/mainSlice.ts
@@ -8,6 +8,7 @@ import initialState from '@redux/initialState';
 import {processResourceRefs} from '@redux/parsing/parser.thunks';
 import {setAlert} from '@redux/reducers/alert';
 import {getResourceContentMapFromState, getResourceMetaMapFromState} from '@redux/selectors/resourceMapGetters';
+import {disconnectFromCluster} from '@redux/services/clusterResourceWatcher';
 import {createFileEntry, getFileEntryForAbsolutePath, removePath} from '@redux/services/fileEntry';
 import {HelmChartEventEmitter} from '@redux/services/helm';
 import {
@@ -354,6 +355,7 @@ export const mainSlice = createSlice({
     builder
       .addCase(reloadClusterResources.pending, state => {
         state.clusterConnectionOptions.isLoading = true;
+        disconnectFromCluster();
       })
       .addCase(reloadClusterResources.fulfilled, (state, action) => {
         state.clusterConnectionOptions.isLoading = false;


### PR DESCRIPTION
## Fixes

- Loading resources from previous namespaces when switching between them

## How to test it

- Connect to the cluster
- After 1-2 seconds, switch to another namespace
- Previous resources should not be loaded

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
