### PR TITLE
fix: tracking event when clicking on the same option currently selected

### DIFF
--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -155,7 +155,7 @@ const PaneManager: React.FC = () => {
                   isLeftActive={leftMenuActive}
                   key={currentActivity?.name}
                   paneCloseIconStyle={{top: '20px', right: '-8px'}}
-                  left={leftMenuActive ? currentActivity?.component : undefined}
+                  left={leftMenuActive || currentActivity?.name !== 'explorer' ? currentActivity?.component : undefined}
                   center={currentActivity?.name === 'explorer' ? <NavigatorPane /> : undefined}
                   right={
                     currentActivity?.name === 'git' ? (

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -32,17 +32,16 @@ const PaneManagerLeftMenu: React.FC = () => {
       value={leftMenuSelection}
       extraValue={leftMenuBottomSelection}
       onChange={activityName => {
-        if (
-          !['compare', 'settings', 'dashboard'].includes(activityName) &&
-          activityName === leftMenuSelection &&
-          leftActive
-        ) {
-          dispatch(setLeftMenuIsActive(false));
-          return;
+        if (!leftActive && activityName === 'explorer') {
+          dispatch(setLeftMenuIsActive(true));
         }
 
-        if (!leftActive) {
+        if (!leftActive && activityName === leftMenuSelection && leftMenuSelection === 'explorer') {
           dispatch(setLeftMenuIsActive(true));
+        }
+
+        if (activityName === leftMenuSelection) {
+          return;
         }
 
         dispatch(setLeftMenuSelection(activityName));


### PR DESCRIPTION
## Fixes

- Clicking on the same currently selected option would trigger the active status and the event tracking

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
