### PR TITLE
fix: kustomize name in compare dropdown

### DIFF
--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeRenderer.tsx
@@ -5,10 +5,10 @@ import {selectResource} from '@redux/reducers/main';
 import {useResourceMeta} from '@redux/selectors/resourceSelectors';
 import {isResourceHighlighted, isResourceSelected} from '@redux/services/resource';
 
+import {renderKustomizeName} from '@utils/kustomize';
 import {isResourcePassingFilter} from '@utils/resources';
 
 import {ResourceIdentifier} from '@shared/models/k8sResource';
-import {isLocalOrigin} from '@shared/models/origin';
 import {trackEvent} from '@shared/utils';
 import {isEqual} from '@shared/utils/isEqual';
 import {isInClusterModeSelector} from '@shared/utils/selectors';
@@ -68,9 +68,7 @@ const KustomizeRenderer: React.FC<IProps> = props => {
       </S.PrefixContainer>
 
       <S.ItemName isDisabled={isDisabled} isSelected={isSelected} isHighlighted={isHighlighted}>
-        {isLocalOrigin(resourceMeta.origin) && resourceMeta.origin.filePath.lastIndexOf('/') > 1
-          ? resourceMeta.origin.filePath.substring(0, resourceMeta.origin.filePath.lastIndexOf('/'))
-          : resourceMeta.name}
+        {renderKustomizeName(resourceMeta, resourceMeta.name)}
       </S.ItemName>
 
       <S.SuffixContainer>

--- a/src/components/organisms/ResourceSetSelector/KustomizeSelect.tsx
+++ b/src/components/organisms/ResourceSetSelector/KustomizeSelect.tsx
@@ -7,6 +7,8 @@ import invariant from 'tiny-invariant';
 import {resourceSetSelected, selectKustomizeResourceSet} from '@redux/compare';
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 
+import {renderKustomizeName} from '@utils/kustomize';
+
 import {PartialResourceSet} from '@shared/models/compare';
 
 import * as S from './ResourceSetSelectColor.styled';
@@ -41,7 +43,7 @@ export const KustomizeSelect: React.FC<Props> = ({side}) => {
         {allKustomizations.map(kustomization => {
           return (
             <Select.Option key={kustomization.id} value={kustomization.id}>
-              {kustomization.name}
+              {renderKustomizeName(kustomization, kustomization.name)}
             </Select.Option>
           );
         })}

--- a/src/utils/kustomize.ts
+++ b/src/utils/kustomize.ts
@@ -1,0 +1,7 @@
+import {ResourceMeta} from '@shared/models/k8sResource';
+import {isLocalOrigin} from '@shared/models/origin';
+
+export const renderKustomizeName = (meta: ResourceMeta<'local' | 'cluster' | 'preview' | 'transient'>, name: string) =>
+  isLocalOrigin(meta.origin) && meta.origin.filePath.lastIndexOf('/') > 1
+    ? meta.origin.filePath.substring(0, meta.origin.filePath.lastIndexOf('/'))
+    : name;


### PR DESCRIPTION
## Fixes

- Kustomize name rendering in compare dropdown

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
