### PR TITLE
fix: rendering of kustomization name when in root folder

### DIFF
--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
@@ -68,7 +68,7 @@ const KustomizeRenderer: React.FC<IProps> = props => {
       </S.PrefixContainer>
 
       <S.ItemName isDisabled={isDisabled} isSelected={isSelected} isHighlighted={isHighlighted}>
-        {isLocalOrigin(resourceMeta.origin)
+        {isLocalOrigin(resourceMeta.origin) && resourceMeta.origin.filePath.lastIndexOf('/') > 1
           ? resourceMeta.origin.filePath.substring(0, resourceMeta.origin.filePath.lastIndexOf('/'))
           : resourceMeta.name}
       </S.ItemName>


### PR DESCRIPTION
This PR fixes the rendering of an empty string when an overlay is in the root folder

## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
