### PR TITLE
fix: check values file if it is associated with a Helm Chart

### DIFF
--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/FileSystemTree.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/FileSystemTree.tsx
@@ -97,7 +97,7 @@ const FileSystemTree: React.FC = () => {
             return;
           }
           if (typeof nodeEvent.key === 'string' && !nodeEvent.disabled) {
-            if (isHelmValuesFile(nodeEvent.key)) {
+            if (isHelmValuesFile(nodeEvent.key) && helmValuesMapByFilePath[nodeEvent.key]) {
               const valuesFileId = helmValuesMapByFilePath[nodeEvent.key].id;
               dispatch(selectHelmValuesFile({valuesFileId}));
             } else {


### PR DESCRIPTION
This PR fixes #3843 

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
