### PR TITLE
feat: match cluster namespace with the graph filter namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/core": "6.0.8",
         "@dnd-kit/sortable": "7.0.2",
         "@kubernetes/client-node": "0.18.1",
-        "@monokle/components": "1.4.3",
+        "@monokle/components": "1.4.4",
         "@monokle/validation": "0.16.0",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@reduxjs/toolkit": "1.9.5",
@@ -4351,9 +4351,9 @@
       }
     },
     "node_modules/@monokle/components": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@monokle/components/-/components-1.4.3.tgz",
-      "integrity": "sha512-dhcYri2XS5huYNIJ+P0JucqBISceElKu7jnKmUJKMdDB2Cp9bmvDzQxLZ+84MtHLFnBSBr8QXmZl4zTU+eHdZA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@monokle/components/-/components-1.4.4.tgz",
+      "integrity": "sha512-PPqfEVTO+DtdJVcIBtiQ8wd28oL++VGgFWOz9evT1EDYQ3ZCEhM7L1/DWis3Ii+K79yzDKYqcAoMxKzsYnMJ9w==",
       "dependencies": {
         "react-fast-compare": "^3.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@dnd-kit/core": "6.0.8",
     "@dnd-kit/sortable": "7.0.2",
     "@kubernetes/client-node": "0.18.1",
-    "@monokle/components": "1.4.3",
+    "@monokle/components": "1.4.4",
     "@monokle/validation": "0.16.0",
     "@open-policy-agent/opa-wasm": "1.8.0",
     "@reduxjs/toolkit": "1.9.5",

--- a/src/components/molecules/ResourceGraphTab/ResourceGraphTab.tsx
+++ b/src/components/molecules/ResourceGraphTab/ResourceGraphTab.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
-import {useAppDispatch} from '@redux/hooks';
+import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectImage, selectResource} from '@redux/reducers/main';
 import {setExplorerSelectedSection} from '@redux/reducers/ui';
 import {
@@ -22,9 +22,10 @@ import {trackEvent} from '@shared/utils';
 
 const ResourceGraphTab: React.FC = () => {
   const dispatch = useAppDispatch();
-  const selectedResource = useSelectedResource();
+  const clusterConnectionNamespace = useAppSelector(state => state.main.clusterConnection?.namespace || '');
   const activeResoureMetaMap = useActiveResourceMetaMap();
   const activeResoureContentMap = useActiveResourceContentMap();
+  const selectedResource = useSelectedResource();
   const transientResourceMetaMap = useResourceMetaMap('transient');
   const transientResourceContentMap = useResourceContentMap('transient');
 
@@ -96,6 +97,13 @@ const ResourceGraphTab: React.FC = () => {
       onSelectResource={onSelectResource}
       onSelectImage={onSelectImage}
       elkWorker={elkWorker}
+      defaultNamespace={
+        clusterConnectionNamespace
+          ? clusterConnectionNamespace !== '<all>' && clusterConnectionNamespace !== '<not-namespaced>'
+            ? clusterConnectionNamespace
+            : undefined
+          : undefined
+      }
     />
   );
 };


### PR DESCRIPTION
## Fixes

- Match cluster namespace with the graph namespace filter

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/1842db38-c27a-42ef-964c-c1bd75e5442a)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
