### PR TITLE
fix: support for identifying child/parent charts

### DIFF
--- a/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
@@ -1,4 +1,4 @@
-import {memo, useState} from 'react';
+import {memo, useMemo, useState} from 'react';
 
 import {Tooltip} from 'antd';
 
@@ -27,6 +27,7 @@ const HelmChartRenderer: React.FC<IProps> = props => {
 
   const dispatch = useAppDispatch();
   const fileOrFolderContainedIn = useAppSelector(state => state.main.resourceFilter.fileOrFolderContainedIn || '');
+  const helmChartMap = useAppSelector(state => state.main.helmChartMap);
   const helmChart = useAppSelector(state => state.main.helmChartMap[id]);
   const isDisabled = useAppSelector(state =>
     Boolean(
@@ -42,6 +43,17 @@ const HelmChartRenderer: React.FC<IProps> = props => {
   );
 
   const [isHovered, setIsHovered] = useState<boolean>(false);
+
+  const chartName = useMemo(() => {
+    let name = helmChart.name;
+    let parentChart = helmChart.parentChartId ? helmChartMap[helmChart.parentChartId] : undefined;
+    while (parentChart) {
+      name = `${parentChart.name}/${name}`;
+      parentChart = parentChart.parentChartId ? helmChartMap[parentChart.parentChartId] : undefined;
+    }
+
+    return name;
+  }, [helmChart, helmChartMap, dispatch]);
 
   return (
     <S.ItemContainer
@@ -61,7 +73,7 @@ const HelmChartRenderer: React.FC<IProps> = props => {
       </S.PrefixContainer>
 
       <S.ItemName isDisabled={isDisabled} isSelected={isSelected}>
-        {helmChart.name}
+        {chartName}
       </S.ItemName>
 
       <Tooltip mouseEnterDelay={TOOLTIP_DELAY} title={helmChart.filePath}>

--- a/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
+++ b/src/components/organisms/ExplorerPane/HelmPane/HelmChartRenderer/HelmChartRenderer.tsx
@@ -53,7 +53,7 @@ const HelmChartRenderer: React.FC<IProps> = props => {
     }
 
     return name;
-  }, [helmChart, helmChartMap, dispatch]);
+  }, [helmChart, helmChartMap]);
 
   return (
     <S.ItemContainer

--- a/src/redux/services/fileEntry.ts
+++ b/src/redux/services/fileEntry.ts
@@ -207,7 +207,8 @@ export function readFiles(
           helmValuesMap,
           helmTemplatesMap,
         },
-        depth
+        depth,
+        helmChart
       )
     );
   } else {
@@ -215,13 +216,9 @@ export function readFiles(
     filterGitFolder(files).forEach(file => {
       const filePath = path.join(folder, file);
       const fileEntryPath = filePath.substring(rootFolder.length);
-
       const isDir = getFileStats(filePath)?.isDirectory();
-
       const isExcluded = fileIsExcluded(fileEntryPath, projectConfig);
-
       let extension = isDir ? '' : path.extname(fileEntryPath);
-
       const fileEntry = createFileEntry({fileEntryPath, fileMap, helmChartId: helmChart?.id, extension, projectConfig});
 
       if (helmChart && isHelmTemplateFile(fileEntry.filePath) && !isExcluded) {

--- a/src/redux/services/helm.ts
+++ b/src/redux/services/helm.ts
@@ -179,7 +179,8 @@ export function processHelmChartFolder(
     helmValuesMap: HelmValuesMapType;
     helmTemplatesMap: HelmTemplatesMapType;
   },
-  depth: number
+  depth: number,
+  parentChart?: HelmChart
 ) {
   const {projectConfig, resourceMetaMap, resourceContentMap, fileMap, helmChartMap, helmValuesMap, helmTemplatesMap} =
     stateArgs;
@@ -195,6 +196,9 @@ export function processHelmChartFolder(
     projectConfig,
   });
   const helmChart = createHelmChart(helmChartFileEntry, helmChartFilePath, helmChartMap, projectConfig);
+  if (helmChart && parentChart) {
+    helmChart.parentChartId = parentChart.id;
+  }
 
   result.push(helmChartFileEntry.name);
 
@@ -226,7 +230,7 @@ export function processHelmChartFolder(
               helmTemplatesMap,
             },
             depth + 1,
-            helmChart
+            helmChart || parentChart
           );
         }
       } else if (helmChart && isHelmValuesFile(file)) {

--- a/src/shared/models/helm.ts
+++ b/src/shared/models/helm.ts
@@ -9,6 +9,7 @@ type HelmChart = {
   name: string;
   valueFileIds: string[]; // ids of contained Helm value files
   templateIds: string[]; // ids of contained Helm templates
+  parentChartId?: string;
 };
 
 type HelmChartMenuItem = {


### PR DESCRIPTION
This PR associates parent charts with child charts - and displays corresponding naming in Helm Chart Sections

<img width="722" alt="image" src="https://github.com/kubeshop/monokle/assets/1917063/406fc884-0592-4b70-80b9-f39bebfd23e6">


## Changes

-

## Fixes

-

## How to test it

-

## Screenshots

-

## Checklist

- [X] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
