### PR TITLE
fix: reset actions tab when changing file

### DIFF
--- a/src/components/organisms/ActionsPane/ActionsPane.tsx
+++ b/src/components/organisms/ActionsPane/ActionsPane.tsx
@@ -277,7 +277,19 @@ const ActionsPane: React.FC = () => {
     if (activeEditorTab === 'logs' && selectedResource?.kind !== 'Pod') {
       dispatch(setActiveEditorTab('source'));
     }
-  }, [selectedResource, activeEditorTab, resourceKindHandler, isKustomization, isSchemaAvailable, dispatch]);
+
+    if (activeEditorTab === 'graph' && !isGraphViewVisible) {
+      dispatch(setActiveEditorTab('source'));
+    }
+  }, [
+    selectedResource,
+    activeEditorTab,
+    resourceKindHandler,
+    isKustomization,
+    isSchemaAvailable,
+    isGraphViewVisible,
+    dispatch,
+  ]);
 
   useEffect(() => {
     if (tabsList && tabsList.length && extraButton.current) {


### PR DESCRIPTION
This PR...

## Changes

- handle case when the graph tab is active then select a resource that has no graph 

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
