### PR TITLE
fix: removing file shows git error modal

### DIFF
--- a/src/redux/services/fileMonitor.ts
+++ b/src/redux/services/fileMonitor.ts
@@ -58,6 +58,10 @@ export function monitorRootFolder(folder: string, thunkAPI: {getState: Function;
         const paths: Array<string> = args.map(arg => arg[0]);
         thunkAPI.dispatch(multiplePathsRemoved(filterGitFolder(paths)));
 
+        if (!thunkAPI.getState().git.repo) {
+          return;
+        }
+
         getRepoInfo({path: folder})
           .then(repo => {
             if (!thunkAPI.getState().git.loading) {
@@ -87,6 +91,10 @@ export function monitorRootFolder(folder: string, thunkAPI: {getState: Function;
       debounceWithPreviousArgs((args: any[]) => {
         const paths: Array<string> = args.map(arg => arg[0]);
         thunkAPI.dispatch(multiplePathsRemoved(filterGitFolder(paths)));
+
+        if (!thunkAPI.getState().git.repo) {
+          return;
+        }
 
         getRepoInfo({path: folder})
           .then(repo => {


### PR DESCRIPTION

## Fixes

- Removing a file would show a git error modal

## How to test it

- Delete a file from file explorer
- File should be deleted and no git error shown

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
