### PR TITLE
refactor: is hovered renderers + change preview to dry-run

### DIFF
--- a/src/components/molecules/QuickActionCompare/QuickActionCompare.styled.tsx
+++ b/src/components/molecules/QuickActionCompare/QuickActionCompare.styled.tsx
@@ -14,4 +14,5 @@ export const PreviewSpan = styled.span<{isItemSelected: boolean}>`
   color: ${props => (props.isItemSelected ? Colors.blackPure : Colors.blue6)};
   margin-left: 5px;
   margin-right: 15px;
+  white-space: nowrap;
 `;

--- a/src/components/molecules/QuickActionPreview/QuickActionPreview.styled.tsx
+++ b/src/components/molecules/QuickActionPreview/QuickActionPreview.styled.tsx
@@ -20,6 +20,7 @@ export const PreviewSpan = styled.span<{isItemSelected: boolean}>`
   color: ${props => (props.isItemSelected ? Colors.blackPure : Colors.blue6)};
   margin-left: 5px;
   margin-right: 15px;
+  white-space: nowrap;
 `;
 
 export const ReloadSpan = styled.span<{isItemSelected: boolean}>`

--- a/src/components/molecules/QuickActionPreview/QuickActionPreview.tsx
+++ b/src/components/molecules/QuickActionPreview/QuickActionPreview.tsx
@@ -41,7 +41,7 @@ const QuickActionPreview: React.FC<IProps> = props => {
           </S.PreviewSpan>
         ) : (
           <S.PreviewSpan isItemSelected={isItemSelected} onClick={selectAndPreview}>
-            Preview
+            Dry-run
           </S.PreviewSpan>
         )}
       </Tooltip>

--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/TreeNode.styled.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/TreeNode.styled.tsx
@@ -12,9 +12,14 @@ export const ActionButtonsContainer = styled.div`
   justify-content: flex-end;
   flex-direction: row;
   height: 100%;
+  z-index: 1;
   position: absolute;
   right: 0;
   cursor: pointer;
+`;
+
+export const ContextMenuPlaceholder = styled.div`
+  width: 15px;
 `;
 
 export const PreviewButton = styled(Button)<{$isItemSelected: boolean}>`

--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/TreeNodeFile.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/TreeNodeFile.tsx
@@ -16,7 +16,6 @@ import {Spinner} from '@monokle/components';
 import {FileEntry} from '@shared/models/fileEntry';
 import {Colors} from '@shared/styles';
 import {isEqual} from '@shared/utils/isEqual';
-import {isInClusterModeSelector, isInPreviewModeSelector} from '@shared/utils/selectors';
 
 import * as S from './TreeNode.styled';
 import {useCanPreview, useDelete, useFileMenuItems, useIsDisabled, usePreview} from './hooks';
@@ -28,9 +27,9 @@ type Props = {
 const TreeNodeFile: React.FC<Props> = props => {
   const {filePath} = props;
   const fileEntry: FileEntry | undefined = useAppSelector(state => state.main.fileMap[filePath]);
-  const isInClusterMode = useAppSelector(isInClusterModeSelector);
-  const isInPreviewMode = useAppSelector(isInPreviewModeSelector);
+
   const selectedFilePath = useAppSelector(selectionFilePathSelector);
+
   const isSelected = selectedFilePath === filePath;
   const isDisabled = useIsDisabled(fileEntry);
   const canBePreviewed = useCanPreview(fileEntry, isDisabled);
@@ -87,27 +86,28 @@ const TreeNodeFile: React.FC<Props> = props => {
         </S.SpinnerContainer>
       )}
 
-      {isHovered && (
-        <S.ActionButtonsContainer ref={actionButtonsRef} onClick={e => e.stopPropagation()}>
-          {canBePreviewed && (
-            <S.PreviewButton
-              type="text"
-              size="small"
-              disabled={isInPreviewMode || isInClusterMode}
-              $isItemSelected={isSelected}
-              onClick={() => preview(fileEntry.filePath)}
-            >
-              Preview
-            </S.PreviewButton>
-          )}
+      <S.ActionButtonsContainer ref={actionButtonsRef} onClick={e => e.stopPropagation()}>
+        {canBePreviewed && (
+          <S.PreviewButton
+            type="text"
+            size="small"
+            $isItemSelected={isSelected}
+            onClick={() => preview(fileEntry.filePath)}
+          >
+            Dry-run
+          </S.PreviewButton>
+        )}
 
+        {isHovered ? (
           <ContextMenu items={menuItems}>
             <div ref={contextMenuButtonRef}>
               <Dots color={isSelected ? Colors.blackPure : undefined} />
             </div>
           </ContextMenu>
-        </S.ActionButtonsContainer>
-      )}
+        ) : (
+          <S.ContextMenuPlaceholder />
+        )}
+      </S.ActionButtonsContainer>
     </S.NodeContainer>
   );
 };

