### PR TITLE
Fixed URL for monokle desktop release 2.3

### DIFF
--- a/resources/releaseNotes/2.3/2.3.json
+++ b/resources/releaseNotes/2.3/2.3.json
@@ -1,6 +1,6 @@
 {
   "title": "Introducing Monokle 2.3",
-  "learnMoreUrl": "https://monokle.io/blog/monokle-2-3-release",
+  "learnMoreUrl": "https://monokle.io/blog/monokle-desktop-2-3-release",
   "about": {
     "when": "July 2023",
     "title": "2.3 focused on:",

--- a/resources/releaseNotes/2.3/2.3.md
+++ b/resources/releaseNotes/2.3/2.3.md
@@ -8,4 +8,4 @@ Introducing Monokle Desktop 2.3 Release:
   - Explore the YAML manifests of deployed resources
 - Validation Plugins for extended configuration validation
   - Install community-contributed plugins
-- [Read our blog post for more details →](https://monokle.io/blog/monokle-2-3-release)
+- [Read our blog post for more details →](https://monokle.io/blog/monokle-desktop-2-3-release)


### PR DESCRIPTION
This PR will fix the URL for the learn more and read our blog post for more details here.
![release2_3_1_desktop](https://github.com/kubeshop/monokle/assets/10183232/c55e742f-1bb6-4194-8faf-b099404c7566)

## Fixes

- updated correct url : https://monokle.io/blog/monokle-desktop-2-3-release


## Screenshots

- Currently it opens incorrect url which is returning 404.
![monokle_404](https://github.com/kubeshop/monokle/assets/10183232/fa533a67-8001-4f92-b67f-2ff0f0b00396)
