### PR TITLE
fix: annotations white-space

### DIFF
--- a/src/components/organisms/Dashboard/Tableview/InfoTab.styled.tsx
+++ b/src/components/organisms/Dashboard/Tableview/InfoTab.styled.tsx
@@ -10,6 +10,10 @@ export const Container = styled.div`
 
 export const Row = styled.div`
   margin-bottom: 24px;
+
+  & .ant-tag {
+    white-space: normal;
+  }
 `;
 
 export const Title = styled.div`

--- a/src/components/organisms/Dashboard/Tableview/InfoTab.tsx
+++ b/src/components/organisms/Dashboard/Tableview/InfoTab.tsx
@@ -91,7 +91,7 @@ export const Labels = ({labels}: {labels: any}) => {
 export const Annotations = ({annotations}: {annotations: any}) => {
   return (
     <S.Row>
-      <S.Title>Annotations</S.Title>
+      <S.Title style={{marginBottom: '6px'}}>Annotations</S.Title>
       <div>
         {Object.keys(annotations).map(key => (
           <Tag key={`${key}=${annotations[key]}`} color="geekblue" style={{marginBottom: '4px'}}>


### PR DESCRIPTION
## Fixes

- Annotations tags taking width wider than the full-width of parent container

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/2a84e6cf-1434-4b6c-892c-3c2fa6bd9e85)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
