### PR TITLE
[Enhancement] .gitignore to ignore files using node-ignore module 

### DIFF
--- a/ignore.js
+++ b/ignore.js
@@ -1,0 +1,10 @@
+import ignore from 'ignore'
+const ig = ignore().add('.gitignore')
+
+//const paths = [
+  //'.abc/a.js',    // filtered out
+  //'.abc/d/e.js',   // included
+//]
+
+//ig.filter(paths)        // ['.abc/d/e.js']
+//ig.ignores('.abc/a.js') // true


### PR DESCRIPTION
This PR aims to use node-ignore for suggesting to add a global setting for using .gitignore to ignore files - default to true - should be straight-forward using https://github.com/kaelzhang/node-ignore.

## Changes

This feature will be consider done when:

- There is a global setting in the Settings panel named "Use .gitignore files", which is selected by default
- There is a similar project setting which defaults to the global setting
- When selected and a .gitignore file is found in the current root folder, the ignores in that file are applied to the resource processing and in the file explorer (i.e. ignored files/folders are grayed out)
- If the user changes this setting at the project level, they should be prompted to reload their project if the project contains a .gitignore file in its root folder


## Fixes Issue #3938 


## How to test it

```javascript
const paths = [
  '.abc/a.js',    // filtered out
  '.abc/d/e.js'   // included
]

ig.filter(paths)        // ['.abc/d/e.js']
ig.ignores('.abc/a.js') // true
```


## Checklist

- [X] tested locally
- [X] added new dependencies
- [X] updated the docs
- [X] added a test
