### PR TITLE
fix: keep transient resources on reload

### DIFF
--- a/src/components/organisms/ExplorerPane/FilePane/FilePane.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FilePane.tsx
@@ -85,7 +85,7 @@ const FilePane: React.FC<InjectedPanelProps> = props => {
                 <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={ReloadFolderTooltip}>
                   <Button
                     size="small"
-                    onClick={() => dispatch(setRootFolder(rootEntry.filePath))}
+                    onClick={() => dispatch(setRootFolder({rootFolder: rootEntry.filePath, isReload: true}))}
                     icon={<ReloadOutlined />}
                     type="link"
                     disabled={isButtonDisabled}

--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
@@ -371,7 +371,7 @@ export const useFileMenuItems = (
     if (!fileEntry) {
       return;
     }
-    dispatch(setRootFolder(fileEntry.rootFolderPath));
+    dispatch(setRootFolder({rootFolder: fileEntry.rootFolderPath, isReload: true}));
   }, [fileEntry, dispatch]);
 
   const {addEntryToScanExcludes, removeEntryFromScanExcludes} = useFileScanning(reloadRootFolder);

--- a/src/components/organisms/ExplorerPane/FilePane/useSetFolderFromMainThread.ts
+++ b/src/components/organisms/ExplorerPane/FilePane/useSetFolderFromMainThread.ts
@@ -11,7 +11,7 @@ export function useSetFolderFromMainThread() {
   const dispatch = useAppDispatch();
   const setFolder = useCallback(
     (folder: string) => {
-      dispatch(setRootFolder(folder));
+      dispatch(setRootFolder({rootFolder: folder}));
     },
     [dispatch]
   );

--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeContextMenu.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeContextMenu.tsx
@@ -70,7 +70,7 @@ const KustomizeContextMenu: React.FC<IProps> = props => {
   );
 
   const refreshFolder = useCallback(
-    () => dispatch(setRootFolder(fileMapRef.current[ROOT_FILE_ENTRY].filePath)),
+    () => dispatch(setRootFolder({rootFolder: fileMapRef.current[ROOT_FILE_ENTRY].filePath, isReload: true})),
     [dispatch, fileMapRef]
   );
   const {onExcludeFromProcessing} = useProcessing(refreshFolder);

--- a/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
+++ b/src/components/organisms/HotKeysHandler/HotKeysHandler.tsx
@@ -68,7 +68,7 @@ const HotKeysHandler = () => {
       if (!folderPath) {
         return;
       }
-      dispatch(setRootFolder(folderPath));
+      dispatch(setRootFolder({rootFolder: folderPath}));
     },
     {
       isDirectoryExplorer: true,
@@ -93,7 +93,7 @@ const HotKeysHandler = () => {
     hotkeys.REFRESH_FOLDER.key,
     () => {
       if (rootFilePath) {
-        dispatch(setRootFolder(rootFilePath));
+        dispatch(setRootFolder({rootFolder: rootFilePath}));
       }
     },
     [rootFilePath]

--- a/src/components/organisms/SettingsPane/Settings/Settings.tsx
+++ b/src/components/organisms/SettingsPane/Settings/Settings.tsx
@@ -360,7 +360,7 @@ export const Settings = ({
             tooltip={AddInclusionPatternTooltip}
             showApplyButton={isScanIncludesUpdated === 'outdated'}
             onApplyClick={() => {
-              dispatch(setRootFolder(filePath));
+              dispatch(setRootFolder({rootFolder: filePath}));
             }}
           />
         </S.Div>
@@ -372,7 +372,7 @@ export const Settings = ({
             tooltip={AddExclusionPatternTooltip}
             showApplyButton={isScanExcludesUpdated === 'outdated'}
             onApplyClick={() => {
-              dispatch(setRootFolder(filePath));
+              dispatch(setRootFolder({rootFolder: filePath}));
             }}
           />
         </S.Div>

--- a/src/redux/appConfig/appConfig.slice.ts
+++ b/src/redux/appConfig/appConfig.slice.ts
@@ -105,7 +105,7 @@ export const setOpenProject = createAsyncThunk(
     // Then set project config by reading .monokle or populating it
     thunkAPI.dispatch(configSlice.actions.updateProjectConfig({config, fromConfigFile: false}));
     // Last set rootFolder so function can read the latest projectConfig
-    thunkAPI.dispatch(setRootFolder(projectRootPath));
+    thunkAPI.dispatch(setRootFolder({rootFolder: projectRootPath}));
   }
 );
 

--- a/src/redux/reducers/main/mainSlice.ts
+++ b/src/redux/reducers/main/mainSlice.ts
@@ -86,6 +86,12 @@ export type SetRootFolderPayload = {
   isScanExcludesUpdated: 'outdated' | 'applied';
   isScanIncludesUpdated: 'outdated' | 'applied';
   isGitRepo: boolean;
+  isReload?: boolean;
+};
+
+export type SetRootFolderArgs = {
+  rootFolder: string | null;
+  isReload?: boolean;
 };
 
 export type UpdateMultipleResourcesPayload = {
@@ -430,12 +436,15 @@ export const mainSlice = createSlice({
     builder.addCase(setRootFolder.fulfilled, (state, action) => {
       state.resourceMetaMapByStorage.local = action.payload.resourceMetaMap;
       state.resourceContentMapByStorage.local = action.payload.resourceContentMap;
-      state.resourceMetaMapByStorage.transient = {};
-      state.resourceContentMapByStorage.transient = {};
       state.fileMap = action.payload.fileMap;
       state.helmChartMap = action.payload.helmChartMap;
       state.helmValuesMap = action.payload.helmValuesMap;
       state.helmTemplatesMap = action.payload.helmTemplatesMap;
+
+      if (!action.payload.isReload) {
+        state.resourceMetaMapByStorage.transient = {};
+        state.resourceContentMapByStorage.transient = {};
+      }
 
       clearSelectionReducer(state);
       clearPreviewReducer(state);

--- a/src/redux/thunks/setRootFolder.ts
+++ b/src/redux/thunks/setRootFolder.ts
@@ -5,7 +5,7 @@ import log from 'loglevel';
 import {currentConfigSelector} from '@redux/appConfig';
 import {setChangedFiles, setGitLoading, setRepo} from '@redux/git';
 import {getChangedFiles, getRepoInfo, isFolderGitRepo} from '@redux/git/git.ipc';
-import {SetRootFolderPayload} from '@redux/reducers/main';
+import {SetRootFolderArgs, SetRootFolderPayload} from '@redux/reducers/main';
 import {createRootFileEntry, readFiles} from '@redux/services/fileEntry';
 import {monitorRootFolder} from '@redux/services/fileMonitor';
 import {isKustomizationResource} from '@redux/services/kustomize';
@@ -27,12 +27,12 @@ import {trackEvent} from '@shared/utils/telemetry';
 
 export const setRootFolder = createAsyncThunk<
   SetRootFolderPayload,
-  string | null,
+  SetRootFolderArgs,
   {
     dispatch: AppDispatch;
     state: RootState;
   }
->('main/setRootFolder', async (rootFolder, thunkAPI) => {
+>('main/setRootFolder', async ({rootFolder, isReload}, thunkAPI) => {
   const startTime = new Date().getTime();
   const projectConfig = currentConfigSelector(thunkAPI.getState());
 
@@ -164,5 +164,6 @@ export const setRootFolder = createAsyncThunk<
     isScanIncludesUpdated: 'applied',
     alert: rootFolder ? generatedAlert : undefined,
     isGitRepo,
+    isReload,
   };
 });


### PR DESCRIPTION
## Fixes

- Keep transient resources when reloading file tree

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
