### PR TITLE
fix: added confirmation popup for file/folder delete

### DIFF
--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
@@ -60,11 +60,23 @@ export const useDelete = () => {
       if (!fileEntry) {
         return;
       }
-      setIsLoading(true);
-      setImmediate(async () => {
-        const result = await deleteFileEntry(fileEntry);
-        dispatchDeleteAlert(dispatch, result);
-        setIsLoading(false);
+
+      let title = `Delete ${isDefined(fileEntry.children) ? 'folder' : 'file'} [${fileEntry.name}]?`;
+
+      Modal.confirm({
+        title,
+        onOk() {
+          return new Promise(resolve => {
+            setImmediate(async () => {
+              setIsLoading(true);
+              const result = await deleteFileEntry(fileEntry);
+              dispatchDeleteAlert(dispatch, result);
+              setIsLoading(false);
+            });
+            resolve({});
+          });
+        },
+        onCancel() {},
       });
     },
     [dispatch]


### PR DESCRIPTION
This PR adds a confirmation prompt when deleting files/folders - #3793 

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