--- a/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
+++ b/src/components/organisms/ExplorerPane/FilePane/FileSystemTree/TreeNode/hooks.tsx
@@ -131,6 +131,7 @@ export const usePreview = () => {
   const localResourceMetaMapRef = useResourceMetaMapRef('local');
   const fileMapRef = useRefSelector(state => state.main.fileMap);
   const helmValuesMapRef = useRefSelector(state => state.main.helmValuesMap);
+  const currentPreviewRef = useRefSelector(state => state.main.preview);
 
   const dispatch = useAppDispatch();
 
@@ -138,18 +139,27 @@ export const usePreview = () => {
     (relativePath: string) => {
       const resourceMetas = getLocalResourceMetasForPath(relativePath, localResourceMetaMapRef.current);
       if (resourceMetas && resourceMetas.length === 1 && isKustomizationResource(resourceMetas[0])) {
+        if (
+          currentPreviewRef.current?.type === 'kustomize' &&
+          currentPreviewRef.current.kustomizationId === resourceMetas[0].id
+        )
+          return;
+
         startPreview({type: 'kustomize', kustomizationId: resourceMetas[0].id}, dispatch);
       } else {
         const fileEntry = fileMapRef.current[relativePath];
         if (fileEntry) {
           const valuesFile = getHelmValuesFile(fileEntry, helmValuesMapRef.current);
           if (valuesFile) {
+            if (currentPreviewRef.current?.type === 'helm' && currentPreviewRef.current.valuesFileId === valuesFile.id)
+              return;
+
             startPreview({type: 'helm', valuesFileId: valuesFile.id, chartId: valuesFile.helmChartId}, dispatch);
           }
         }
       }
     },
-    [dispatch, localResourceMetaMapRef, fileMapRef, helmValuesMapRef]
+    [localResourceMetaMapRef, dispatch, fileMapRef, helmValuesMapRef, currentPreviewRef]
   );
 
   return preview;
@@ -593,6 +603,8 @@ export const useFolderMenuItems = (
     dispatch,
     createNewResource,
     onFilterByFileOrFolder,
+    removeEntryFromScanExcludes,
+    addEntryToScanExcludes,
   ]);
 
   return menuItems;

--- a/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
@@ -68,16 +68,18 @@ const HelmChartRenderer: React.FC<IProps> = props => {
         <S.SuffixContainer isSelected={isSelected}>{dirname(helmChart.filePath)}</S.SuffixContainer>
       </Tooltip>
 
-      <div
-        style={{display: 'flex', alignItems: 'center', marginLeft: 'auto'}}
-        onClick={e => {
-          e.stopPropagation();
-        }}
-      >
-        <S.ContextMenuContainer>
-          <HelmContextMenu id={id} isSelected={isSelected} />
-        </S.ContextMenuContainer>
-      </div>
+      {isHovered && (
+        <div
+          style={{display: 'flex', alignItems: 'center', marginLeft: 'auto'}}
+          onClick={e => {
+            e.stopPropagation();
+          }}
+        >
+          <S.ContextMenuContainer>
+            <HelmContextMenu id={id} isSelected={isSelected} />
+          </S.ContextMenuContainer>
+        </div>
+      )}
     </S.ItemContainer>
   );
 };

