### PR TITLE
feat: order of create resource options + disable in cluster mode

### DIFF
--- a/src/components/organisms/NavigatorPane/EmptyResourceNavigator/EmptyResourceNavigator.tsx
+++ b/src/components/organisms/NavigatorPane/EmptyResourceNavigator/EmptyResourceNavigator.tsx
@@ -32,30 +32,32 @@ const EmptyResourceNavigator: React.FC = () => {
   const newResourceActionsList: NewResourceAction[] = useMemo(
     () => [
       {
-        image: FromAI,
-        hoverImage: FromAIHovered,
-        fromTypeLabel: 'AI',
+        image: FromModel,
+        hoverImage: FromModelHovered,
+        typeLabel: 'Basic Form',
         onClick: () => {
-          trackEvent('new_resource/create', {type: 'AI', from: 'empty_navigator'});
-          dispatch(openNewAiResourceWizard());
+          trackEvent('new_resource/create', {type: 'wizard', from: 'empty_navigator'});
+          dispatch(openNewResourceWizard());
         },
       },
+
       {
         image: FromAdvancedTemplate,
         hoverImage: FromAdvancedTemplateHovered,
-        fromTypeLabel: 'advanced template',
+        typeLabel: 'Advanced Template',
         onClick: () => {
           trackEvent('new_resource/create', {type: 'advanced_template', from: 'empty_navigator'});
           dispatch(openTemplateExplorer());
         },
       },
+
       {
-        image: FromModel,
-        hoverImage: FromModelHovered,
-        fromTypeLabel: 'model',
+        image: FromAI,
+        hoverImage: FromAIHovered,
+        typeLabel: 'AI Assistant',
         onClick: () => {
-          trackEvent('new_resource/create', {type: 'wizard', from: 'empty_navigator'});
-          dispatch(openNewResourceWizard());
+          trackEvent('new_resource/create', {type: 'AI', from: 'empty_navigator'});
+          dispatch(openNewAiResourceWizard());
         },
       },
     ],
@@ -71,7 +73,7 @@ const EmptyResourceNavigator: React.FC = () => {
       ) : (
         <NewResourceCardsContainer>
           {newResourceActionsList.map(action => (
-            <NewResourceCard key={action.fromTypeLabel} action={action} />
+            <NewResourceCard key={action.typeLabel} action={action} />
           ))}
         </NewResourceCardsContainer>
       )}

--- a/src/components/organisms/NavigatorPane/EmptyResourceNavigator/NewResourceCard.tsx
+++ b/src/components/organisms/NavigatorPane/EmptyResourceNavigator/NewResourceCard.tsx
@@ -1,11 +1,14 @@
-import {useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {Image} from 'antd';
 
 import styled from 'styled-components';
 
+import {useAppSelector} from '@redux/hooks';
+
 import {NewResourceAction} from '@shared/models/resourceCreate';
 import {Colors} from '@shared/styles/colors';
+import {isInClusterModeSelector} from '@shared/utils';
 
 type IProps = {
   action: NewResourceAction;
@@ -13,19 +16,37 @@ type IProps = {
 
 const NewResourceCard: React.FC<IProps> = props => {
   const {
-    action: {hoverImage, image, fromTypeLabel, onClick},
+    action: {hoverImage, image, typeLabel, onClick},
   } = props;
+
+  const isInClusterMode = useAppSelector(isInClusterModeSelector);
 
   const [isHovered, setIsHovered] = useState(false);
 
+  const isDisabled = useMemo(() => isInClusterMode, [isInClusterMode]);
+
+  const onClickHanlder = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+
+    onClick();
+  }, [isDisabled, onClick]);
+
   return (
-    <CardContainer onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)} onClick={onClick}>
-      <Image src={isHovered ? hoverImage : image} preview={false} />
+    <CardContainer
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      onClick={onClickHanlder}
+      $isDisabled={isDisabled}
+    >
+      <Image src={isHovered && !isDisabled ? hoverImage : image} preview={false} />
 
       <CardLabel>
         <span>New resource</span>
+
         <span>
-          from <b>{fromTypeLabel}</b>
+          using <b>{typeLabel}</b>
         </span>
       </CardLabel>
     </CardContainer>
@@ -36,17 +57,17 @@ export default NewResourceCard;
 
 // Styled Components
 
-const CardContainer = styled.div`
+const CardContainer = styled.div<{$isDisabled: boolean}>`
   display: flex;
   gap: 24px;
   align-items: center;
   border: 1px solid ${Colors.grey2};
   border-radius: 4px;
   padding: 24px;
-  cursor: pointer;
+  cursor: ${({$isDisabled}) => ($isDisabled ? 'not-allowed' : 'pointer')};
 
   &:hover {
-    background-color: ${Colors.blue7};
+    background-color: ${({$isDisabled}) => ($isDisabled ? 'transparent' : Colors.blue7)};
   }
 `;
 

--- a/src/hooks/menuItemsHooks/useNewResourceMenuItems.tsx
+++ b/src/hooks/menuItemsHooks/useNewResourceMenuItems.tsx
@@ -24,7 +24,7 @@ export function useNewResourceMenuItems() {
         label: (
           <MenuItem>
             <FileAddOutlined />
-            Create manually
+            use Basic Form
           </MenuItem>
         ),
         onClick: () => {
@@ -37,7 +37,7 @@ export function useNewResourceMenuItems() {
         label: (
           <MenuItem>
             <img src={TemplateSmallWhiteSvg} />
-            Use Advanced Template
+            use Advanced Template
           </MenuItem>
         ),
         onClick: () => {
@@ -50,7 +50,7 @@ export function useNewResourceMenuItems() {
         label: (
           <MenuItem>
             <RobotOutlined />
-            AI Assisted
+            use AI Assistant
           </MenuItem>
         ),
         onClick: () => {

--- a/src/shared/models/resourceCreate.ts
+++ b/src/shared/models/resourceCreate.ts
@@ -4,7 +4,7 @@ export type NewResourceTelemtryFrom = 'empty_navigator' | 'navigator_header';
 export type NewResourceAction = {
   image: string;
   hoverImage: string;
-  fromTypeLabel: 'AI' | 'advanced template' | 'model';
+  typeLabel: string;
   onClick: () => void;
 };
 


### PR DESCRIPTION
## Changes

- Order + labels of creating a new resource options

## Fixes

- Disable options of creating new resource from empty navigator in cluster mode

## Screenshots

![image](https://github.com/kubeshop/monokle/assets/47887589/fa6cd900-b9fc-40f1-9016-42c84683f03d)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
