### PR TITLE
fix: saving multiple resources with same name from template

### DIFF
--- a/src/components/organisms/TemplateExplorer/CreatedResources/SaveToFolderModal.tsx
+++ b/src/components/organisms/TemplateExplorer/CreatedResources/SaveToFolderModal.tsx
@@ -46,7 +46,7 @@ const SaveToFolderModal: React.FC<Props> = props => {
         resourcePayloads: resourcesRef.current.map(resource => {
           return {
             resource,
-            absolutePath: path.join(folder, `${resource.name}-${resource.kind}.yaml`),
+            absolutePath: path.join(folder, `${resource.name}-${resource.kind.toLowerCase()}.yaml`),
           };
         }),
         saveMode: 'saveToFolder',

--- a/src/components/organisms/TemplateExplorer/CreatedResources/SaveToFolderModal.tsx
+++ b/src/components/organisms/TemplateExplorer/CreatedResources/SaveToFolderModal.tsx
@@ -24,7 +24,7 @@ type Props = {
 const SaveToFolderModal: React.FC<Props> = props => {
   const {isVisible, onClose, resources} = props;
   const dispatch = useAppDispatch();
-  const [selectedFolder, setSelectedFolder, selectedFolderRef] = useStateWithRef<string | undefined>(undefined);
+  const [selectedFolder, setSelectedFolder, selectedFolderRef] = useStateWithRef<string | undefined>(ROOT_FILE_ENTRY);
   const [isLoading, setIsLoading] = useState(false);
   const folderTreeData = useFileFolderTreeSelectData('folder');
   const rootFolderPathRef = useRefSelector(state => state.main.fileMap[ROOT_FILE_ENTRY]?.filePath);
@@ -46,7 +46,7 @@ const SaveToFolderModal: React.FC<Props> = props => {
         resourcePayloads: resourcesRef.current.map(resource => {
           return {
             resource,
-            absolutePath: path.join(folder, `${resource.name}.yaml`),
+            absolutePath: path.join(folder, `${resource.name}-${resource.kind}.yaml`),
           };
         }),
         saveMode: 'saveToFolder',

--- a/src/hooks/useFolderTreeSelectData.ts
+++ b/src/hooks/useFolderTreeSelectData.ts
@@ -18,7 +18,7 @@ const createNode = (fileEntry: FileEntry, fileMap: FileMapType, rootFolderName: 
   const node: any = {
     value: filePath,
     title: name,
-    label: filePath,
+    label: filePath === ROOT_FILE_ENTRY ? name : filePath,
     children: [],
   };
 


### PR DESCRIPTION
## Changes

- By default show project root folder as value when saving transient resources

## Fixes

- Saving multiple resources with same name from template would override each other

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
