### PR TITLE
fix: create resource and save to folder / append to file duplicate

### DIFF
--- a/src/redux/services/transientResource.ts
+++ b/src/redux/services/transientResource.ts
@@ -27,7 +27,8 @@ export function createTransientResource(
   input: {name: string; kind: string; apiVersion: string; namespace?: string},
   dispatch: AppDispatch,
   createdIn: 'local' | 'cluster',
-  jsonTemplate?: Partial<K8sObject>
+  jsonTemplate?: Partial<K8sObject>,
+  saveToFileOrFolder?: boolean
 ) {
   const newResourceId = uuidv4();
   let newResourceText: string;
@@ -76,7 +77,10 @@ export function createTransientResource(
     object: newResourceObject,
     isClusterScoped: getResourceKindHandler(input.kind)?.isNamespaced || false,
   };
-  dispatch(addResource(newResource));
+
+  if (!saveToFileOrFolder) {
+    dispatch(addResource(newResource));
+  }
 
   return newResource;
 }

--- a/src/redux/thunks/saveResourceToFileFolder.ts
+++ b/src/redux/thunks/saveResourceToFileFolder.ts
@@ -1,0 +1,75 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+
+import fs from 'fs';
+import util from 'util';
+
+import {YAML_DOCUMENT_DELIMITER} from '@constants/constants';
+
+import {getFileTimestamp, hasValidExtension} from '@utils/files';
+
+import {ROOT_FILE_ENTRY} from '@shared/constants/fileEntry';
+import {AppDispatch} from '@shared/models/appDispatch';
+import {K8sResource} from '@shared/models/k8sResource';
+import {ResourceSavingDestination} from '@shared/models/resourceCreate';
+import {RootState} from '@shared/models/rootState';
+
+const readFilePromise = util.promisify(fs.readFile);
+const appendFilePromise = util.promisify(fs.appendFile);
+const writeFilePromise = util.promisify(fs.writeFile);
+
+export type SaveResourceToFileFolderPayload = {
+  resourceRange: {start: number; length: number} | undefined;
+  fileTimestamp: number | undefined;
+};
+type SaveResourceToFileFolderArgs = {
+  resource: K8sResource;
+  absolutePath: string;
+  saveMode: ResourceSavingDestination;
+};
+
+export const saveResourceToFileFolder = createAsyncThunk<
+  SaveResourceToFileFolderPayload,
+  SaveResourceToFileFolderArgs,
+  {dispatch: AppDispatch; state: RootState}
+>('main/saveResourceToFileFolder', async (payload, thunkAPI) => {
+  const mainState = thunkAPI.getState().main;
+  const rootFolder = mainState.fileMap[ROOT_FILE_ENTRY];
+
+  const {absolutePath, resource, saveMode} = payload;
+
+  let resourceRange: {start: number; length: number} | undefined;
+
+  if (!rootFolder) {
+    throw new Error('Could not find the root folder.');
+  }
+
+  if (saveMode === 'saveToFolder') {
+    await writeFilePromise(absolutePath, resource.text);
+  } else if (saveMode === 'appendToFile') {
+    const fileName = absolutePath.split('\\').pop();
+
+    if (!hasValidExtension(fileName, ['.yaml', '.yml'])) {
+      throw new Error('The selected file does not have .yaml extension.');
+    }
+
+    const fileContent = await readFilePromise(absolutePath, 'utf-8');
+    let contentToAppend = resource.text;
+    if (fileContent.trim().length > 0) {
+      if (fileContent.trim().endsWith(YAML_DOCUMENT_DELIMITER)) {
+        contentToAppend = `\n${resource.text}`;
+      } else {
+        contentToAppend = `\n${YAML_DOCUMENT_DELIMITER}\n${resource.text}`;
+      }
+    }
+
+    resourceRange = {
+      start: fileContent.length,
+      length: contentToAppend.length,
+    };
+
+    await appendFilePromise(absolutePath, contentToAppend);
+  }
+  const fileTimestamp = getFileTimestamp(absolutePath);
+
+  return {resourceRange, fileTimestamp};
+});

--- a/src/redux/thunks/saveTransientResources.ts
+++ b/src/redux/thunks/saveTransientResources.ts
@@ -1,21 +1,12 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 
-import fs from 'fs';
-import util from 'util';
-
-import {YAML_DOCUMENT_DELIMITER} from '@constants/constants';
-
 import {fileIsExcluded} from '@redux/services/fileEntry';
 
