### PR TITLE
fix: mark unresolved optional-links as warnings for now

### DIFF
--- a/src/redux/validation/validation.thunks.ts
+++ b/src/redux/validation/validation.thunks.ts
@@ -29,6 +29,12 @@ export const loadValidation = createAsyncThunk<LoadValidationResult, undefined, 
     merge(config, state.config);
     electronStore.set('validation.config', config);
 
+    // @ts-ignore
+    if (config && config['rules']) {
+      // @ts-ignore
+      config.rules['resource-links/no-missing-optional-links'] = 'warn';
+    }
+
     await VALIDATOR.loadValidation({config});
 
     return {


### PR DESCRIPTION
This PR makes unresolved optional links show up as warnings instead of errors - until we have #3840 resolved

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
