### PR TITLE
Add client data to synchronizer instances

### DIFF
--- a/electron/app/services/cloud/authenticator.ts
+++ b/electron/app/services/cloud/authenticator.ts
@@ -3,13 +3,14 @@ import {app} from 'electron';
 import {join} from 'path';
 
 import {Authenticator, StorageHandlerAuth, createMonokleAuthenticatorFromOrigin} from '@monokle/synchronizer';
+import {getClientConfig} from './client-config';
 
 export const AUTH_CLIENT_ID = 'mc-cli';
 
 let authenticator: Authenticator | undefined;
 
 const initAuthenticator = async (cloudStorageDir: string) => {
-  const newAuthenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, undefined, new StorageHandlerAuth(cloudStorageDir));
+  const newAuthenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, getClientConfig(), undefined, new StorageHandlerAuth(cloudStorageDir));
   authenticator = newAuthenticator;
   return newAuthenticator;
 };

--- a/electron/app/services/cloud/authenticator.ts
+++ b/electron/app/services/cloud/authenticator.ts
@@ -2,12 +2,14 @@ import {app} from 'electron';
 
 import {join} from 'path';
 
-import {Authenticator, StorageHandlerAuth, createDefaultMonokleAuthenticator} from '@monokle/synchronizer';
+import {Authenticator, StorageHandlerAuth, createMonokleAuthenticatorFromOrigin} from '@monokle/synchronizer';
+
+export const AUTH_CLIENT_ID = 'mc-cli';
 
 let authenticator: Authenticator | undefined;
 
 const initAuthenticator = async (cloudStorageDir: string) => {
-  const newAuthenticator = createDefaultMonokleAuthenticator(new StorageHandlerAuth(cloudStorageDir));
+  const newAuthenticator = await createMonokleAuthenticatorFromOrigin(AUTH_CLIENT_ID, undefined, new StorageHandlerAuth(cloudStorageDir));
   authenticator = newAuthenticator;
   return newAuthenticator;
 };

--- a/electron/app/services/cloud/client-config.ts
+++ b/electron/app/services/cloud/client-config.ts
@@ -1,16 +1,18 @@
 import {type, release} from 'os';
 import {machineIdSync} from 'node-machine-id';
 import {app} from 'electron';
+import electronStore from '@shared/utils/electronStore';
 
 const CLIENT_NAME = 'Monokle Desktop';
 
 export function getClientConfig() {
+	const isTrackingDisabled = Boolean(electronStore.get('appConfig.disableEventTracking'));
+	const additionalData = isTrackingDisabled ? undefined : { machineId: machineIdSync() };
+
 	return {
 		name: CLIENT_NAME,
 		version: app.getVersion(),
 		os: `${type()} ${release()}`,
-		additionalData: {
-			machineId: machineIdSync(),
-		}
+		additionalData,
 	};
 }

--- a/electron/app/services/cloud/client-config.ts
+++ b/electron/app/services/cloud/client-config.ts
@@ -1,0 +1,16 @@
+import {type, release} from 'os';
+import {machineIdSync} from 'node-machine-id';
+import {app} from 'electron';
+
+const CLIENT_NAME = 'Monokle Desktop';
+
+export function getClientConfig() {
+	return {
+		name: CLIENT_NAME,
+		version: app.getVersion(),
+		os: `${type()} ${release()}`,
+		additionalData: {
+			machineId: machineIdSync(),
+		}
+	};
+}

--- a/electron/app/services/cloud/synchronizer.ts
+++ b/electron/app/services/cloud/synchronizer.ts
@@ -3,11 +3,12 @@ import {app} from 'electron';
 import {join} from 'path';
 
 import {StorageHandlerPolicy, Synchronizer, createMonokleSynchronizerFromOrigin} from '@monokle/synchronizer';
+import {getClientConfig} from './client-config';
 
 let synchronizer: Synchronizer | undefined;
 
 const initSynchronizer = async (cloudStorageDir: string) => {
-  const newSynchronizer = await createMonokleSynchronizerFromOrigin(undefined, new StorageHandlerPolicy(cloudStorageDir));
+  const newSynchronizer = await createMonokleSynchronizerFromOrigin(getClientConfig(), undefined, new StorageHandlerPolicy(cloudStorageDir));
   synchronizer = newSynchronizer;
   return newSynchronizer;
 };

--- a/electron/app/services/cloud/synchronizer.ts
+++ b/electron/app/services/cloud/synchronizer.ts
@@ -2,12 +2,12 @@ import {app} from 'electron';
 
 import {join} from 'path';
 
