### PR TITLE
fix: typo in Template's Title bar

### DIFF
--- a/src/components/organisms/TemplateExplorer/TitleBarDescription/TitleBarDescription.tsx
+++ b/src/components/organisms/TemplateExplorer/TitleBarDescription/TitleBarDescription.tsx
@@ -22,7 +22,7 @@ const TitleBarDescription: React.FC = () => {
     <S.Container>
       <img src={TemplateExplorerDescription} />
       <S.Text>
-        No need to be a K8s expert anymore! Create reosurces through easy forms.{' '}
+        No need to be a K8s expert anymore! Create resources through easy forms.{' '}
         <Link onClick={onLinkClickHandler}>Install additional templates using Plugins here</Link>
       </S.Text>
     </S.Container>


### PR DESCRIPTION
This PR...

## Changes

- Fix typo

## Fixes

- A typo in template's title bar

## How to test it

N/A

## Screenshots

N/A

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