--- a/src/components/organisms/ExplorerPane/HelmPane/HelmValueRenderer/HelmValueRenderer.styled.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmValueRenderer/HelmValueRenderer.styled.tsx
@@ -13,6 +13,10 @@ type ItemNameProps = {
   isSelected: boolean;
 };
 
+export const ContextMenuPlaceholder = styled.div`
+  width: 31px;
+`;
+
 export const ItemContainer = styled.span<ItemContainerProps>`
   display: flex;
   align-items: center;

--- a/src/components/organisms/ExplorerPane/HelmPane/HelmValueRenderer/HelmValueRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmValueRenderer/HelmValueRenderer.tsx
@@ -63,9 +63,13 @@ const HelmValueRenderer: React.FC<IProps> = props => {
           <HelmValueQuickAction id={helmValue.id} isSelected={isSelected} />
         </S.QuickActionContainer>
 
-        <S.ContextMenuContainer>
-          <HelmContextMenu id={id} isSelected={isSelected} />
-        </S.ContextMenuContainer>
+        {isHovered ? (
+          <S.ContextMenuContainer>
+            <HelmContextMenu id={id} isSelected={isSelected} />
+          </S.ContextMenuContainer>
+        ) : (
+          <S.ContextMenuPlaceholder />
+        )}
       </div>
     </S.ItemContainer>
   );

--- a/src/components/organisms/ExplorerPane/ImagesPane/ImageFilteredTag.tsx
+++ b/src/components/organisms/ExplorerPane/ImagesPane/ImageFilteredTag.tsx
@@ -20,7 +20,7 @@ const ImageFilteredTag: React.FC = () => {
   }
 
   if (isInPreviewMode) {
-    return <PreviewOutputTag>Filtered By Dry-running Mode</PreviewOutputTag>;
+    return <PreviewOutputTag>Filtered By Dry-run</PreviewOutputTag>;
   }
 
   return null;

--- a/src/components/organisms/ExplorerPane/ImagesPane/ImageFilteredTag.tsx
+++ b/src/components/organisms/ExplorerPane/ImagesPane/ImageFilteredTag.tsx
@@ -20,7 +20,7 @@ const ImageFilteredTag: React.FC = () => {
   }
 
   if (isInPreviewMode) {
-    return <PreviewOutputTag>Filtered By Preview Mode</PreviewOutputTag>;
+    return <PreviewOutputTag>Filtered By Dry-running Mode</PreviewOutputTag>;
   }
 
   return null;

--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.styled.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.styled.tsx
@@ -10,6 +10,10 @@ type ItemNameProps = {
   isHighlighted: boolean;
 };
 
+export const ContextMenuPlaceholder = styled.div`
+  width: 31px;
+`;
+
 export const ItemContainer = styled.span<ItemContainerProps>`
   display: flex;
   align-items: center;

--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
@@ -87,9 +87,13 @@ const KustomizeRenderer: React.FC<IProps> = props => {
           <KustomizeQuickAction id={resourceMeta.id} isSelected={isSelected} />
         </S.QuickActionContainer>
 
-        <S.ContextMenuContainer>
-          <KustomizeContextMenu id={resourceMeta.id} isSelected={isSelected} />
-        </S.ContextMenuContainer>
+        {isHovered ? (
+          <S.ContextMenuContainer>
+            <KustomizeContextMenu id={resourceMeta.id} isSelected={isSelected} />
+          </S.ContextMenuContainer>
+        ) : (
+          <S.ContextMenuPlaceholder />
+        )}
       </div>
     </S.ItemContainer>
   );

