### PR TITLE
refactor: remove New File/Folder from file context menu

### DIFF
--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
@@ -6,7 +6,7 @@ import {ItemType as AntdMenuItem} from 'antd/lib/menu/hooks/useItems';
 import {ExclamationCircleOutlined} from '@ant-design/icons';
 
 import micromatch from 'micromatch';
-import {basename, dirname, join, sep} from 'path';
+import {basename, dirname, join} from 'path';
 
 import {scanExcludesSelector, updateProjectConfig} from '@redux/appConfig';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
@@ -406,32 +406,6 @@ export const useFileMenuItems = (
         },
       });
     }
-
-    newMenuItems.push({
-      key: 'new-file',
-      label: 'New File',
-      onClick: () => {
-        dispatch(
-          openCreateFileFolderModal({
-            rootDir: join(fileEntry.rootFolderPath, fileEntry.filePath.split(sep).slice(0, -1).join(sep)),
-            type: 'file',
-          })
-        );
-      },
-    });
-
-    newMenuItems.push({
-      key: 'new-folder',
-      label: 'New Folder',
-      onClick: () => {
-        dispatch(
-          openCreateFileFolderModal({
-            rootDir: join(fileEntry.rootFolderPath, fileEntry.filePath.split(sep).slice(0, -1).join(sep)),
-            type: 'folder',
-          })
-        );
-      },
-    });
 
     newMenuItems.push({
       key: 'add-resource',


### PR DESCRIPTION
## Changes

- Remove `New File/Folder` from file context menu



## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/29588e5a-be94-4cad-80c1-7d66174686ba)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