-import {getFileTimestamp, hasValidExtension} from '@utils/files';
-
-import {ROOT_FILE_ENTRY} from '@shared/constants/fileEntry';
 import {AppDispatch} from '@shared/models/appDispatch';
-import {FileEntry} from '@shared/models/fileEntry';
 import {K8sResource} from '@shared/models/k8sResource';
 import {RootState} from '@shared/models/rootState';
-import {trackEvent} from '@shared/utils/telemetry';
 
+import {SaveResourceToFileFolderPayload, saveResourceToFileFolder} from './saveResourceToFileFolder';
 import {createRejectionWithAlert} from './utils';
 
 const ERROR_TITLE = 'Resource Save Failed';
@@ -34,54 +25,6 @@ type SaveMultipleTransientResourcesArgs = {
   saveMode: 'saveToFolder' | 'appendToFile';
 };
 
-const readFilePromise = util.promisify(fs.readFile);
-const appendFilePromise = util.promisify(fs.appendFile);
-const writeFilePromise = util.promisify(fs.writeFile);
-
-const performSaveTransientResource = async (
-  resource: K8sResource,
-  rootFolder: FileEntry | undefined,
-  absolutePath: string,
-  saveMode: 'saveToFolder' | 'appendToFile'
-) => {
-  let resourceRange: {start: number; length: number} | undefined;
-  if (!rootFolder) {
-    throw new Error('Could not find the root folder.');
-  }
-
-  trackEvent('create/resource', {resourceKind: resource.kind});
-
-  if (saveMode === 'saveToFolder') {
-    await writeFilePromise(absolutePath, resource.text);
-  } else {
-    const fileName = absolutePath.split('\\').pop();
-
-    if (!hasValidExtension(fileName, ['.yaml', '.yml'])) {
-      throw new Error('The selected file does not have .yaml extension.');
-    }
-
-    const fileContent = await readFilePromise(absolutePath, 'utf-8');
-    let contentToAppend = resource.text;
-    if (fileContent.trim().length > 0) {
-      if (fileContent.trim().endsWith(YAML_DOCUMENT_DELIMITER)) {
-        contentToAppend = `\n${resource.text}`;
-      } else {
-        contentToAppend = `\n${YAML_DOCUMENT_DELIMITER}\n${resource.text}`;
-      }
-    }
-
-    resourceRange = {
-      start: fileContent.length,
-      length: contentToAppend.length,
-    };
-
-    await appendFilePromise(absolutePath, contentToAppend);
-  }
-  const fileTimestamp = getFileTimestamp(absolutePath);
-
-  return {resourceRange, fileTimestamp};
-};
-
 export const saveTransientResources = createAsyncThunk<
   SaveMultipleTransientResourcesPayload,
   SaveMultipleTransientResourcesArgs,
@@ -90,22 +33,15 @@ export const saveTransientResources = createAsyncThunk<
     state: RootState;
   }
 >('main/saveTransientResources', async (args, thunkAPI) => {
-  const mainState = thunkAPI.getState().main;
-  const rootFolder = mainState.fileMap[ROOT_FILE_ENTRY];
-
   let resourcePayloads: ResourcePayload[] = [];
 
   for (let i = 0; i < args.resourcePayloads.length; i += 1) {
     const {resource, absolutePath} = args.resourcePayloads[i];
 
     try {
-      // eslint-disable-next-line no-await-in-loop
-      const {resourceRange, fileTimestamp} = await performSaveTransientResource(
-        resource,
-        rootFolder,
-        absolutePath,
-        args.saveMode
-      );
+      const {resourceRange, fileTimestamp} = (
+        await thunkAPI.dispatch(saveResourceToFileFolder({resource, absolutePath, saveMode: args.saveMode}))
+      ).payload as SaveResourceToFileFolderPayload;
 
       resourcePayloads.push({
         resourceId: resource.id,

--- a/src/shared/models/resourceCreate.ts
+++ b/src/shared/models/resourceCreate.ts
@@ -7,3 +7,5 @@ export type NewResourceAction = {
   fromTypeLabel: 'AI' | 'advanced template' | 'model';
   onClick: () => void;
 };
+
+export type ResourceSavingDestination = 'doNotSave' | 'saveToFolder' | 'appendToFile';


### PR DESCRIPTION
## Fixes

- Do not create duplicate transient resource when saving a new resource to folder / append to a file

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
