### PR TITLE
fix: remove parsedDoc cache and improve handling of timestamp in files

### DIFF
--- a/src/redux/thunks/utils.ts
+++ b/src/redux/thunks/utils.ts
@@ -19,11 +19,10 @@ import {ResourceMeta} from '@shared/models/k8sResource';
  * - change Date objects to properly quoted strings
  */
 
-function preprocessClusterResource(item: any) {
-  let doc = new Document(item, {schema: 'yaml-1.1'});
+export function processK8sResourceDoc(doc: Document, removeNullValues?: boolean) {
   visit(doc, {
     Pair(_, pair) {
-      if (isScalar(pair.value) && pair.value.value === null) {
+      if (removeNullValues === true && isScalar(pair.value) && pair.value.value === null) {
         return visit.REMOVE;
       }
     },
@@ -36,6 +35,11 @@ function preprocessClusterResource(item: any) {
     },
   });
   return doc;
+}
+
+function preprocessClusterResource(item: any) {
+  let doc = new Document(item, {schema: 'yaml-1.1'});
+  return processK8sResourceDoc(doc, true);
 }
 
 /**


### PR DESCRIPTION
This PR fixes #3862 - we won't remove null values in local files since they might be there for a reason. Also removed the parsedDocCache as this was a remnant from when we did ref processing in Desktop - the cache wasn't used anymore and a potential memory-leak..

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
