### PR TITLE
feat: active back to project button

### DIFF
--- a/src/components/organisms/StartPage/StartPageHeader.styled.tsx
+++ b/src/components/organisms/StartPage/StartPageHeader.styled.tsx
@@ -28,8 +28,7 @@ export const BackToProjectButton = styled(Button)`
   }
 
   & .anticon-left {
-    font-size: 12px !important;
-    padding-top: 2px;
+    font-size: 10px !important;
   }
 `;
 

--- a/src/components/organisms/StartPage/StartPageHeader.styled.tsx
+++ b/src/components/organisms/StartPage/StartPageHeader.styled.tsx
@@ -16,6 +16,23 @@ export const ActionsContainer = styled.div`
   }
 `;
 
+export const BackToProjectButton = styled(Button)`
+  color: ${Colors.grey9};
+  border-color: ${Colors.grey9};
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    color: ${Colors.grey8};
+    border-color: ${Colors.grey8};
+  }
+
+  & .anticon-left {
+    font-size: 12px !important;
+    padding-top: 2px;
+  }
+`;
+
 export const LearnButton = styled(Button)<{$isActive: boolean}>`
   font-size: 16px;
   padding: 0px 10px;
@@ -31,14 +48,13 @@ export const LearnButton = styled(Button)<{$isActive: boolean}>`
 `;
 
 export const Logo = styled.img`
-  height: 31px;
+  height: 32px;
   cursor: pointer;
 `;
 
 export const LogoContainer = styled.div<{$isNewVersionNoticeVisible: boolean}>`
-  border-right: ${AppBorders.sectionDivider};
-  width: 50px;
-  padding-right: ${({$isNewVersionNoticeVisible}) => ($isNewVersionNoticeVisible ? '356px' : '0px')};
+  width: 32px;
+  padding-right: ${({$isNewVersionNoticeVisible}) => ($isNewVersionNoticeVisible ? '332px' : '0px')};
 `;
 
 export const NewVersionBadge = styled(Badge)`
@@ -51,7 +67,7 @@ export const StartPageHeaderContainer = styled.div`
   height: 32px;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
 `;
 
 export const SearchItemLabel = styled.div.attrs({className: 'search-item-label'})`
@@ -63,6 +79,9 @@ export const SearchItemLabel = styled.div.attrs({className: 'search-item-label'}
 `;
 
 export const SearchContainer = styled.div`
+  padding-left: 16px;
+  border-left: ${AppBorders.sectionDivider};
+
   .selected-menu-item {
     background-color: ${Colors.blue7};
   }

--- a/src/components/organisms/StartPage/StartPageHeader.tsx
+++ b/src/components/organisms/StartPage/StartPageHeader.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 
 import {AutoComplete, Badge, Dropdown, Tooltip, Typography} from 'antd';
 
-import {BellOutlined, EllipsisOutlined} from '@ant-design/icons';
+import {BellOutlined, EllipsisOutlined, LeftOutlined} from '@ant-design/icons';
 
 import _ from 'lodash';
 
@@ -10,7 +10,12 @@ import {TOOLTIP_DELAY} from '@constants/constants';
 import {NotificationsTooltip} from '@constants/tooltips';
 
 import {useAppDispatch, useAppSelector} from '@redux/hooks';
-import {setShowStartPageLearn, setStartPageMenuOption, toggleNotifications} from '@redux/reducers/ui';
+import {
+  setShowStartPageLearn,
+  setStartPageMenuOption,
+  toggleNotifications,
+  toggleStartProjectPane,
+} from '@redux/reducers/ui';
 import {setOpenProject} from '@redux/thunks/project';
 
 import {NewVersionNotice} from '@molecules';
@@ -24,12 +29,13 @@ import {useRefSelector} from '@utils/hooks';
 import MonokleKubeshopLogo from '@assets/NewMonokleLogoDark.svg';
 
 import {SearchInput} from '@monokle/components';
-import {trackEvent} from '@shared/utils';
+import {activeProjectSelector, trackEvent} from '@shared/utils';
 
 import * as S from './StartPageHeader.styled';
 
 const StartPageHeader: React.FC = () => {
   const dispatch = useAppDispatch();
+  const activeProject = useAppSelector(activeProjectSelector);
   const isNewVersionAvailable = useAppSelector(state => state.config.isNewVersionAvailable);
   const isNewVersionNoticeVisible = useAppSelector(state => state.ui.newVersionNotice.isVisible);
   const isStartPageLearnVisible = useAppSelector(state => state.ui.startPage.learn.isVisible);
@@ -88,6 +94,17 @@ const StartPageHeader: React.FC = () => {
         </S.NewVersionBadge>
       </S.LogoContainer>
 
+      {activeProject && (
+        <S.BackToProjectButton
+          icon={<LeftOutlined />}
+          onClick={() => {
+            dispatch(toggleStartProjectPane());
+          }}
+        >
+          Back to project
+        </S.BackToProjectButton>
+      )}
+
       <S.SearchContainer>
         <AutoComplete
           style={{width: '340px'}}
@@ -104,6 +121,7 @@ const StartPageHeader: React.FC = () => {
         </AutoComplete>
         <div id="projectsList" />
       </S.SearchContainer>
+
       <S.ActionsContainer>
         <S.LearnButton
           $isActive={isStartPageLearnVisible}

--- a/src/shared/styles/borders.ts
+++ b/src/shared/styles/borders.ts
@@ -16,5 +16,5 @@ export enum BorderWidth {
 
 export const AppBorders = {
   pageDivider: `1px solid ${Colors.grey3};`,
-  sectionDivider: `1px solid ${Colors.grey3}`,
+  sectionDivider: `1px solid ${Colors.grey4}`,
 };


### PR DESCRIPTION
## Changes

- Add a `Back to project` button in the start page header when there is an active project

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/b44c6eaa-5847-4219-b3b6-fc3882c8d1f1)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
