### PR TITLE
fix: kubeconfig isValid

### DIFF
--- a/electron/app/services/cluster/daemons/kubeconfigWatcher.ts
+++ b/electron/app/services/cluster/daemons/kubeconfigWatcher.ts
@@ -4,7 +4,7 @@ import {BrowserWindow} from 'electron';
 
 import {FSWatcher, watch} from 'chokidar';
 import fs from 'fs-extra';
-import {uniq} from 'lodash';
+import {size, uniq} from 'lodash';
 import log from 'loglevel';
 
 import {InvalidKubeConfig, ValidKubeConfig} from '@shared/models/config';
@@ -105,7 +105,16 @@ export class KubeConfigWatcher {
     try {
       const config = new k8s.KubeConfig();
       config.loadFromFile(kubeconfigPath);
-      this.broadcastSuccess(kubeconfigPath, config);
+
+      if (size(config.contexts) === 0 && size(config.clusters) === 0) {
+        this.broadcastError({
+          path: kubeconfigPath,
+          code: 'empty',
+          reason: `The kubeconfig is empty. No context or clusters found.`,
+        });
+      } else {
+        this.broadcastSuccess(kubeconfigPath, config);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : undefined;
       this.broadcastError({

--- a/electron/kubernetes/ProxyInstance.ts
+++ b/electron/kubernetes/ProxyInstance.ts
@@ -125,7 +125,7 @@ export class ProxyInstance {
   }
 
   stop() {
-    console.log('[kubectl-proxy] STOP', this._process?.pid);
+    log.info('[kubectl-proxy] STOP', this._process?.pid);
     if (!this._process || !this._process.pid) {
       return;
     }

--- a/src/components/organisms/SettingsPane/Settings/Settings.tsx
+++ b/src/components/organisms/SettingsPane/Settings/Settings.tsx
@@ -25,6 +25,7 @@ import {
 } from '@constants/tooltips';
 
 import {isInClusterModeSelector} from '@redux/appConfig';
+import {selectKubeconfig} from '@redux/cluster/selectors';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {downloadK8sSchema} from '@redux/thunks/downloadK8sSchema';
 import {setRootFolder} from '@redux/thunks/setRootFolder';
@@ -61,6 +62,7 @@ export const Settings = ({
   const dispatch = useAppDispatch();
   const [settingsForm] = useForm();
 
+  const kubeConfig = useAppSelector(selectKubeconfig);
   const isScanIncludesUpdated = useAppSelector(state => state.config.isScanIncludesUpdated);
   const isScanExcludesUpdated = useAppSelector(state => state.config.isScanExcludesUpdated);
   const filePath = useAppSelector(state => state.main.fileMap[ROOT_FILE_ENTRY]?.filePath);
@@ -73,7 +75,7 @@ export const Settings = ({
   const [isClusterActionDisabled, setIsClusterActionDisabled] = useState(
     Boolean(!config?.kubeConfig?.path) || Boolean(!config?.kubeConfig?.isPathValid)
   );
-  const [currentKubeConfig, setCurrentKubeConfig] = useState(config?.kubeConfig?.path);
+  const [currentKubeConfigPath, setCurrentKubeConfigPath] = useState(kubeConfig?.path);
   const [currentProjectName, setCurrentProjectName] = useState(projectName);
   const isEditingDisabled = isInClusterMode;
   const [k8sVersions] = useState<Array<string>>(K8S_VERSIONS);
@@ -90,7 +92,7 @@ export const Settings = ({
 
   useEffect(() => {
     setIsClusterActionDisabled(Boolean(!config?.kubeConfig?.path) || Boolean(!config?.kubeConfig?.isPathValid));
-    setCurrentKubeConfig(config?.kubeConfig?.path);
+    setCurrentKubeConfigPath(config?.kubeConfig?.path);
     setIsKubeConfigBrowseSettingsOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.kubeConfig]);
@@ -205,12 +207,12 @@ export const Settings = ({
 
   useDebounce(
     () => {
-      if (currentKubeConfig !== localConfig?.kubeConfig?.path) {
-        setLocalConfig({...localConfig, kubeConfig: {path: currentKubeConfig}});
+      if (currentKubeConfigPath !== localConfig?.kubeConfig?.path) {
+        setLocalConfig({...localConfig, kubeConfig: {path: currentKubeConfigPath}});
       }
     },
     DEFAULT_KUBECONFIG_DEBOUNCE,
-    [currentKubeConfig]
+    [currentKubeConfigPath]
   );
 
   useDebounce(
@@ -227,7 +229,7 @@ export const Settings = ({
     if (isEditingDisabled) {
       return;
     }
-    setCurrentKubeConfig(e.target.value);
+    setCurrentKubeConfigPath(e.target.value);
     setIsKubeConfigBrowseSettingsOpen(false);
   };
 
@@ -237,7 +239,7 @@ export const Settings = ({
       const file: any = fileInput.current.files[0];
       if (file.path) {
         const selectedFilePath = file.path;
-        setCurrentKubeConfig(selectedFilePath);
+        setCurrentKubeConfigPath(selectedFilePath);
         setIsKubeConfigBrowseSettingsOpen(false);
       }
     }
@@ -300,7 +302,7 @@ export const Settings = ({
             {isClusterActionDisabled && wasRehydrated && (
               <S.WarningOutlined
                 className={isClusterPaneIconHighlighted ? 'animated-highlight' : ''}
-                isKubeconfigPathValid={Boolean(config?.kubeConfig?.isPathValid)}
+                isKubeconfigPathValid={Boolean(kubeConfig?.isValid)}
                 highlighted={Boolean(isClusterPaneIconHighlighted)}
               />
             )}
@@ -310,7 +312,7 @@ export const Settings = ({
             <Input.Search
               ref={inputRef}
               onClick={() => focusInput()}
-              value={currentKubeConfig}
+              value={currentKubeConfigPath}
               onChange={onUpdateKubeconfig}
               disabled={isEditingDisabled}
               loading={!isKubeConfigBrowseSettingsOpen}

--- a/src/shared/models/config.ts
+++ b/src/shared/models/config.ts
@@ -131,7 +131,7 @@ export type ValidKubeConfig = {
 export type InvalidKubeConfig = {
   isValid: false;
   path: string;
-  code: 'not_found' | 'malformed' | 'unknown';
+  code: 'not_found' | 'malformed' | 'unknown' | 'empty';
   reason: string;
 };
 


### PR DESCRIPTION
## Fixes

- Fixed the case where loading a kubeconfig still returns as valid from the k8s client node, even if the array of context/cluster 
## How to test it

- Load a random file ( containing only strings for example )
- See the warning icon appear in the settings

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
