### PR TITLE
fix: show name of overlay folder instead of filename in navigator

### DIFF
--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeList.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeList.tsx
@@ -54,7 +54,7 @@ const KustomizeList: React.FC = () => {
   }
 
   if (!size(list)) {
-    return <EmptyText>No Kustomizations found in the current project.</EmptyText>;
+    return <EmptyText>No Kustomize Overlays found in the current project.</EmptyText>;
   }
 
   return (

--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
@@ -8,6 +8,7 @@ import {isResourceHighlighted, isResourceSelected} from '@redux/services/resourc
 import {isResourcePassingFilter} from '@utils/resources';
 
 import {ResourceIdentifier} from '@shared/models/k8sResource';
+import {isLocalOrigin} from '@shared/models/origin';
 import {isEqual} from '@shared/utils/isEqual';
 import {isInClusterModeSelector} from '@shared/utils/selectors';
 
@@ -65,7 +66,9 @@ const KustomizeRenderer: React.FC<IProps> = props => {
       </S.PrefixContainer>
 
       <S.ItemName isDisabled={isDisabled} isSelected={isSelected} isHighlighted={isHighlighted}>
-        {resourceMeta.name}
+        {isLocalOrigin(resourceMeta.origin)
+          ? resourceMeta.origin.filePath.substring(0, resourceMeta.origin.filePath.lastIndexOf('/'))
+          : resourceMeta.name}
       </S.ItemName>
 
       <S.SuffixContainer>

--- a/src/redux/selectors/kustomizeSelectors.ts
+++ b/src/redux/selectors/kustomizeSelectors.ts
@@ -10,7 +10,7 @@ import {RootState} from '@shared/models/rootState';
 import {getResourceMetaMapFromState} from './resourceMapGetters';
 
 const kindNameRenderer = (kind: string) => {
-  if (kind === 'Kustomization') return kind;
+  if (kind === 'Kustomization') return 'Kustomize Overlays';
 
   return `${kind} Patches`;
 };


### PR DESCRIPTION
This PR fixes #3498 - I opened #3859 as a follow-up

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

<img width="692" alt="image" src="https://user-images.githubusercontent.com/1917063/236126972-d3ef4264-f5fe-454d-9c2c-2fe111af4dc6.png">


## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
