### PR TITLE
fix: disable add resource in cluster mode + add tooltip

### DIFF
--- a/src/components/organisms/NavigatorPane/KindRenderer/KindSuffix.tsx
+++ b/src/components/organisms/NavigatorPane/KindRenderer/KindSuffix.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useMemo} from 'react';
 
 import {Button, Tooltip} from 'antd';
 
@@ -7,6 +7,7 @@ import {PlusOutlined} from '@ant-design/icons';
 import styled from 'styled-components';
 
 import {TOOLTIP_DELAY} from '@constants/constants';
+import {DisabledAddResourceTooltip} from '@constants/tooltips';
 
 import {isInClusterModeSelector} from '@redux/appConfig';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
@@ -27,7 +28,8 @@ const ButtonContainer = styled.span`
   display: flex;
   align-items: center;
   padding: 0 4px;
-  margin-right: 2px;
+  margin-right: 16px;
+
   & .ant-btn-sm {
     height: 20px;
     width: 20px;
@@ -48,6 +50,8 @@ const KindSuffix: React.FC<Props> = props => {
   const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const isSectionCollapsed = useAppSelector(state => state.ui.navigator.collapsedResourceKinds.includes(resourceKind));
 
+  const isAddResourceDisabled = useMemo(() => isInPreviewMode || isInClusterMode, [isInClusterMode, isInPreviewMode]);
+
   const createResource = useCallback(() => {
     if (!resourceKind) {
       return;
@@ -67,13 +71,20 @@ const KindSuffix: React.FC<Props> = props => {
   return (
     <SuffixContainer>
       <ButtonContainer>
-        <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={`Create a new ${resourceKind}`}>
+        <Tooltip
+          mouseEnterDelay={TOOLTIP_DELAY}
+          title={
+            isAddResourceDisabled
+              ? DisabledAddResourceTooltip({type: isInClusterMode ? 'cluster' : 'preview', kind: resourceKind})
+              : `Create a new ${resourceKind}`
+          }
+        >
           <Button
             icon={<PlusOutlined />}
             type="link"
             onClick={createResource}
             size="small"
-            disabled={isInPreviewMode || isInClusterMode}
+            disabled={isAddResourceDisabled}
             style={{color: isSelected && isSectionCollapsed ? Colors.blackPure : undefined}}
           />
         </Tooltip>

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import {TOOLTIP_DELAY} from '@constants/constants';
 import {NewResourceTooltip} from '@constants/tooltips';
 
+import {isInClusterModeSelector} from '@redux/appConfig';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {collapseResourceKinds, expandResourceKinds, toggleResourceFilters} from '@redux/reducers/ui';
 import {isInPreviewModeSelectorNew} from '@redux/selectors';
@@ -36,6 +37,7 @@ const NavPane: React.FC = () => {
   const checkedResourceIdentifiers = useAppSelector(state => state.main.checkedResourceIdentifiers);
   const isFolderOpen = useAppSelector(state => Boolean(state.main.fileMap[ROOT_FILE_ENTRY]));
   const highlightedItems = useAppSelector(state => state.ui.highlightedItems);
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
   const isInPreviewMode = useAppSelector(isInPreviewModeSelectorNew);
   const isPreviewLoading = useAppSelector(state => state.main.previewOptions.isLoading);
   const isResourceFiltersOpen = useAppSelector(state => state.ui.isResourceFiltersOpen);
@@ -75,14 +77,14 @@ const NavPane: React.FC = () => {
                     trigger={['click']}
                     menu={{items: newResourceMenuItems}}
                     overlayClassName="dropdown-secondary"
-                    disabled={!isFolderOpen || isInPreviewMode}
+                    disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
                   >
                     <S.PlusButton
                       id="create-resource-button"
-                      $disabled={!isFolderOpen || isInPreviewMode}
+                      $disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
                       $highlighted={isHighlighted}
                       className={isHighlighted ? 'animated-highlight' : ''}
-                      disabled={!isFolderOpen || isInPreviewMode}
+                      disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
                       icon={<PlusOutlined />}
                       size="small"
                       type="link"

--- a/src/components/organisms/NavigatorPane/NavigatorPane.tsx
+++ b/src/components/organisms/NavigatorPane/NavigatorPane.tsx
@@ -8,7 +8,7 @@ import {PlusOutlined} from '@ant-design/icons';
 import styled from 'styled-components';
 
 import {TOOLTIP_DELAY} from '@constants/constants';
-import {NewResourceTooltip} from '@constants/tooltips';
+import {DisabledAddResourceTooltip, NewResourceTooltip} from '@constants/tooltips';
 
 import {isInClusterModeSelector} from '@redux/appConfig';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
@@ -47,6 +47,11 @@ const NavPane: React.FC = () => {
   const height = usePaneHeight();
   const newResourceMenuItems = useNewResourceMenuItems();
 
+  const isAddResourceDisabled = useMemo(
+    () => !isFolderOpen || isInPreviewMode || isInClusterMode,
+    [isFolderOpen, isInClusterMode, isInPreviewMode]
+  );
+
   const resourceFilterButtonHandler = useCallback(() => {
     dispatch(toggleResourceFilters());
   }, [dispatch]);
@@ -72,25 +77,35 @@ const NavPane: React.FC = () => {
             actions={
               <S.TitleBarRightButtons>
                 <CollapseAction />
-                <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={NewResourceTooltip}>
-                  <Dropdown
-                    trigger={['click']}
-                    menu={{items: newResourceMenuItems}}
-                    overlayClassName="dropdown-secondary"
-                    disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
+
+                <Dropdown
+                  trigger={['click']}
+                  menu={{items: newResourceMenuItems}}
+                  overlayClassName="dropdown-secondary"
+                  disabled={isAddResourceDisabled}
+                >
+                  <Tooltip
+                    mouseEnterDelay={TOOLTIP_DELAY}
+                    title={
+                      isAddResourceDisabled
+                        ? DisabledAddResourceTooltip({
+                            type: isInClusterMode ? 'cluster' : isInPreviewMode ? 'preview' : 'other',
+                          })
+                        : NewResourceTooltip
+                    }
                   >
                     <S.PlusButton
                       id="create-resource-button"
-                      $disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
+                      $disabled={isAddResourceDisabled}
                       $highlighted={isHighlighted}
                       className={isHighlighted ? 'animated-highlight' : ''}
-                      disabled={!isFolderOpen || isInPreviewMode || isInClusterMode}
+                      disabled={isAddResourceDisabled}
                       icon={<PlusOutlined />}
                       size="small"
                       type="link"
                     />
-                  </Dropdown>
-                </Tooltip>
+                  </Tooltip>
+                </Dropdown>
               </S.TitleBarRightButtons>
             }
           />

--- a/src/components/organisms/NavigatorPane/ResourceRenderer/ResourceRenderer.styled.tsx
+++ b/src/components/organisms/NavigatorPane/ResourceRenderer/ResourceRenderer.styled.tsx
@@ -18,14 +18,16 @@ export const ItemContainer = styled.span<ItemContainerProps>`
     min-width: 0;
   }
   padding-left: 30px;
