### PR TITLE
fix: catch crd dir exists error

### DIFF
--- a/src/utils/crds.ts
+++ b/src/utils/crds.ts
@@ -12,7 +12,7 @@ export async function saveCRD(crdsDir: string, crdContent: string) {
       await createFolder(crdsDir);
     }
   } catch (error) {
-    log.error(`Failed to create CRDs directory at ${crdsDir}. The dir already exists.`);
+    log.warn(`Failed to create CRDs directory at ${crdsDir}. The dir already exists.`);
   }
 
   try {

--- a/src/utils/crds.ts
+++ b/src/utils/crds.ts
@@ -6,10 +6,15 @@ import {parseAllYamlDocuments} from '@utils/yaml';
 import {createFolder, deleteFile, doesPathExist, writeFile} from '@shared/utils/fileSystem';
 
 export async function saveCRD(crdsDir: string, crdContent: string) {
-  const doesPluginsDirExist = await doesPathExist(crdsDir);
-  if (!doesPluginsDirExist) {
-    await createFolder(crdsDir);
+  try {
+    const doesPluginsDirExist = await doesPathExist(crdsDir);
+    if (!doesPluginsDirExist) {
+      await createFolder(crdsDir);
+    }
+  } catch (error) {
+    log.error(`Failed to create CRDs directory at ${crdsDir}. The dir already exists.`);
   }
+
   try {
     const documents = parseAllYamlDocuments(crdContent);
     for (let i = 0; i < documents.length; i += 1) {


### PR DESCRIPTION
This PR...

## Changes

- added tr/catch cluse to handle EEXIST: file already exists. 

## Fixes

-  fixing a race condition while saving many crds at once 

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
