### PR TITLE
fix: connect to default namespace when nonexistence namespace 

### DIFF
--- a/src/redux/cluster/thunks/connect.ts
+++ b/src/redux/cluster/thunks/connect.ts
@@ -25,8 +25,11 @@ type ConnectResponse = {
 export const connectCluster = createAsyncThunk<ConnectResponse, ConnectArgs, ThunkApi>(
   'cluster/connect',
   async (payload, {getState, dispatch, rejectWithValue}) => {
-    const lastNamespaceLoaded = getState().main.clusterConnectionOptions?.lastNamespaceLoaded;
-
+    let lastNamespaceLoaded;
+    const lastConnectionContext = getState().main.clusterConnection?.context;
+    if (lastConnectionContext === payload.context) {
+      lastNamespaceLoaded = getState().main.clusterConnectionOptions?.lastNamespaceLoaded;
+    }
     // Ping for healthy connection
     await dispatch(setupCluster());
     const contextId = selectCurrentContextId(getState());

--- a/src/redux/thunks/cluster/loadClusterResources.ts
+++ b/src/redux/thunks/cluster/loadClusterResources.ts
@@ -58,14 +58,22 @@ const loadClusterResourcesHandler = async (
   trackEvent('preview/cluster/start');
 
   try {
+    let namespaces: Array<string> = [];
+    if (kubeConfigPath?.trim().length) {
+      namespaces = await getTargetClusterNamespaces(kubeConfigPath, kubeConfigContext, clusterAccess);
+      if (namespaces.length === 0) {
+        throw new Error('no_namespaces_found');
+      }
+      if (!namespaces.includes(currentNamespace)) {
+        currentNamespace = 'default';
+      }
+    }
+
     let kc = createKubeClient(kubeConfigPath, context, port);
     let results: PromiseSettledResult<string>[] | PromiseSettledResult<string>[][] = [];
 
     if (currentNamespace === '<all>') {
-      if (kubeConfigPath?.trim().length) {
-        const namespaces = await getTargetClusterNamespaces(kubeConfigPath, kubeConfigContext, clusterAccess);
-        results = await Promise.all(namespaces.map(ns => getNonCustomClusterObjects(kc, ns, true)));
-      }
+      results = await Promise.all(namespaces.map(ns => getNonCustomClusterObjects(kc, ns, true)));
     } else if (currentNamespace === '<not-namespaced>') {
       results = await getNonCustomClusterObjects(kc);
     } else {


### PR DESCRIPTION
This PR...

## Changes

- when changing context, set the namespace to default
-  check namespace existence before loading the resources 

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