-  padding-right: 8px;
+  padding-right: 20px;
   margin-bottom: 2px;
   cursor: pointer;
+
   ${props => {
     if (props.isLastItem) {
       return `margin-bottom: 12px;`;
     }
   }}
+
   ${props => {
     if (!props.isSelected && props.isHighlighted) {
       if (props.isHovered) {

--- a/src/constants/tooltips.tsx
+++ b/src/constants/tooltips.tsx
@@ -106,3 +106,11 @@ export const GitCommitEnabledTooltip = ({branchName}: {branchName: string}) => (
 export const ClusterDashboardErrorsWarningTooltip = ({type}: {type: 'errors' | 'warnings'}) => (
   <div>Click to see all your cluster {type}</div>
 );
+export const DisabledAddResourceTooltip = ({type, kind}: {type: 'cluster' | 'preview' | 'other'; kind?: string}) =>
+  type === 'other' ? (
+    <div>Adding a resource is not possible</div>
+  ) : (
+    <div>
+      Adding a {kind || 'resource'} is not possible in {type === 'cluster' ? 'cluster' : 'preview'} mode
+    </div>
+  );


### PR DESCRIPTION
## Changes

- Add button tooltip when disabled

## Fixes

- Disable add resource in cluster mode

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/235087728-2ee1567c-6c38-4601-835e-a74690855d43.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