--- a/src/components/organisms/PageHeader/PreviewControl/PreviewLabel.tsx
+++ b/src/components/organisms/PageHeader/PreviewControl/PreviewLabel.tsx
@@ -22,7 +22,7 @@ export function PreviewLabel() {
       <LabelBox>
         {PREVIEW_ICON_MAP[preview.type]}
         <LabelContent>
-          Previewing <span style={{fontWeight: 700}}>{previewDisplayContent.name}</span>
+          Dry-running <span style={{fontWeight: 700}}>{previewDisplayContent.name}</span>
         </LabelContent>
       </LabelBox>
     </Tooltip>

--- a/src/components/organisms/PageHeader/PreviewControl/PreviewLabel.tsx
+++ b/src/components/organisms/PageHeader/PreviewControl/PreviewLabel.tsx
@@ -22,7 +22,7 @@ export function PreviewLabel() {
       <LabelBox>
         {PREVIEW_ICON_MAP[preview.type]}
         <LabelContent>
-          Dry-running <span style={{fontWeight: 700}}>{previewDisplayContent.name}</span>
+          Performing Dry-run <span style={{fontWeight: 700}}>{previewDisplayContent.name}</span>
         </LabelContent>
       </LabelBox>
     </Tooltip>

--- a/src/redux/ipcRendererRedux.ts
+++ b/src/redux/ipcRendererRedux.ts
@@ -64,7 +64,7 @@ const getWindowTitle = (state: RootState) => {
 
   if (preview?.type === 'kustomize') {
     const kustomization = localResourceMetaMap[preview.kustomizationId];
-    windowTitle = kustomization ? `Monokle - previewing [${kustomization.name}] kustomization` : `Monokle`;
+    windowTitle = kustomization ? `Monokle - dry-running [${kustomization.name}] kustomization` : `Monokle`;
     return windowTitle;
   }
 
@@ -72,7 +72,7 @@ const getWindowTitle = (state: RootState) => {
     const valuesFile = helmValuesMap[preview.valuesFileId];
     const helmChart = helmChartMap[valuesFile.helmChartId];
 
-    windowTitle = `Monokle - previewing ${valuesFile?.name} for ${helmChart?.name} Helm chart`;
+    windowTitle = `Monokle - dry-running ${valuesFile?.name} for ${helmChart?.name} Helm chart`;
     return windowTitle;
   }
 

--- a/src/redux/reducers/main/selectors.ts
+++ b/src/redux/reducers/main/selectors.ts
@@ -23,16 +23,16 @@ export const selectPreviewDisplayContent = (state: RootState): PreviewDisplayCon
     case 'helm': {
       const helmId = preview.chartId;
       const helmChart = state.main.helmChartMap[helmId];
-      if (!helmChart) return {name: 'Helm Chart', description: 'You are previewing a Helm Chart.'};
+      if (!helmChart) return {name: 'Helm Chart', description: 'You are dry-running a Helm Chart.'};
       return {
         name: helmChart.name,
-        description: `You are previewing ${helmChart.name} located at ${helmChart.filePath}.`,
+        description: `You are dry-running ${helmChart.name} located at ${helmChart.filePath}.`,
       };
     }
     case 'helm-config': {
       const helmId = preview.configId;
       const helmConfig = state.config.projectConfig?.helm?.previewConfigurationMap?.[helmId];
-      if (!helmConfig) return {name: 'Helm Chart', description: 'You are previewing a Helm Chart.'};
+      if (!helmConfig) return {name: 'Helm Chart', description: 'You are dry-running a Helm Chart.'};
       const helmChart = state.main.helmChartMap[helmId];
       return {
         name: helmConfig.name,
@@ -47,12 +47,12 @@ export const selectPreviewDisplayContent = (state: RootState): PreviewDisplayCon
       if (!isLocalResourceMeta(kustomization)) {
         return {
           name: 'Kustomize overlay',
-          description: `You are previewing a Kustomize overlay.`,
+          description: `You are dry-running a Kustomize overlay.`,
         };
       }
       return {
         name: 'Kustomize overlay',
-        description: `You are previewing a Kustomize overlay located at ${kustomization.origin.filePath}.`,
+        description: `You are dry-running a Kustomize overlay located at ${kustomization.origin.filePath}.`,
       };
     }
     default:


### PR DESCRIPTION

## Changes

- Show the context menu dots only on hover
- Change `Preview` label to `Dry-run`

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/f7d8a36d-531e-4bd8-9cda-aa9445388ad2)

![image](https://github.com/kubeshop/monokle/assets/47887589/3be258fa-f9ae-4fd8-be31-6e3bf8ef2f27)


## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
