### PR TITLE
fix: handling side effects from removing files or resources

### DIFF
--- a/src/redux/reducers/main/mainSlice.ts
+++ b/src/redux/reducers/main/mainSlice.ts
@@ -57,7 +57,7 @@ import {
 } from '@shared/models/k8sResource';
 import {PreviewType} from '@shared/models/preview';
 import {RootState} from '@shared/models/rootState';
-import {AppSelection} from '@shared/models/selection';
+import {AppSelection, isResourceSelection} from '@shared/models/selection';
 import electronStore from '@shared/utils/electronStore';
 import {isEqual} from '@shared/utils/isEqual';
 import {trackEvent} from '@shared/utils/telemetry';
@@ -305,6 +305,18 @@ export const mainSlice = createSlice({
         delete state.resourceMetaMapByStorage.cluster[r.id];
         delete state.resourceContentMapByStorage.cluster[r.id];
       });
+      // clear the selection if the selected resource has been deleted
+      const selection = state.selection;
+      if (isResourceSelection(selection)) {
+        const selectedResourceIdentifier = selection.resourceIdentifier;
+        if (
+          action.payload.some(
+            r => r.id === selectedResourceIdentifier.id && r.storage === selectedResourceIdentifier.storage
+          )
+        ) {
+          clearSelectionReducer(state);
+        }
+      }
     },
     setActiveEditorTab: (state: Draft<AppState>, action: PayloadAction<ActionPaneTab>) => {
       state.activeEditorTab = action.payload;

--- a/src/redux/validation/validation.listeners.tsx
+++ b/src/redux/validation/validation.listeners.tsx
@@ -14,7 +14,14 @@ import {
   updateProjectK8sVersion,
 } from '@redux/appConfig';
 import {AppListenerFn} from '@redux/listeners/base';
-import {addMultipleResources, addResource, clearPreview, clearPreviewAndSelectionHistory} from '@redux/reducers/main';
+import {
+  addMultipleResources,
+  addResource,
+  clearPreview,
+  clearPreviewAndSelectionHistory,
+  multiplePathsRemoved,
+  updateMultipleClusterResources,
+} from '@redux/reducers/main';
 import {setIsInQuickClusterMode} from '@redux/reducers/ui';
 import {getResourceMapFromState} from '@redux/selectors/resourceMapGetters';
 import {previewSavedCommand} from '@redux/services/previewCommand';
@@ -82,6 +89,7 @@ const validateListener: AppListenerFn = listen => {
       runPreviewConfiguration.rejected,
       previewSavedCommand.rejected,
       stopClusterConnection.fulfilled,
+      multiplePathsRemoved,
       clearPreviewAndSelectionHistory,
       clearPreview
     ),
@@ -143,6 +151,7 @@ const incrementalValidationListener: AppListenerFn = listen => {
       addMultipleResources,
       updateResource.fulfilled,
       updateMultipleResources.fulfilled,
+      updateMultipleClusterResources,
       updateFileEntry.fulfilled,
       removeResources.fulfilled,
       multiplePathsAdded.fulfilled,
@@ -168,7 +177,7 @@ const incrementalValidationListener: AppListenerFn = listen => {
         resourceIdentifiers = [_action.payload];
       }
 
-      if (isAnyOf(addMultipleResources)(_action)) {
+      if (isAnyOf(addMultipleResources, updateMultipleClusterResources)(_action)) {
         resourceIdentifiers = _action.payload;
       }
 

--- a/src/redux/validation/validation.listeners.tsx
+++ b/src/redux/validation/validation.listeners.tsx
@@ -19,6 +19,7 @@ import {
   addResource,
   clearPreview,
   clearPreviewAndSelectionHistory,
+  deleteMultipleClusterResources,
   multiplePathsRemoved,
   updateMultipleClusterResources,
 } from '@redux/reducers/main';
@@ -89,6 +90,7 @@ const validateListener: AppListenerFn = listen => {
       runPreviewConfiguration.rejected,
       previewSavedCommand.rejected,
       stopClusterConnection.fulfilled,
+      deleteMultipleClusterResources,
       multiplePathsRemoved,
       clearPreviewAndSelectionHistory,
       clearPreview


### PR DESCRIPTION
This PR...

## Fixes

- Clears the selection on `deleteMultipleClusterResources` if any of the deleted resources was the current selection
- Handle `multiplePathsRemoved`, `updateMultipleClusterResources` and `deleteMultipleClusterResources` in the validation listener (Closes https://github.com/kubeshop/monokle/issues/3783)
