### PR TITLE
fix: updated to latest Kustomize schema and enable helm by default

### DIFF
--- a/resources/schemas/kustomization.json
+++ b/resources/schemas/kustomization.json
@@ -1,233 +1,6 @@
 {
+  "$ref": "#/definitions/Kustomization",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "properties": {
-    "apiVersion": {
-      "type": "string"
-    },
-    "bases": {
-      "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "commonAnnotations": {
-      "description": "CommonAnnotations to add to all objects",
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "buildMetadata": {
-      "description": "BuildMetadata is a list of strings used to toggle different build options",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "commonLabels": {
-      "description": " CommonLabels to add to all objects and selectors",
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "configMapGenerator": {
-      "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
-      "items": {
-        "$ref": "#/definitions/ConfigMapArgs"
-      },
-      "type": "array"
-    },
-    "configurations": {
-      "description": "Configurations is a list of transformer configuration files",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "crds": {
-      "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "generatorOptions": {
-      "$ref": "#/definitions/GeneratorOptions"
-    },
-    "generators": {
-      "description": "Generators is a list of files containing custom generators",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "helmCharts": {
-      "description": "HelmCharts is a list of helm chart configuration instances",
-      "items": {
-        "$ref": "#/definitions/HelmChart"
-      },
-      "type": "array"
-    },
-    "helmGlobals": {
-      "description": "HelmGlobals contains helm configuration that isn't chart specific",
-      "properties": {
-        "chartHome": {
-          "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
-          "type": "string"
-        },
-        "configHome": {
-          "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "images": {
-      "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
-      "items": {
-        "$ref": "#/definitions/Image"
-      },
-      "type": "array"
-    },
-    "inventory": {
-      "$ref": "#/definitions/Inventory"
-    },
-    "labels": {
-      "description": "Labels to add to all objects but not selectors",
-      "items": {
-        "$ref": "#/definitions/Labels"
-      },
-      "type": "array"
-    },
-    "kind": {
-      "type": "string"
-    },
-    "metadata": {
-      "description": "Contains metadata about a Resource",
-      "$ref": "#/definitions/Metadata"
-    },
-    "namePrefix": {
-      "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
-      "type": "string"
-    },
-    "nameSuffix": {
-      "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
-      "type": "string"
-    },
-    "namespace": {
-      "description": "Namespace to add to all objects",
-      "type": "string"
-    },
-    "replacements": {
-      "type": "array",
-      "description": "Substitute field(s) in N target(s) with a field from a source",
-      "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/ReplacementsPath"
-          },
-          {
-            "$ref": "#/definitions/ReplacementsInline"
-          }
-        ]
-      }
-    },
-    "openapi": {
-      "description": "OpenAPI contains information about what kubernetes schema to use",
-      "patternProperties": {
-        ".*": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "patches": {
-      "description": "Apply a patch to multiple resources",
-      "items": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/PatchesPatchPath"
-          },
-          {
-            "$ref": "#/definitions/PatchesInlinePatch"
-          }
-        ]
-      },
-      "type": "array"
-    },
-    "patchesJson6902": {
-      "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
-      "items": {
-        "$ref": "#/definitions/PatchJson6902"
-      },
-      "type": "array"
-    },
-    "patchesStrategicMerge": {
-      "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "replicas": {
-      "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
-      "items": {
-        "$ref": "#/definitions/Replicas"
-      },
-      "type": "array"
-    },
-    "resources": {
-      "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "components": {
-      "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "secretGenerator": {
-      "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
-      "items": {
-        "$ref": "#/definitions/SecretArgs"
-      },
-      "type": "array"
-    },
-    "transformers": {
-      "description": "Transformers is a list of files containing transformers",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "validators": {
-      "description": "Validators is a list of files containing validators",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "vars": {
-      "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
-      "items": {
-        "$ref": "#/definitions/Var"
-      },
-      "type": "array"
-    }
-  },
-  "additionalProperties": false,
-  "type": "object",
   "definitions": {
     "ConfigMapArgs": {
       "description": "ConfigMapArgs contains the metadata of how to generate a configmap",
@@ -239,11 +12,7 @@
           "type": "array"
         },
         "behavior": {
-          "enum": [
-            "create",
-            "replace",
-            "merge"
-          ]
+          "enum": ["create", "replace", "merge"]
         },
         "env": {
           "description": "Deprecated.  Use envs instead.",
@@ -378,14 +147,28 @@
         },
         "valuesMerge": {
           "type": "string",
-          "enum": [
-            "merge",
-            "override",
-            "replace"
-          ]
+          "enum": ["merge", "override", "replace"]
         },
         "includeCRDs": {
           "type": "boolean"
+        },
+        "additionalValuesFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipTests": {
+          "type": "boolean"
+        },
+        "apiVersions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nameTemplate": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -440,6 +223,236 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "Kustomization": {
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "bases": {
+          "description": "DEPRECATED. Bases are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonAnnotations": {
+          "description": "CommonAnnotations to add to all objects",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "buildMetadata": {
+          "description": "BuildMetadata is a list of strings used to toggle different build options",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commonLabels": {
+          "description": " CommonLabels to add to all objects and selectors",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "configMapGenerator": {
+          "description": "ConfigMapGenerator is a list of configmaps to generate from local data (one configMap per list item)",
+          "items": {
+            "$ref": "#/definitions/ConfigMapArgs"
+          },
+          "type": "array"
+        },
+        "configurations": {
+          "description": "Configurations is a list of transformer configuration files",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "crds": {
+          "description": "Crds specifies relative paths to Custom Resource Definition files. This allows custom resources to be recognized as operands, making it possible to add them to the Resources list. CRDs themselves are not modified.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "generatorOptions": {
+          "$ref": "#/definitions/GeneratorOptions"
+        },
+        "generators": {
+          "description": "Generators is a list of files containing custom generators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "helmCharts": {
+          "description": "HelmCharts is a list of helm chart configuration instances",
+          "items": {
+            "$ref": "#/definitions/HelmChart"
+          },
+          "type": "array"
+        },
+        "helmGlobals": {
+          "description": "HelmGlobals contains helm configuration that isn't chart specific",
+          "properties": {
+            "chartHome": {
+              "description": "ChartHome is a file path, relative to the kustomization root, to a directory containing a subdirectory for each chart to be included in the kustomization",
+              "type": "string"
+            },
+            "configHome": {
+              "description": "ConfigHome defines a value that kustomize should pass to helm via the HELM_CONFIG_HOME environment variable",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "images": {
+          "description": "Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.",
+          "items": {
+            "$ref": "#/definitions/Image"
+          },
+          "type": "array"
+        },
+        "inventory": {
+          "$ref": "#/definitions/Inventory"
+        },
+        "labels": {
+          "description": "Labels to add to all objects but not selectors",
+          "items": {
+            "$ref": "#/definitions/Labels"
+          },
+          "type": "array"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "metadata": {
+          "description": "Contains metadata about a Resource",
+          "$ref": "#/definitions/Metadata"
+        },
+        "namePrefix": {
+          "description": "NamePrefix will prefix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "nameSuffix": {
+          "description": "NameSuffix will suffix the names of all resources mentioned in the kustomization file including generated configmaps and secrets",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace to add to all objects",
+          "type": "string"
+        },
+        "replacements": {
+          "type": "array",
+          "description": "Substitute field(s) in N target(s) with a field from a source",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/ReplacementsPath"
+              },
+              {
+                "$ref": "#/definitions/ReplacementsInline"
+              }
+            ]
+          }
+        },
+        "openapi": {
+          "description": "OpenAPI contains information about what kubernetes schema to use",
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "patches": {
+          "description": "Apply a patch to multiple resources",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/PatchesPatchPath"
+              },
+              {
+                "$ref": "#/definitions/PatchesInlinePatch"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "patchesJson6902": {
+          "description": "JSONPatches is a list of JSONPatch for applying JSON patch. See http://jsonpatch.com",
+          "items": {
+            "$ref": "#/definitions/PatchJson6902"
+          },
+          "type": "array"
+        },
+        "patchesStrategicMerge": {
+          "description": " PatchesStrategicMerge specifies the relative path to a file containing a strategic merge patch. URLs and globs are not supported",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replicas": {
+          "description": "Replicas is a list of (resource name, count) for changing number of replicas for a resources. It will match any group and kind that has a matching name and that is one of: Deployment, ReplicationController, Replicaset, Statefulset.",
+          "items": {
+            "$ref": "#/definitions/Replicas"
+          },
+          "type": "array"
+        },
+        "resources": {
+          "description": "Resources specifies relative paths to files holding YAML representations of kubernetes API objects. URLs and globs not supported.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "components": {
+          "description": "Components are relative paths or git repository URLs specifying a directory containing a kustomization.yaml file of Kind Component.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "secretGenerator": {
+          "description": "SecretGenerator is a list of secrets to generate from local data (one secret per list item)",
+          "items": {
+            "$ref": "#/definitions/SecretArgs"
+          },
+          "type": "array"
+        },
+        "transformers": {
+          "description": "Transformers is a list of files containing transformers",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "validators": {
+          "description": "Validators is a list of files containing validators",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "vars": {
+          "description": "Allows things modified by kustomize to be injected into a container specification. A var is a name (e.g. FOO) associated with a field in a specific resource instance.  The field must contain a value of type string, and defaults to the name field of the instance",
+          "items": {
+            "$ref": "#/definitions/Var"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Labels": {
       "properties": {
         "pairs": {
@@ -452,6 +465,10 @@
         },
         "includeSelectors": {
           "description": "IncludeSelectors inidicates should transformer include the fieldSpecs for selectors",
+          "type": "boolean"
+        },
+        "includeTemplates": {
+          "description": "IncludeTemplates inidicates should transformer include the template labels",
           "type": "boolean"
         },
         "fields": {
@@ -508,10 +525,7 @@
     "PatchJson6902": {
       "oneOf": [
         {
-          "required": [
-            "path",
-            "target"
-          ],
+          "required": ["path", "target"],
           "properties": {
             "path": {
               "description": "relative file path for a json patch file inside a kustomization",
@@ -526,10 +540,7 @@
           "type": "object"
         },
         {
-          "required": [
-            "patch",
-            "target"
-          ],
+          "required": ["patch", "target"],
           "properties": {
             "patch": {
               "description": "inline json patch",
@@ -544,22 +555,12 @@
           "type": "object"
         },
         {
-          "required": [
-            "op",
-            "path"
-          ],
+          "required": ["op", "path"],
           "properties": {
             "op": {
               "description": "The operation",
               "type": "string",
-              "enum": [
-                "add",
-                "remove",
-                "replace",
-                "move",
-                "copy",
-                "test"
-              ]
+              "enum": ["add", "remove", "replace", "move", "copy", "test"]
             },
             "from": {
               "description": "The source location.",
@@ -589,11 +590,7 @@
       ]
     },
     "PatchTarget": {
-      "required": [
-        "kind",
-        "name",
-        "version"
-      ],
+      "required": ["kind", "name", "version"],
       "properties": {
         "group": {
           "type": "string"
@@ -642,9 +639,7 @@
       "type": "object"
     },
     "PatchesPatchPath": {
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "properties": {
         "path": {
           "type": "string"
@@ -657,9 +652,7 @@
       "additionalProperties": false
     },
     "PatchesInlinePatch": {
-      "required": [
-        "patch"
-      ],
+      "required": ["patch"],
       "properties": {
         "patch": {
           "type": "string"
@@ -672,10 +665,7 @@
       "additionalProperties": false
     },
     "ReplacementsInline": {
-      "required": [
-        "source",
-        "targets"
-      ],
+      "required": ["source", "targets"],
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -727,9 +717,7 @@
           "description": "The N fields to write the value to",
           "type": "array",
           "items": {
-            "required": [
-              "select"
-            ],
+            "required": ["select"],
             "type": "object",
             "properties": {
               "select": {
@@ -759,28 +747,32 @@
                 }
               },
               "reject": {
-                "type": "object",
+                "type": "array",
                 "description": "Exclude objects that match this",
-                "properties": {
-                  "group": {
-                    "type": "string",
-                    "description": "The group of the referent"
-                  },
-                  "version": {
-                    "type": "string",
-                    "description": "The version of the referent"
-                  },
-                  "kind": {
-                    "type": "string",
-                    "description": "The kind of the referent"
-                  },
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the referent"
-                  },
-                  "namespace": {
-                    "type": "string",
-                    "description": "The namespace of the referent"
+                "items": {
+                  "type": "object",
+                  "description": "Exclude objects that match this",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "description": "The group of the referent"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "The version of the referent"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "description": "The kind of the referent"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the referent"
+                    },
+                    "namespace": {
+                      "type": "string",
+                      "description": "The namespace of the referent"
+                    }
                   }
                 }
               },
@@ -812,9 +804,7 @@
       }
     },
     "ReplacementsPath": {
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -845,11 +835,7 @@
           "type": "array"
         },
         "behavior": {
-          "enum": [
-            "create",
-            "replace",
-            "merge"
-          ]
+          "enum": ["create", "replace", "merge"]
         },
         "env": {
           "type": "string"
@@ -892,9 +878,7 @@
       "type": "object"
     },
     "Target": {
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "apiVersion": {
           "type": "string"
@@ -917,10 +901,7 @@
     },
     "Var": {
       "description": "Represents a variable whose value will be sourced from a field in a Kubernetes object.",
-      "required": [
-        "name",
-        "objref"
-      ],
+      "required": ["name", "objref"],
       "properties": {
         "fieldref": {
           "description": "Refers to the field of the object referred to by objref whose value will be extracted for use in replacing $(FOO)",

--- a/src/shared/constants/electronStore.ts
+++ b/src/shared/constants/electronStore.ts
@@ -295,6 +295,7 @@ export const electronStoreDefaults = {
       createDefaultObjects: false,
       setDefaultPrimitiveValues: true,
       allowEditInClusterMode: true,
+      enableHelmWithKustomize: true,
     },
     recentFolders: [],
     newVersion: 0,


### PR DESCRIPTION
This PR updates to the latest kustomize 5.x schema and enables Helm features by default as some users are getting a related error message

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
