### PR TITLE
fix: add modal confirms when transferring in compare

### DIFF
--- a/src/components/organisms/CompareSyncPane/CompareSyncPane.tsx
+++ b/src/components/organisms/CompareSyncPane/CompareSyncPane.tsx
@@ -13,8 +13,7 @@ import CompareModalComparing from './CompareModalComparing';
 import CompareModalSelecting from './CompareModalSelecting';
 import * as S from './CompareSyncPane.styled';
 import InspectionActionBar from './InspectionActionBar';
-
-// import TransferButton from './TransferButton';
+import TransferButton from './TransferButton';
 
 const CompareSyncPane: React.FC = () => {
   const inspection = useAppSelector(state => state.compare.current.inspect);
@@ -27,7 +26,6 @@ const CompareSyncPane: React.FC = () => {
   return (
     <S.CompareSyncPaneContainer>
       <TitleBar title="Compare & Sync" description={!inspection ? <CompareActionBar /> : <InspectionActionBar />} />
-
       <Row ref={containerRef}>
         <Col span={10}>
           <ResourceSetSelector side="left" />
@@ -41,8 +39,6 @@ const CompareSyncPane: React.FC = () => {
         {status === 'selecting' ? <CompareModalSelecting /> : <CompareModalComparing />}
       </S.Content>
 
-      {/*
-      TODO: 2.0+ re-enable transfer button after fixing transferResource.fulfilled
       {!inspection || inspection?.type === 'diff' ? (
         <S.ActionsRow>
           <Col span={10}>
@@ -53,7 +49,7 @@ const CompareSyncPane: React.FC = () => {
             <TransferButton side="right" />
           </Col>
         </S.ActionsRow>
-      ) : null} */}
+      ) : null}
     </S.CompareSyncPaneContainer>
   );
 };

--- a/src/components/organisms/CompareSyncPane/InspectionActionBar/InspectionActionBar.styled.tsx
+++ b/src/components/organisms/CompareSyncPane/InspectionActionBar/InspectionActionBar.styled.tsx
@@ -5,6 +5,7 @@ export const ActionBarDiv = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 9px 12px;
+  width: 100%;
 `;
 
 export const ActionBarRightDiv = styled.div`

--- a/src/components/organisms/CompareSyncPane/TransferButton/TransferButton.tsx
+++ b/src/components/organisms/CompareSyncPane/TransferButton/TransferButton.tsx
@@ -1,6 +1,6 @@
 import {useCallback} from 'react';
 
-import {Button} from 'antd';
+import {Button, Modal} from 'antd';
 
 import {ArrowLeftOutlined, ArrowRightOutlined} from '@ant-design/icons';
 
@@ -43,8 +43,14 @@ const TransferButton: React.FC<Props> = ({side}) => {
   });
 
   const handleTransfer = useCallback(() => {
-    dispatch(transferResource({ids, direction}));
-  }, [direction, dispatch, ids]);
+    Modal.confirm({
+      title: `Are you sure you want to ${buttonLabel.toLowerCase()}?`,
+      onOk() {
+        dispatch(transferResource({ids, direction}));
+      },
+      onCancel() {},
+    });
+  }, [buttonLabel, direction, dispatch, ids]);
 
   if (status === 'selecting') {
     return null;


### PR DESCRIPTION
## Fixes

- Show a confirm when trying to transfer a resource in the compare & sync
- Show back the extract buttons inside the inspection ( diff )

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
