### PR TITLE
fix: on selecting a file, expand tree accordingly

### DIFF
--- a/src/components/organisms/ExplorerPane/HelmPane/HelmContextMenu.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmContextMenu.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectFile} from '@redux/reducers/main';
-import {setLeftMenuSelection} from '@redux/reducers/ui';
+import {setExplorerSelectedSection, setLeftMenuSelection} from '@redux/reducers/ui';
 
 import {ContextMenu, Dots} from '@atoms';
 
@@ -84,6 +84,7 @@ const HelmContextMenu: React.FC<IProps> = props => {
           }
 
           dispatch(setLeftMenuSelection('explorer'));
+          dispatch(setExplorerSelectedSection('files'));
           dispatch(selectFile({filePath: helmItem.filePath}));
         },
       },

--- a/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeContextMenu.tsx
+++ b/src/components/organisms/ExplorerPane/KustomizePane/KustomizeRenderer/KustomizeContextMenu.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {selectFile} from '@redux/reducers/main';
-import {setLeftMenuSelection} from '@redux/reducers/ui';
+import {setExplorerSelectedSection, setLeftMenuSelection} from '@redux/reducers/ui';
 import {useResource} from '@redux/selectors/resourceSelectors';
 import {getAbsoluteFilePath} from '@redux/services/fileEntry';
 import {isResourceSelected} from '@redux/services/resource';
@@ -81,6 +81,7 @@ const KustomizeContextMenu: React.FC<IProps> = props => {
     }
 
     dispatch(setLeftMenuSelection('explorer'));
+    dispatch(setExplorerSelectedSection('files'));
     dispatch(selectFile({filePath: resourceRef.current.origin.filePath}));
   }, [dispatch, resourceRef]);
 

--- a/src/redux/reducers/ui.ts
+++ b/src/redux/reducers/ui.ts
@@ -2,7 +2,7 @@ import {webFrame} from 'electron';
 
 import {Draft, PayloadAction, createSlice} from '@reduxjs/toolkit';
 
-import path from 'path';
+import path, {sep} from 'path';
 import {Entries} from 'type-fest';
 
 import {DEFAULT_PANE_CONFIGURATION} from '@constants/constants';
@@ -35,6 +35,9 @@ import {
   UiState,
 } from '@shared/models/ui';
 import electronStore from '@shared/utils/electronStore';
+import {generateExpandedPaths} from '@shared/utils/file';
+
+import {selectFile} from './main';
 
 export const uiSlice = createSlice({
   name: 'ui',
@@ -434,6 +437,17 @@ export const uiSlice = createSlice({
       })
       .addCase(setRootFolder.rejected, state => {
         state.isFolderLoading = false;
+      })
+      .addCase(selectFile, (state, action) => {
+        if (!action.payload.filePath) {
+          return;
+        }
+
+        const items = action.payload.filePath.split(sep).filter(item => item);
+        state.fileExplorerExpandedFolders = [
+          ...state.fileExplorerExpandedFolders,
+          ...generateExpandedPaths(items, state.fileExplorerExpandedFolders),
+        ];
       })
       .addCase(connectCluster.fulfilled, (state, action) => {
         state.leftMenu.activityBeforeClusterConnect = state.leftMenu.selection;

--- a/src/shared/utils/file.ts
+++ b/src/shared/utils/file.ts
@@ -1,0 +1,16 @@
+import {sep} from 'path';
+
+export const generateExpandedPaths = (items: string[], currentExpandedPaths: string[]) => {
+  let result: string[] = [];
+  let currentPath = '';
+
+  for (let i = 0; i < items.length; i += 1) {
+    currentPath += sep + items[i];
+
+    if (!currentExpandedPaths.includes(currentPath)) {
+      result.push(currentPath);
+    }
+  }
+
+  return result;
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,5 +1,6 @@
 export {default as electronStore} from './electronStore';
 export * from './env';
+export * from './file';
 export * from './fileSystem';
 export * from './helm';
 export * from './hotkey';


### PR DESCRIPTION
## Fixes

- On selecting a file, expand the file tree accordingly so that the selected file is shown
- On select file, set the selected section to `files`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
