### PR TITLE
fix: dashboard warnings/errors count

### DIFF
--- a/src/components/organisms/Dashboard/Overview/Overview.styled.tsx
+++ b/src/components/organisms/Dashboard/Overview/Overview.styled.tsx
@@ -16,7 +16,7 @@ export const Container = styled.div`
   column-gap: 8px;
   row-gap: 8px;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-template-rows: 30% 70%;
+  grid-template-rows: 20% 80%;
   grid-template-areas:
     'status utilization utilization'
     'inventory-info activity activity';

--- a/src/components/organisms/Dashboard/Overview/Status.styled.tsx
+++ b/src/components/organisms/Dashboard/Overview/Status.styled.tsx
@@ -13,12 +13,14 @@ export const InnerContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 24px;
   width: 100%;
 `;
 
-export const Count = styled.span`
-  font-weight: 600;
-  margin-right: 4px;
+export const Count = styled.div<{$small?: boolean}>`
+  display: flex;
+  gap: 4px;
+  ${({$small}) => ($small ? 'font-size: 12px' : 'font-size: 16px')};
 `;
 
 export const KindRow = styled.div<{$type: 'error' | 'warning' | 'resource'}>`
@@ -27,7 +29,7 @@ export const KindRow = styled.div<{$type: 'error' | 'warning' | 'resource'}>`
   border-radius: 4px;
   width: 100%;
   margin-bottom: 10px;
-  padding: 10px;
+  padding: 8px 10px;
   cursor: ${({$type}) => ($type === 'warning' || $type === 'error' ? 'pointer' : 'default')};
 
   ${props =>
@@ -46,9 +48,5 @@ export const KindRow = styled.div<{$type: 'error' | 'warning' | 'resource'}>`
       (props.$type === 'error' && Colors.red7) ||
       (props.$type === 'resource' && Colors.geekblue7)
     };
-    font-size: ${
-      (props.$type === 'warning' && '17px') ||
-      (props.$type === 'error' && '17px') ||
-      (props.$type === 'resource' && '21px')
-    };`}
+    `}
 `;

--- a/src/components/organisms/Dashboard/Overview/Status.tsx
+++ b/src/components/organisms/Dashboard/Overview/Status.tsx
@@ -39,22 +39,25 @@ export const Status = () => {
   return (
     <S.Container>
       <S.KindRow $type="resource">
-        <S.Count>{clusterResourceCount}</S.Count>
-        <span>resources</span>
+        <S.Count>
+          <b>{clusterResourceCount}</b> resources
+        </S.Count>
       </S.KindRow>
 
       <S.InnerContainer>
         <Tooltip title={<ClusterDashboardErrorsWarningTooltip type="errors" />} mouseEnterDelay={TOOLTIP_DELAY}>
           <S.KindRow $type="error" style={{width: '48.5%'}} onClick={() => handleSetFilters('error')}>
-            <S.Count>{errorsCount}</S.Count>
-            <span>errors</span>
+            <S.Count $small>
+              <b>{errorsCount}</b> errors
+            </S.Count>
           </S.KindRow>
         </Tooltip>
 
         <Tooltip title={<ClusterDashboardErrorsWarningTooltip type="warnings" />} mouseEnterDelay={TOOLTIP_DELAY}>
           <S.KindRow $type="warning" style={{width: '48.5%'}} onClick={() => handleSetFilters('warning')}>
-            <S.Count>{warningsCount}</S.Count>
-            <span>warnings</span>
+            <S.Count $small>
+              <b>{warningsCount}</b> warnings
+            </S.Count>
           </S.KindRow>
         </Tooltip>
       </S.InnerContainer>


### PR DESCRIPTION
## Fixes

- Cluster dashboard warnings/errors count styling

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/ce193765-4614-4808-b16b-33f2109982d8)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
