### PR TITLE
fix: keep leftMenuActive status when changing options

### DIFF
--- a/src/components/organisms/PaneManager/PaneManager.tsx
+++ b/src/components/organisms/PaneManager/PaneManager.tsx
@@ -95,16 +95,12 @@ const PaneManager: React.FC = () => {
       return [leftPaneWidth, 350, 1 - leftPaneWidth - 350];
     }
 
-    if (leftMenuActive && currentActivity?.name === 'explorer') {
+    if (currentActivity?.name === 'explorer') {
       return [leftPaneWidth, navPaneWidth, editPaneWidth];
     }
 
-    if (currentActivity?.name !== 'explorer') {
-      return [leftPaneWidth, 0, width - leftPaneWidth];
-    }
-
-    return [navPaneWidth, 0, editPaneWidth];
-  }, [currentActivity?.name, layout.editPane, layout.leftPane, layout.navPane, leftMenuActive, width]);
+    return [leftPaneWidth, 0, width - leftPaneWidth];
+  }, [currentActivity?.name, layout.editPane, layout.leftPane, layout.navPane, width]);
 
   const rowsSizes = useMemo(() => {
     return [height - layout.bottomPaneHeight, layout.bottomPaneHeight];
@@ -153,9 +149,12 @@ const PaneManager: React.FC = () => {
               ) : (
                 <ResizableColumnsPanel
                   isLeftActive={leftMenuActive}
-                  key={currentActivity?.name}
                   paneCloseIconStyle={{top: '20px', right: '-8px'}}
-                  left={leftMenuActive || currentActivity?.name !== 'explorer' ? currentActivity?.component : undefined}
+                  left={
+                    currentActivity?.name !== 'explorer' || (leftMenuActive && currentActivity.name === 'explorer')
+                      ? currentActivity?.component
+                      : undefined
+                  }
                   center={currentActivity?.name === 'explorer' ? <NavigatorPane /> : undefined}
                   right={
                     currentActivity?.name === 'git' ? (

--- a/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
+++ b/src/components/organisms/PaneManager/PaneManagerLeftMenu.tsx
@@ -32,10 +32,6 @@ const PaneManagerLeftMenu: React.FC = () => {
       value={leftMenuSelection}
       extraValue={leftMenuBottomSelection}
       onChange={activityName => {
-        if (!leftActive && activityName === 'explorer') {
-          dispatch(setLeftMenuIsActive(true));
-        }
-
         if (!leftActive && activityName === leftMenuSelection && leftMenuSelection === 'explorer') {
           dispatch(setLeftMenuIsActive(true));
         }


### PR DESCRIPTION
## Fixes

- Keep `leftMenuActive` status while changing left menu options

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