-import {StorageHandlerPolicy, Synchronizer, createDefaultMonokleSynchronizer} from '@monokle/synchronizer';
+import {StorageHandlerPolicy, Synchronizer, createMonokleSynchronizerFromOrigin} from '@monokle/synchronizer';
 
 let synchronizer: Synchronizer | undefined;
 
 const initSynchronizer = async (cloudStorageDir: string) => {
-  const newSynchronizer = createDefaultMonokleSynchronizer(new StorageHandlerPolicy(cloudStorageDir));
+  const newSynchronizer = await createMonokleSynchronizerFromOrigin(undefined, new StorageHandlerPolicy(cloudStorageDir));
   synchronizer = newSynchronizer;
   return newSynchronizer;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dnd-kit/sortable": "7.0.2",
         "@kubernetes/client-node": "0.19.0",
         "@monokle/components": "1.7.0",
-        "@monokle/synchronizer": "^0.12.5",
+        "@monokle/synchronizer": "^0.13.0",
         "@monokle/validation": "0.31.5",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@reduxjs/toolkit": "1.9.5",
@@ -5539,9 +5539,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.5.tgz",
-      "integrity": "sha512-NBD9VLrIiuihevElowmG9tikIHQZV6HuAMXgC6TmINWyTV08ZjnnsZLDC+4VHsKNnE3KvIuJ37IPAVgAKaAqjQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.13.0.tgz",
+      "integrity": "sha512-rTfzoDC4A3mLkxYnpUeYHzLK2cIjugBarxJ3+Dyq8MgSbXcPmW5GaxbqTJRZX2KEPlj2ozJHRmXAsoxcOpwQVA==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@dnd-kit/sortable": "7.0.2",
         "@kubernetes/client-node": "0.19.0",
         "@monokle/components": "1.7.0",
-        "@monokle/synchronizer": "^0.6.0",
+        "@monokle/synchronizer": "^0.12.5",
         "@monokle/validation": "0.31.5",
         "@open-policy-agent/opa-wasm": "1.8.0",
         "@reduxjs/toolkit": "1.9.5",
@@ -135,8 +135,8 @@
         "concurrently": "8.0.1",
         "craco-less": "2.0.0",
         "cross-env": "7.0.3",
-        "electron": "27.1.0",
-        "electron-builder": "24.6.4",
+        "electron": "27.1.3",
+        "electron-builder": "24.9.1",
         "electron-reload": "2.0.0-alpha.1",
         "eslint-config-airbnb": "19.0.4",
         "eslint-config-prettier": "8.8.0",
@@ -5539,9 +5539,9 @@
       }
     },
     "node_modules/@monokle/synchronizer": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.6.0.tgz",
-      "integrity": "sha512-CoFzrikvXUOa2PEzsoegERHN1OZ+mNzXfup1FJvNG59VvWTJ2pFZNppfzM2pJMmp07FiHqads2T4yFOWn5Cl9A==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@monokle/synchronizer/-/synchronizer-0.12.5.tgz",
+      "integrity": "sha512-NBD9VLrIiuihevElowmG9tikIHQZV6HuAMXgC6TmINWyTV08ZjnnsZLDC+4VHsKNnE3KvIuJ37IPAVgAKaAqjQ==",
       "dependencies": {
         "@monokle/types": "*",
         "env-paths": "^2.2.1",
@@ -8300,9 +8300,9 @@
       "dev": true
     },
     "node_modules/7zip-bin": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.1.1.tgz",
