### PR TITLE
fix: preview helm configuration

### DIFF
--- a/src/components/organisms/ExplorerPane/PreviewConfigurationPane/PreviewConfigurationRenderer/PreviewConfigurationRenderer.styled.tsx
+++ b/src/components/organisms/ExplorerPane/PreviewConfigurationPane/PreviewConfigurationRenderer/PreviewConfigurationRenderer.styled.tsx
@@ -42,7 +42,6 @@ export const ItemContainer = styled.span<ItemContainerProps>`
       return `background: ${Colors.blackPearl};`;
     }
   }};
-  ${props => !props.isHovered && 'padding-right: 46px;'}
 `;
 
 export const ItemName = styled.div<ItemNameProps>`

--- a/src/utils/helm.ts
+++ b/src/utils/helm.ts
@@ -10,7 +10,11 @@ export function buildHelmCommand(
   rootFolderPath: string,
   clusterContext?: string
 ): string[] {
-  const chartFolderPath = path.join(rootFolderPath, path.dirname(helmChart.filePath));
+  let chartFolderPath = path.join(rootFolderPath, path.dirname(helmChart.filePath));
+
+  if (chartFolderPath.endsWith(path.sep)) {
+    chartFolderPath = chartFolderPath.slice(0, -1);
+  }
 
   const args = [
     'helm',


### PR DESCRIPTION
## Fixes

- In some cases, the chart path ends with the corresponding OS separator. Removed it if found.
- Hovering styling of the helm configuration preview

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
