### PR TITLE
fix: preview configuration multiple fixes

### DIFF
--- a/src/components/organisms/ExplorerPane/PreviewConfigurationPane/PreviewConfigurationRenderer/PreviewConfigurationQuickAction.tsx
+++ b/src/components/organisms/ExplorerPane/PreviewConfigurationPane/PreviewConfigurationRenderer/PreviewConfigurationQuickAction.tsx
@@ -1,4 +1,4 @@
-import {useCallback} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {Popconfirm} from 'antd';
 
@@ -10,7 +10,7 @@ import {DeletePreviewConfigurationTooltip} from '@constants/tooltips';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
 import {openPreviewConfigurationEditor} from '@redux/reducers/main';
-import {startPreview} from '@redux/services/preview';
+import {startPreview, stopPreview} from '@redux/services/preview';
 import {deletePreviewConfiguration} from '@redux/thunks/previewConfiguration';
 
 import {Colors} from '@shared/styles/colors';
@@ -24,11 +24,20 @@ const PreviewConfigurationQuickAction: React.FC<IProps> = props => {
   const {id, isSelected} = props;
 
   const dispatch = useAppDispatch();
+  const preview = useAppSelector(state => state.main.preview);
   const previewConfiguration = useAppSelector(state => state.config.projectConfig?.helm?.previewConfigurationMap?.[id]);
   const helmChart = useAppSelector(state =>
     previewConfiguration
       ? Object.values(state.main.helmChartMap).find(h => h.filePath === previewConfiguration.helmChartFilePath)
       : undefined
+  );
+
+  const isCurrentPreviewing = useMemo(
+    () =>
+      !previewConfiguration || !preview
+        ? false
+        : preview?.type === 'helm-config' && preview.configId === previewConfiguration.id,
+    [preview, previewConfiguration]
   );
 
   const onClickDelete = useCallback(() => {
@@ -57,14 +66,27 @@ const PreviewConfigurationQuickAction: React.FC<IProps> = props => {
     startPreview({type: 'helm-config', configId: previewConfiguration.id}, dispatch);
   }, [dispatch, previewConfiguration]);
 
+  const onClickExit = useCallback(() => {
+    stopPreview(dispatch);
+  }, [dispatch]);
+
   if (!previewConfiguration || !helmChart) {
     return null;
   }
 
   return (
     <>
-      <Button isItemSelected={isSelected} onClick={() => onClickRun()}>
-        Preview
+      <Button
+        isItemSelected={isSelected}
+        onClick={() => {
+          if (isCurrentPreviewing) {
+            onClickExit();
+          } else {
+            onClickRun();
+          }
+        }}
+      >
+        {isCurrentPreviewing ? 'Exit' : 'Preview'}
       </Button>
 
       <Button isItemSelected={isSelected} onClick={() => onClickEdit()}>

--- a/src/redux/thunks/previewConfiguration.ts
+++ b/src/redux/thunks/previewConfiguration.ts
@@ -4,6 +4,7 @@ import {cloneDeep} from 'lodash';
 
 import {updateProjectConfig} from '@redux/appConfig';
 import {clearSelection, selectFile} from '@redux/reducers/main';
+import {stopPreview} from '@redux/services/preview';
 
 import {AppDispatch} from '@shared/models/appDispatch';
 import {RootState} from '@shared/models/rootState';
@@ -21,11 +22,21 @@ export const deletePreviewConfiguration = createAsyncThunk<void, string, {dispat
     if (state.main.preview?.type === 'helm-config' && state.main.preview.configId === previewConfigurationId) {
       const previewConfiguration = previewConfigurationMap[previewConfigurationId];
       const helmChartFilePath = previewConfiguration?.helmChartFilePath;
+
       if (helmChartFilePath) {
         thunkAPI.dispatch(selectFile({filePath: helmChartFilePath}));
       } else {
         thunkAPI.dispatch(clearSelection());
       }
+
+      stopPreview(thunkAPI.dispatch);
+    }
+
+    if (
+      state.main.selection?.type === 'preview.configuration' &&
+      state.main.selection.previewConfigurationId === previewConfigurationId
+    ) {
+      thunkAPI.dispatch(clearSelection());
     }
 
     const previewConfigurationMapCopy = cloneDeep(previewConfigurationMap);


### PR DESCRIPTION
 ## Changes

- Show `Exit` quick action when the preview configuration is being previewed

## Fixes

- If the preview configuration is selected and deleted, clear the selection
- If the preview configuration is being previewed and deleted, clear selection and stop the preview

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