-      "integrity": "sha512-sAP4LldeWNz0lNzmTird3uWfFDWWTeg6V/MsmyyLR9X1idwKBWIgt/ZvinqQldJm3LecKEs1emkbquO6PCiLVQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
       "dev": true
     },
     "node_modules/abab": {
@@ -8661,9 +8661,9 @@
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "24.6.4",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.6.4.tgz",
-      "integrity": "sha512-m9931WXb83teb32N0rKg+ulbn6+Hl8NV5SUpVDOVz9MWOXfhV6AQtTdftf51zJJvCQnQugGtSqoLvgw6mdF/Rg==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.9.1.tgz",
+      "integrity": "sha512-Q1nYxZcio4r+W72cnIRVYofEAyjBd3mG47o+zms8HlD51zWtA/YxJb01Jei5F+jkWhge/PTQK+uldsPh6d0/4g==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
@@ -8672,15 +8672,15 @@
         "@electron/universal": "1.4.1",
         "@malept/flatpak-bundler": "^0.4.0",
         "@types/fs-extra": "9.0.13",
-        "7zip-bin": "~5.1.1",
+        "7zip-bin": "~5.2.0",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "24.5.0",
-        "builder-util-runtime": "9.2.1",
+        "builder-util": "24.8.1",
+        "builder-util-runtime": "9.2.3",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.8",
-        "electron-publish": "24.5.0",
+        "electron-publish": "24.8.1",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
@@ -8715,6 +8715,19 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
+      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/form-data": {
@@ -9982,16 +9995,16 @@
       "dev": true
     },
     "node_modules/builder-util": {
-      "version": "24.5.0",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.5.0.tgz",
-      "integrity": "sha512-STnBmZN/M5vGcv01u/K8l+H+kplTaq4PAIn3yeuufUKSpcdro0DhJWxPI81k5XcNfC//bjM3+n9nr8F9uV4uAQ==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-24.8.1.tgz",
+      "integrity": "sha512-ibmQ4BnnqCnJTNrdmdNlnhF48kfqhNzSeqFMXHLIl+o9/yhn6QfOaVrloZ9YUu3m0k3rexvlT5wcki6LWpjTZw==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
-        "7zip-bin": "~5.1.1",
+        "7zip-bin": "~5.2.0",
         "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.2.1",
+        "builder-util-runtime": "9.2.3",
         "chalk": "^4.1.2",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
@@ -10030,6 +10043,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/builder-util/node_modules/builder-util-runtime": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
+      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/builder-util/node_modules/chalk": {
@@ -12874,20 +12900,33 @@
       "dev": true
     },
     "node_modules/dmg-builder": {
-      "version": "24.6.4",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.6.4.tgz",
-      "integrity": "sha512-BNcHRc9CWEuI9qt0E655bUBU/j/3wUCYBVKGu1kVpbN5lcUdEJJJeiO0NHK3dgKmra6LUUZlo+mWqc+OCbi0zw==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.9.1.tgz",
+      "integrity": "sha512-huC+O6hvHd24Ubj3cy2GMiGLe2xGFKN3klqVMLAdcbB6SWMd1yPSdZvV8W1O01ICzCCRlZDHiv4VrNUgnPUfbQ==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "24.6.4",
-        "builder-util": "24.5.0",
-        "builder-util-runtime": "9.2.1",
+        "app-builder-lib": "24.9.1",
+        "builder-util": "24.8.1",
+        "builder-util-runtime": "9.2.3",
         "fs-extra": "^10.1.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
       },
       "optionalDependencies": {
         "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/builder-util-runtime": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
+      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/dmg-builder/node_modules/fs-extra": {
@@ -13244,9 +13283,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-27.1.0.tgz",
-      "integrity": "sha512-XPdJiO475QJ8cx59/goWNNWnlV0vab+Ut3occymos7VDxkHV5mFrlW6tcGi+M3bW6gBfwpJocWMng8tw542vww==",
+      "version": "27.1.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-27.1.3.tgz",
+      "integrity": "sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13262,16 +13301,16 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "24.6.4",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.6.4.tgz",
-      "integrity": "sha512-uNWQoU7pE7qOaIQ6CJHpBi44RJFVG8OHRBIadUxrsDJVwLLo8Nma3K/EEtx5/UyWAQYdcK4nVPYKoRqBb20hbA==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.9.1.tgz",
+      "integrity": "sha512-v7BuakDuY6sKMUYM8mfQGrwyjBpZ/ObaqnenU0H+igEL10nc6ht049rsCw2HghRBdEwJxGIBuzs3jbEhNaMDmg==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "24.6.4",
-        "builder-util": "24.5.0",
-        "builder-util-runtime": "9.2.1",
+        "app-builder-lib": "24.9.1",
+        "builder-util": "24.8.1",
+        "builder-util-runtime": "9.2.3",
         "chalk": "^4.1.2",
-        "dmg-builder": "24.6.4",
+        "dmg-builder": "24.9.1",
         "fs-extra": "^10.1.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -13300,6 +13339,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/electron-builder/node_modules/builder-util-runtime": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
+      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-builder/node_modules/chalk": {
@@ -13388,14 +13440,14 @@
       "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
     },
     "node_modules/electron-publish": {
-      "version": "24.5.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.5.0.tgz",
-      "integrity": "sha512-zwo70suH15L15B4ZWNDoEg27HIYoPsGJUF7xevLJLSI7JUPC8l2yLBdLGwqueJ5XkDL7ucYyRZzxJVR8ElV9BA==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.8.1.tgz",
+      "integrity": "sha512-IFNXkdxMVzUdweoLJNXSupXkqnvgbrn3J4vognuOY06LaS/m0xvfFYIf+o1CM8if6DuWYWoQFKPcWZt/FUjZPw==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "24.5.0",
-        "builder-util-runtime": "9.2.1",
+        "builder-util": "24.8.1",
+        "builder-util-runtime": "9.2.3",
         "chalk": "^4.1.2",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
@@ -13424,6 +13476,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/electron-publish/node_modules/builder-util-runtime": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
+      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-publish/node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@dnd-kit/sortable": "7.0.2",
     "@kubernetes/client-node": "0.19.0",
     "@monokle/components": "1.7.0",
-    "@monokle/synchronizer": "^0.12.5",
+    "@monokle/synchronizer": "^0.13.0",
     "@monokle/validation": "0.31.5",
     "@open-policy-agent/opa-wasm": "1.8.0",
     "@reduxjs/toolkit": "1.9.5",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@dnd-kit/sortable": "7.0.2",
     "@kubernetes/client-node": "0.19.0",
     "@monokle/components": "1.7.0",
-    "@monokle/synchronizer": "^0.6.0",
+    "@monokle/synchronizer": "^0.12.5",
     "@monokle/validation": "0.31.5",
     "@open-policy-agent/opa-wasm": "1.8.0",
     "@reduxjs/toolkit": "1.9.5",


### PR DESCRIPTION
This PR adds client data to synchronizer instances. Part of https://github.com/kubeshop/monokle-saas/issues/1904.

Requires https://github.com/kubeshop/monokle-core/pull/593.

## Changes

- As above.

## Fixes

- As above.

## How to test it

- E2E - either by looking into API logs (e.g. run locally) or with a tool such Charles or WireShark to see `User-Agent` send correctly.

## Screenshots

- None.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
