### PR TITLE
refactor: pane manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "6.0.8",
         "@dnd-kit/sortable": "7.0.2",
         "@kubernetes/client-node": "0.18.1",
-        "@monokle/components": "1.4.0",
+        "@monokle/components": "1.4.1",
         "@monokle/validation": "0.16.0",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@reduxjs/toolkit": "1.9.3",
@@ -4007,9 +4007,9 @@
       }
     },
     "node_modules/@monokle/components": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monokle/components/-/components-1.4.0.tgz",
-      "integrity": "sha512-hk1odP9TgUBbwSAdPLjzK+o2UGkfLCM0E4abpiIeJsgAmCfvVXAKzPhTk+/7+IXDgtV2c1L6yqWLoJdNiwR+4w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@monokle/components/-/components-1.4.1.tgz",
+      "integrity": "sha512-beVLHlzIaFUrgk7z14sOpoOce0cpcTzAgAtOfjVwivz5SJ5C8WVLDO7lliiJwBx+585JXuYbgh3AZcVZKlEgNQ==",
       "dependencies": {
         "react-fast-compare": "^3.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@dnd-kit/core": "6.0.8",
     "@dnd-kit/sortable": "7.0.2",
     "@kubernetes/client-node": "0.18.1",
-    "@monokle/components": "1.4.0",
+    "@monokle/components": "1.4.1",
     "@monokle/validation": "0.16.0",
     "@open-policy-agent/opa-wasm": "1.8.0",
     "@reduxjs/toolkit": "1.9.3",

--- a/src/components/molecules/ClosedPanePlaceholder/ClosedPanePlaceholder.tsx
+++ b/src/components/molecules/ClosedPanePlaceholder/ClosedPanePlaceholder.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+import {useAppDispatch} from '@redux/hooks';
+import {toggleLeftMenu} from '@redux/reducers/ui';
+
+import {PaneCloseIcon} from '@monokle/components';
+import {CLOSED_PANE_PLACEHOLDER_WIDTH} from '@shared/constants/constants';
+import {Colors} from '@shared/styles/colors';
+
+const ClosedPanePlaceholder: React.FC = () => {
+  const dispatch = useAppDispatch();
+
+  return (
+    <Container>
+      <PaneCloseIcon
+        onClick={() => dispatch(toggleLeftMenu())}
+        containerStyle={{position: 'absolute', top: '20px', right: '-8px', zIndex: 1000, transform: 'rotate(180deg)'}}
+      />
+    </Container>
+  );
+};
+
+export default ClosedPanePlaceholder;
+
+// Styled Components
+
+const Container = styled.div`
+  position: relative;
+  overflow-x: visible;
+  height: 100%;
+  width: ${CLOSED_PANE_PLACEHOLDER_WIDTH}px;
+  background-color: ${Colors.grey10};
+`;

--- a/src/components/molecules/ClosedPanePlaceholder/index.ts
+++ b/src/components/molecules/ClosedPanePlaceholder/index.ts
@@ -1,0 +1,1 @@
+export {default} from './ClosedPanePlaceholder';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,6 +1,7 @@
 export {default as BranchSelect} from './BranchSelect';
 export {default as ChangeFiltersConfirmModal} from './ChangeFiltersConfirmModal';
 export {default as CheckedResourcesActionsMenu} from './CheckedResourcesActionsMenu';
+export {default as ClosedPanePlaceholder} from './ClosedPanePlaceholder';
 export {default as FormEditor} from './FormEditor';
 export {default as HelmChartModalConfirmWithNamespaceSelect} from './HelmChartModalConfirmWithNamespaceSelect';
 export {default as ImageDetails} from './ImageDetails';

--- a/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
+++ b/src/components/organisms/BottomPaneManager/BottomPaneManager.styled.tsx
@@ -19,7 +19,7 @@ export const BottomPaneManagerContainer = styled.div<{$isLeftMenuActive: boolean
 
   ${({$isLeftMenuActive}) => {
     if ($isLeftMenuActive) {
-      return `border-left: 9px solid ${PanelColors.toolBar}`;
+      return `border-left: 12px solid ${PanelColors.toolBar}`;
     }
   }}
 `;

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -9,6 +9,8 @@ import {setPaneConfiguration, toggleLeftMenu} from '@redux/reducers/ui';
 import {ActionsPane, BottomPaneManager, Dashboard, GitOpsView, NavigatorPane} from '@organisms';
 import {EmptyDashboard} from '@organisms/Dashboard/EmptyDashboard';
 
+import {ClosedPanePlaceholder} from '@molecules';
+
 import {useMainPaneDimensions} from '@utils/hooks';
 
 import {ResizableColumnsPanel, ResizableRowsPanel} from '@monokle/components';
@@ -43,8 +45,12 @@ const PaneManager: React.FC = () => {
       return '1fr';
     }
 
+    if (!leftMenuActive) {
+      return 'max-content 12px 1fr';
+    }
+
     return 'max-content 1fr';
-  }, [activeProject, isStartProjectPaneVisible, isInQuickClusterMode]);
+  }, [activeProject, isInQuickClusterMode, isStartProjectPaneVisible, leftMenuActive]);
 
   const handleColumnResize = useCallback(
     (sizes: number[]) => {
@@ -74,6 +80,8 @@ const PaneManager: React.FC = () => {
     [currentActivity?.name, dispatch, width]
   );
 
+  console.log(currentActivity);
+
   const columnsSizes = useMemo(() => {
     const editPane = layout.editPane === 0 ? 1 - layout.leftPane - layout.navPane : layout.editPane;
 
@@ -95,6 +103,8 @@ const PaneManager: React.FC = () => {
 
     return [navPaneWidth, 0, editPaneWidth];
   }, [currentActivity?.name, layout.editPane, layout.leftPane, layout.navPane, leftMenuActive, width]);
+
+  console.log(columnsSizes);
 
   const rowsSizes = useMemo(() => {
     return [height - layout.bottomPaneHeight, layout.bottomPaneHeight];
@@ -127,6 +137,8 @@ const PaneManager: React.FC = () => {
         <>
           <PaneManagerLeftMenu />
 
+          {!leftMenuActive && <ClosedPanePlaceholder />}
+
           <ResizableRowsPanel
             defaultSizes={rowsSizes}
             top={
@@ -140,6 +152,7 @@ const PaneManager: React.FC = () => {
                 )
               ) : (
                 <ResizableColumnsPanel
+                  isLeftActive={leftMenuActive}
                   key={currentActivity?.name}
                   paneCloseIconStyle={{top: '20px', right: '-8px'}}
                   left={leftMenuActive ? currentActivity?.component : undefined}

--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -80,8 +80,6 @@ const PaneManager: React.FC = () => {
     [currentActivity?.name, dispatch, width]
   );
 
-  console.log(currentActivity);
-
   const columnsSizes = useMemo(() => {
     const editPane = layout.editPane === 0 ? 1 - layout.leftPane - layout.navPane : layout.editPane;
 
@@ -103,8 +101,6 @@ const PaneManager: React.FC = () => {
 
     return [navPaneWidth, 0, editPaneWidth];
   }, [currentActivity?.name, layout.editPane, layout.leftPane, layout.navPane, leftMenuActive, width]);
-
-  console.log(columnsSizes);
 
   const rowsSizes = useMemo(() => {
     return [height - layout.bottomPaneHeight, layout.bottomPaneHeight];

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -19,8 +19,8 @@ const PaneManagerLeftMenu: React.FC = () => {
   const isInQuickClusterMode = useAppSelector(state => state.ui.isInQuickClusterMode);
 
   const isActive = useMemo(
-    () => Boolean(activeProject || isInQuickClusterMode) && leftActive,
-    [activeProject, leftActive, isInQuickClusterMode]
+    () => Boolean(activeProject || isInQuickClusterMode) && Boolean(leftMenuSelection),
+    [activeProject, isInQuickClusterMode, leftMenuSelection]
   );
 
   return (

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -45,7 +45,6 @@ export const DEFAULT_PANE_CONFIGURATION: PaneConfiguration = {
   navPane: 0.25,
   editPane: 0,
   bottomPaneHeight: 250,
-  recentProjectsPaneWidth: 450,
 };
 
 export const PANE_CONSTRAINT_VALUES = {

--- a/src/shared/constants/constants.ts
+++ b/src/shared/constants/constants.ts
@@ -1,1 +1,2 @@
 export const ERROR_MSG_FALLBACK = 'Looks like something unexpected went wrong. Please try again later.';
+export const CLOSED_PANE_PLACEHOLDER_WIDTH = 12;

--- a/src/shared/models/ui.ts
+++ b/src/shared/models/ui.ts
@@ -83,7 +83,6 @@ type PaneConfiguration = {
   navPane: number;
   editPane: number;
   bottomPaneHeight: number;
-  recentProjectsPaneWidth: number;
 };
 
 type RightMenuSelectionType = 'logs' | 'graph';


### PR DESCRIPTION
## Changes

- Styling when the left pane is closed ( explorer )

## Fixes

- Styling when an option is active

## Screenshots

![image](https://user-images.githubusercontent.com/47887589/237059810-9baf9abd-c91e-4742-882c-932e97e23d52.png)

![image](https://user-images.githubusercontent.com/47887589/237060035-0e64faa6-60f6-4b69-9d02-bb73f752e312.png)

![image](https://user-images.githubusercontent.com/47887589/237060113-3041933b-84e3-460a-ba43-5a836cc9eaed.png)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
